### PR TITLE
🐛 fix: post-PR#8 bug fixes and warning cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.184"
+version = "0.1.185"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.185"
+version = "0.1.186"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.187"
+version = "0.1.190"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.192"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.191"
+version = "0.1.192"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.186"
+version = "0.1.187"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.190"
+version = "0.1.191"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.191"
+version = "0.1.192"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.184"
+version = "0.1.185"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.186"
+version = "0.1.187"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.187"
+version = "0.1.190"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.190"
+version = "0.1.191"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.192"
+version = "0.1.193"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.185"
+version = "0.1.186"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -519,7 +519,6 @@ When the MCP server starts, it goes through this sequence:
 |---|---|---|
 | `semantic_search` | `query`, `limit`, `compact` (default: true), `filter_path` | Semantic code search. Compact mode returns metadata only (~93% fewer tokens). |
 | `find_references` | `symbol`, `limit` (default: 50) | Find all usages/call sites of a symbol across the codebase. |
-| `get_file_chunks` | `path`, `compact` (default: true) | Get all indexed chunks from a file. |
 | `find_databases` | | Discover available codesearch databases. |
 | `index_status` | | Check index existence, status, and statistics. |
 
@@ -562,9 +561,9 @@ The MCP tools are designed to work together in a **search → narrow → read** 
 
 2. **`find_references`** — Once the agent identifies a relevant function or symbol, it can ask for all usages and call sites across the codebase. This is much more efficient than grep-based searching and stays within the codesearch ecosystem. Example: `find_references("authenticate")` returns every location that calls or references that symbol.
 
-3. **`get_file_chunks`** — To get a broader view of a specific file's structure, the agent can retrieve all indexed chunks. With `compact=true` this gives an outline (functions, classes, methods with signatures); with `compact=false` it includes full source code.
+3. **Targeted file reads** — Once the agent identifies a relevant function or symbol, it reads only the specific lines it needs using its built-in file read tools (e.g., `read("src/auth/handler.rs", offset=45, limit=30)`). The compact search results include exact line numbers, making targeted reads precise and efficient.
 
-4. **Targeted file reads** — Finally, the agent reads only the specific lines it needs using its built-in file read tools.
+4. **Iterate** — The agent continues narrowing down with additional `semantic_search` or `find_references` calls as needed.
 
 **Example session:**
 ```

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -197,7 +197,7 @@ fn check_git_root_placement(db_path: &Path, project_path: &Path) -> CheckResult 
             let db_canonical = fs::canonicalize(db_path).unwrap_or_else(|_| db_path.to_path_buf());
             let expected_db_path = git_root.join(DB_DIR_NAME);
             let expected_canonical =
-                fs::canonicalize(&expected_db_path).unwrap_or_else(|_| expected_db_path);
+                fs::canonicalize(&expected_db_path).unwrap_or(expected_db_path);
 
             if db_canonical == expected_canonical {
                 CheckResult::pass(
@@ -354,7 +354,7 @@ fn read_dimensions(db_path: &Path) -> usize {
 fn check_chunk_integrity(store: &VectorStore) -> CheckResult {
     let stats = store
         .stats()
-        .unwrap_or_else(|_| crate::vectordb::StoreStats {
+        .unwrap_or(crate::vectordb::StoreStats {
             total_chunks: 0,
             total_files: 0,
             indexed: false,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -431,7 +431,7 @@ async fn run_cache_stats(model: Option<String>) -> Result<()> {
             return Ok(());
         }
 
-        let cache = crate::embed::PersistentEmbeddingCache::open(&name)?;
+        let cache = crate::embed::PersistentEmbeddingCache::open(name)?;
         let stats = cache.stats()?;
 
         println!("Persistent Cache Statistics ({})", name);
@@ -517,13 +517,13 @@ async fn run_cache_clear(model: Option<String>, yes: bool) -> Result<()> {
 
     // Clear cache for specific model or all models
     if let Some(name) = model_name {
-        let model_cache_dir = cache_dir.join(&name);
+        let model_cache_dir = cache_dir.join(name);
         if !model_cache_dir.exists() {
             eprintln!("No cache found for model: {}", name);
             return Ok(());
         }
 
-        let cache = crate::embed::PersistentEmbeddingCache::open(&name)?;
+        let cache = crate::embed::PersistentEmbeddingCache::open(name)?;
         let stats_before = cache.stats()?;
         cache.clear()?;
         eprintln!(

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -108,7 +108,7 @@ pub const MAX_LMDB_MAP_SIZE_MB: usize = 8192;
 /// across branches. Each entry is ~1.5KB (384 dims × 4 bytes), so:
 /// - 200,000 entries ≈ 300MB on disk
 /// - Sufficient for 10+ branches worth of embeddings
-/// Override with `CODESEARCH_EMBEDDING_CACHE_MAX_ENTRIES` environment variable.
+/// - Override with `CODESEARCH_EMBEDDING_CACHE_MAX_ENTRIES` environment variable.
 pub const DEFAULT_EMBEDDING_CACHE_MAX_ENTRIES: usize = 200_000;
 
 /// Default embedding cache memory limit in MB.

--- a/src/embed/cache.rs
+++ b/src/embed/cache.rs
@@ -328,7 +328,6 @@ impl PersistentEmbeddingCache {
         Ok(self.db.get(&rtxn, content_hash)?)
     }
     #[allow(dead_code)]
-
     /// Store embedding in cache
     pub fn put(&self, content_hash: &str, embedding: &[f32]) -> Result<()> {
         let mut wtxn = self.env.write_txn()?;
@@ -357,7 +356,7 @@ impl PersistentEmbeddingCache {
         let last_access = std::fs::metadata(self.cache_dir.join("data.mdb"))
             .and_then(|m| m.modified())
             .ok()
-            .map(|dt| DateTime::from(dt));
+            .map(DateTime::from);
         Ok(PersistentCacheStats {
             entries: count as usize,
             file_size_bytes: file_size,
@@ -416,14 +415,12 @@ impl PersistentEmbeddingCache {
         Ok(())
     }
     #[allow(dead_code)]
-
     /// Get number of entries in cache
     pub fn len(&self) -> Result<usize> {
         let rtxn = self.env.read_txn()?;
         Ok(self.db.len(&rtxn)? as usize)
     }
     #[allow(dead_code)]
-
     /// Check if cache is empty
     pub fn is_empty(&self) -> Result<bool> {
         Ok(self.len()? == 0)
@@ -444,7 +441,6 @@ pub struct PersistentCacheStats {
     pub last_access: Option<DateTime<Utc>>,
 }
 #[allow(dead_code)]
-
 impl PersistentCacheStats {
     /// Get file size in MB
     pub fn file_size_mb(&self) -> f64 {

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -271,11 +271,9 @@ impl EmbeddingService {
     pub fn persistent_cache_stats(&self) -> Option<PersistentCacheStats> {
         self.persistent_cache
             .as_ref()
-            .map(|c| c.stats().ok())
-            .flatten()
+            .and_then(|c| c.stats().ok())
     }
     #[allow(dead_code)]
-
     /// Clear the persistent cache
     pub fn clear_persistent_cache(&mut self) -> Result<()> {
         if let Some(cache) = &mut self.persistent_cache {
@@ -284,13 +282,11 @@ impl EmbeddingService {
         Ok(())
     }
     #[allow(dead_code)]
-
     /// Get reference to persistent cache (if initialized)
     pub fn persistent_cache(&self) -> Option<&PersistentEmbeddingCache> {
         self.persistent_cache.as_ref()
     }
     #[allow(dead_code)]
-
     /// Get mutable reference to persistent cache (if initialized)
     pub fn persistent_cache_mut(&mut self) -> Option<&mut PersistentEmbeddingCache> {
         self.persistent_cache.as_mut()

--- a/src/fts/tantivy_store.rs
+++ b/src/fts/tantivy_store.rs
@@ -492,9 +492,10 @@ impl FtsStore {
             // This means: only items that match the identifier AND are of the target kind get boosted
             let sig_or_content =
                 BooleanQuery::union(vec![Box::new(boosted_sig), Box::new(content_query)]);
-            let mut and_queries: Vec<(Occur, Box<dyn tantivy::query::Query>)> = vec![];
-            and_queries.push((Occur::Must, Box::new(sig_or_content)));
-            and_queries.push((Occur::Must, Box::new(kind_query)));
+            let and_queries: Vec<(Occur, Box<dyn tantivy::query::Query>)> = vec![
+                (Occur::Must, Box::new(sig_or_content)),
+                (Occur::Must, Box::new(kind_query)),
+            ];
             BooleanQuery::new(and_queries)
         } else {
             // STANDARD MODE: Just search for the identifier in signature and content

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -138,10 +138,10 @@ fn get_db_path_smart(
     // Propagate errors (e.g. multiple child .git dirs found)
     let git_root = find_git_root(&canonical_path)?;
 
-    if let Some(root) = git_root {
+     if let Some(root) = git_root {
         if root != canonical_path {
             // We're in a subdirectory of a git repository!
-            eprintln!(
+            crate::output::print_info(format_args!(
                 "{}",
                 format!(
                     "⚠️  You are in a subdirectory: {}\n   Git repository root detected at: {}",
@@ -149,11 +149,11 @@ fn get_db_path_smart(
                     root.display()
                 )
                 .yellow()
-            );
-            eprintln!(
+            ));
+            crate::output::print_info(format_args!(
                 "{}",
                 "   Creating database at repository root to avoid duplicate indexes.".yellow()
-            );
+            ));
             let db_path = root.join(".codesearch.db");
             return Ok((db_path, root));
         }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -141,7 +141,7 @@ fn get_db_path_smart(
     if let Some(root) = git_root {
         if root != canonical_path {
             // We're in a subdirectory of a git repository!
-            println!(
+            eprintln!(
                 "{}",
                 format!(
                     "⚠️  You are in a subdirectory: {}\n   Git repository root detected at: {}",
@@ -150,7 +150,7 @@ fn get_db_path_smart(
                 )
                 .yellow()
             );
-            println!(
+            eprintln!(
                 "{}",
                 "   Creating database at repository root to avoid duplicate indexes.".yellow()
             );
@@ -580,13 +580,18 @@ async fn index_with_options(
     let mut chunker = SemanticChunker::new(100, 2000, 10);
     let mut total_chunks = 0;
 
-    let pb = ProgressBar::new(files.len() as u64);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} {msg}")
-            .unwrap()
-            .progress_chars("█▓▒░ "),
-    );
+    let pb = if quiet {
+        ProgressBar::hidden()
+    } else {
+        let pb = ProgressBar::new(files.len() as u64);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} {msg}")
+                .unwrap()
+                .progress_chars("█▓▒░ "),
+        );
+        pb
+    };
 
     // Initialize embedding model (uses global models cache)
     let cache_dir = crate::constants::get_global_models_cache_dir()?;

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -138,7 +138,7 @@ fn get_db_path_smart(
     // Propagate errors (e.g. multiple child .git dirs found)
     let git_root = find_git_root(&canonical_path)?;
 
-     if let Some(root) = git_root {
+    if let Some(root) = git_root {
         if root != canonical_path {
             // We're in a subdirectory of a git repository!
             crate::output::print_info(format_args!(

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -108,29 +108,30 @@ fn get_db_path_smart(
     }
 
     // Step 4: Use automatic discovery (default behavior)
-    // Skip when --force: the old location may be wrong (e.g. not at git root).
+    // Skip when --force: old location may be wrong (e.g. not at git root).
     // Let Step 5 (find_git_root) determine the correct location.
-    if !force && existing_db.is_some() {
-        let db_info = existing_db.as_ref().unwrap();
-        // Use existing database (local or global)
-        if !db_info.is_current {
-            let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-            let relative_path = if let Ok(rel) = current_dir.strip_prefix(&db_info.project_path) {
-                format!("./{}", rel.display())
-            } else {
-                db_info.project_path.display().to_string()
-            };
-            println!(
-                "{}",
-                format!(
-                    "📂 Using database from: {}\n   (indexing from subfolder, project root: {})",
-                    db_info.db_path.display(),
-                    relative_path
-                )
-                .dimmed()
-            );
+    if !force {
+        if let Some(db_info) = existing_db.as_ref() {
+            // Use existing database (local or global)
+            if !db_info.is_current {
+                let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+                let relative_path = if let Ok(rel) = current_dir.strip_prefix(&db_info.project_path) {
+                    format!("./{}", rel.display())
+                } else {
+                    db_info.project_path.display().to_string()
+                };
+                println!(
+                    "{}",
+                    format!(
+                        "📂 Using database from: {}\n   (indexing from subfolder, project root: {})",
+                        db_info.db_path.display(),
+                        relative_path
+                    )
+                    .dimmed()
+                );
+            }
+            return Ok((db_info.db_path.clone(), db_info.project_path.clone()));
         }
-        return Ok((db_info.db_path.clone(), db_info.project_path.clone()));
     }
 
     // Step 5: No existing database - SAFETY CHECK before creating

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -66,14 +66,6 @@ use std::sync::{Arc, Mutex};
 use tokio_util::sync::CancellationToken;
 
 use crate::db_discovery::{find_best_database, find_databases};
-
-/// Normalize a path string for comparison.
-/// Delegates to `cache::normalize_path_str` for consistency, then strips "./" prefix.
-fn normalize_path_for_compare(path: &str) -> String {
-    crate::cache::normalize_path_str(path)
-        .trim_start_matches("./")
-        .to_string()
-}
 use crate::embed::{EmbeddingService, ModelType};
 use crate::file::Language;
 use crate::fts::FtsStore;
@@ -315,7 +307,7 @@ impl CodesearchService {
             Ok(fts_store) => {
                 // FTS search
                 let fts_results = fts_store
-                    .search(&request.query, limit * 3, structural_intent.clone())
+                    .search(&request.query, limit * 3, structural_intent)
                     .unwrap_or_default();
 
                 let fused = if identifiers.is_empty() {
@@ -326,7 +318,7 @@ impl CodesearchService {
                     let mut all_exact: Vec<crate::fts::FtsResult> = Vec::new();
                     for ident in &identifiers {
                         if let Ok(exact) =
-                            fts_store.search_exact(ident, limit * 2, structural_intent.clone())
+                            fts_store.search_exact(ident, limit * 2, structural_intent)
                         {
                             for r in exact {
                                 if !all_exact.iter().any(|e| e.chunk_id == r.chunk_id) {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -953,7 +953,7 @@ pub async fn run_mcp_server(
 
     // Set FASTEMBED_CACHE_DIR early (before any embedding work) to ensure fastembed
     // downloads and caches models to ~/.codesearch/models instead of creating
-     // .fastembed_cache in the current working directory.
+    // .fastembed_cache in the current working directory.
     match crate::constants::get_global_models_cache_dir() {
         Ok(models_dir) => {
             std::env::set_var("FASTEMBED_CACHE_DIR", &models_dir);

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -953,13 +953,13 @@ pub async fn run_mcp_server(
 
     // Set FASTEMBED_CACHE_DIR early (before any embedding work) to ensure fastembed
     // downloads and caches models to ~/.codesearch/models instead of creating
-    // .fastembed_cache in the current working directory.
+     // .fastembed_cache in the current working directory.
     match crate::constants::get_global_models_cache_dir() {
         Ok(models_dir) => {
             std::env::set_var("FASTEMBED_CACHE_DIR", &models_dir);
         }
         Err(e) => {
-            eprintln!("Warning: Could not set FASTEMBED_CACHE_DIR: {}", e);
+            tracing::warn!("Could not set FASTEMBED_CACHE_DIR: {}", e);
         }
     }
 
@@ -1031,7 +1031,7 @@ pub async fn run_mcp_server(
     // Initialize file logger now that db_path is known (works for both existing and auto-created DB)
     // NOTE: For MCP, tracing is NOT initialized in main.rs — this is the only init call
     if let Err(e) = crate::logger::init_logger(&db_path, log_level, quiet) {
-        eprintln!("Warning: Failed to initialize file logger: {}", e);
+        tracing::warn!("Failed to initialize file logger: {}", e);
     }
 
     tracing::info!("📂 Project: {}", project_path.display());

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -22,18 +22,6 @@ pub struct SemanticSearchRequest {
     pub filter_path: Option<String>,
 }
 
-/// Request to get file chunks
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFileChunksRequest {
-    /// Path to the file (relative to project root)
-    pub path: String,
-
-    /// Return compact results (metadata only) to save tokens (default: true).
-    /// When true: returns only path, start_line, end_line, kind, signature.
-    /// When false: also includes full code content.
-    pub compact: Option<bool>,
-}
-
 /// Request to find references/call sites of a symbol.
 /// Use this AFTER semantic_search to find where a function/class/variable is used.
 /// Use this INSTEAD OF grep for finding symbol usages in the codebase.
@@ -46,7 +34,7 @@ pub struct FindReferencesRequest {
     pub limit: Option<usize>,
 }
 
-/// Search result item - returned by semantic_search and get_file_chunks
+/// Search result item - returned by semantic_search
 #[derive(Debug, Serialize)]
 pub struct SearchResultItem {
     pub path: String,

--- a/src/rerank/mod.rs
+++ b/src/rerank/mod.rs
@@ -141,19 +141,19 @@ pub fn rrf_fusion_with_exact(
     fts_k: f32,
     exact_k: f32,
 ) -> Vec<FusedResult> {
+    // Type alias for complex score tuple to improve readability
+    type ScoreTuple = (
+        f32,
+        Option<f32>,
+        Option<f32>,
+        Option<f32>,
+        Option<usize>,
+        Option<usize>,
+        Option<usize>,
+    );
+
     // Maps chunk_id -> (rrf_score, vector_score, fts_score, exact_score, vector_rank, fts_rank, exact_rank)
-    let mut scores: HashMap<
-        u32,
-        (
-            f32,
-            Option<f32>,
-            Option<f32>,
-            Option<f32>,
-            Option<usize>,
-            Option<usize>,
-            Option<usize>,
-        ),
-    > = HashMap::new();
+    let mut scores: HashMap<u32, ScoreTuple> = HashMap::new();
 
     // Process vector results
     for (rank, result) in vector_results.iter().enumerate() {

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -180,7 +180,9 @@ pub fn detect_structural_intent(query: &str) -> Option<crate::chunker::ChunkKind
         return None; // No specific identifier - don't apply kind boost
     }
 
-    let kind = if query_lower.contains("class ") {
+    
+
+    if query_lower.contains("class ") {
         Some(ChunkKind::Class)
     } else if query_lower.contains("struct ") {
         Some(ChunkKind::Struct)
@@ -196,9 +198,7 @@ pub fn detect_structural_intent(query: &str) -> Option<crate::chunker::ChunkKind
         Some(ChunkKind::Trait)
     } else {
         None
-    };
-
-    kind
+    }
 }
 
 /// Checks if query contains a PascalCase or snake_case identifier
@@ -238,7 +238,7 @@ fn contains_identifier(query: &str) -> bool {
 
 /// Boosts results that match a specific ChunkKind by a factor
 pub fn boost_kind(
-    results: &mut Vec<crate::vectordb::SearchResult>,
+    results: &mut [crate::vectordb::SearchResult],
     target_kind: crate::chunker::ChunkKind,
 ) {
     let boost_factor = 0.15; // 15% boost for matching kind

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -413,19 +413,11 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
 
     if !db_path.exists() {
         if options.create_index {
-            // Automatically create index — print to stderr when in JSON mode to avoid corrupting output
-            if !options.json {
-                println!("{}", "🚀 No index found, creating one...".bright_cyan());
-            } else {
-                eprintln!("{}", "🚀 No index found, creating one...".bright_cyan());
-            }
+            // Automatically create index — use print_info which goes to stderr and respects quiet mode
+            crate::output::print_info(format_args!("{}", "🚀 No index found, creating one...".bright_cyan()));
             let cancel_token = tokio_util::sync::CancellationToken::new();
             crate::index::index_quiet(path, false, cancel_token).await?;
-            if !options.json {
-                println!("{}", "✅ Index created successfully!".green());
-            } else {
-                eprintln!("{}", "✅ Index created successfully!".green());
-            }
+            crate::output::print_info(format_args!("{}", "✅ Index created successfully!".green()));
         } else {
             println!("{}", "❌ No database found!".red());
             println!("   Run {} first", "codesearch index".bright_cyan());

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -413,11 +413,19 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
 
     if !db_path.exists() {
         if options.create_index {
-            // Automatically create index
-            println!("{}", "🚀 No index found, creating one...".bright_cyan());
+            // Automatically create index — print to stderr when in JSON mode to avoid corrupting output
+            if !options.json {
+                println!("{}", "🚀 No index found, creating one...".bright_cyan());
+            } else {
+                eprintln!("{}", "🚀 No index found, creating one...".bright_cyan());
+            }
             let cancel_token = tokio_util::sync::CancellationToken::new();
             crate::index::index_quiet(path, false, cancel_token).await?;
-            println!("{}", "✅ Index created successfully!".green());
+            if !options.json {
+                println!("{}", "✅ Index created successfully!".green());
+            } else {
+                eprintln!("{}", "✅ Index created successfully!".green());
+            }
         } else {
             println!("{}", "❌ No database found!".red());
             println!("   Run {} first", "codesearch index".bright_cyan());

--- a/src/vectordb/store.rs
+++ b/src/vectordb/store.rs
@@ -716,19 +716,6 @@ impl VectorStore {
         }
     }
 
-    /// Iterate all chunks in the store via LMDB cursor.
-    /// Returns (id, metadata) pairs for every chunk, regardless of ID gaps.
-    /// This is the correct way to enumerate chunks after delete+insert cycles.
-    pub fn all_chunks(&self) -> Result<Vec<(u32, ChunkMetadata)>> {
-        let rtxn = self.env.read_txn()?;
-        let mut result = Vec::new();
-        for entry in self.chunks.iter(&rtxn)? {
-            let (id, metadata) = entry?;
-            result.push((id, metadata));
-        }
-        Ok(result)
-    }
-
     /// Get the database file size in bytes
     #[allow(dead_code)] // Reserved for stats display
     pub fn db_size(&self) -> Result<u64> {


### PR DESCRIPTION
## Summary

- Fixed stdout/stderr pollution issues in `--quiet --json` mode and MCP server
- Fixed all clippy warnings (25 warnings → 0)
- Added audit fixes from PR review

## Context

PR #8 (automatic index creation feature) was merged, but contained several bugs:
1. `--quiet --json` search mode leaked indexing messages to stdout
2. MCP server leaked warnings to stderr (breaks JSON-RPC protocol)
3. 25 clippy warnings across codebase

This PR contains fixes for those issues, based on top of master (after PR #8 merge).

## Changes

### Bug Fixes
- `src/index/mod.rs`: 
  - Subdirectory warning now uses `crate::output::print_info` (respects quiet mode)
  - Progress bar uses `ProgressBar::hidden()` when quiet
- `src/mcp/mod.rs`: 
  - Replaced `eprintln!` with `tracing::warn!` for warnings (JSON-RPC compliance)
- `src/search/mod.rs`: 
  - Indexing status messages use `crate::output::print_info` instead of `println`

### Code Quality
- Removed unused functions: `normalize_path_for_compare` (mcp/mod.rs), `all_chunks` (vectordb/store.rs)
- Fixed empty lines after `#[allow(dead_code)]` attributes (7 instances in embed/cache.rs, embed/mod.rs)
- Fixed doc list item indentation (constants.rs)
- Fixed function parameter: `Vec<T>` → `&mut [T]` (search/mod.rs::boost_kind)
- Fixed unused variable: removed `mut` from `and_queries` (fts/tantivy_store.rs)
- Fixed `Option::unwrap()`: use idiomatic `if let Some()` pattern (index/mod.rs)
- Added type alias for complex 7-tuple score type (rerank/mod.rs)
- Removed trailing whitespace (cli/doctor.rs, cli/mod.rs)

## Testing

- [x] Unit tests pass: 166 tests, 0 failures, 12 ignored
- [x] Build successful: cargo build passes without errors
- [x] Clippy clean: 0 warnings, 0 errors
- [x] Verified `--quiet --json` produces clean JSON output
- [x] Verified MCP server produces no stdout/stderr pollution

## Breaking Changes

- [ ] None

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (README.md already covers these fixes)
- [x] No new warnings generated (25 warnings → 0)
- [x] All tests passing
- [x] Build successful