### PR TITLE
🐛 fix: restore quiet mode on error paths in branch refresh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
         description: 'Include macOS build (10x minutes cost)'
         required: false
         type: boolean
-        default: false
+        default: true
 
 permissions:
   contents: write
@@ -80,7 +80,7 @@ jobs:
           path: ${{ matrix.artifact }}
 
   build-macos:
-    if: github.event_name == 'workflow_dispatch' && inputs.include_macos
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.include_macos)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.196"
+version = "0.1.197"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.197"
+version = "0.1.200"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.197"
+version = "0.1.200"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.196"
+version = "0.1.197"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -352,15 +352,13 @@ fn read_dimensions(db_path: &Path) -> usize {
 
 /// Check 6: Chunk integrity - vector store health
 fn check_chunk_integrity(store: &VectorStore) -> CheckResult {
-    let stats = store
-        .stats()
-        .unwrap_or(crate::vectordb::StoreStats {
-            total_chunks: 0,
-            total_files: 0,
-            indexed: false,
-            dimensions: 0,
-            max_chunk_id: 0,
-        });
+    let stats = store.stats().unwrap_or(crate::vectordb::StoreStats {
+        total_chunks: 0,
+        total_files: 0,
+        indexed: false,
+        dimensions: 0,
+        max_chunk_id: 0,
+    });
     if stats.indexed {
         CheckResult::pass(
             "Chunk integrity",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -382,10 +382,7 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
         Commands::Clear { path, yes } => crate::index::clear(path, yes).await,
         Commands::Doctor { fix, json } => crate::cli::doctor::run(fix, json).await,
         Commands::Setup { model } => crate::cli::setup::run(model).await,
-        Commands::Mcp {
-            path,
-            create_index,
-        } => {
+        Commands::Mcp { path, create_index } => {
             // Logger is initialized inside run_mcp_server() once db_path is known.
             // This handles both the "DB already exists" and "auto-create DB" paths correctly.
             crate::mcp::run_mcp_server(path, create_index, log_level, cli.quiet, cancel_token).await

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -269,9 +269,7 @@ impl EmbeddingService {
     #[allow(dead_code)]
     /// Get persistent cache statistics
     pub fn persistent_cache_stats(&self) -> Option<PersistentCacheStats> {
-        self.persistent_cache
-            .as_ref()
-            .and_then(|c| c.stats().ok())
+        self.persistent_cache.as_ref().and_then(|c| c.stats().ok())
     }
     #[allow(dead_code)]
     /// Clear the persistent cache

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -115,7 +115,8 @@ fn get_db_path_smart(
             // Use existing database (local or global)
             if !db_info.is_current {
                 let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-                let relative_path = if let Ok(rel) = current_dir.strip_prefix(&db_info.project_path) {
+                let relative_path = if let Ok(rel) = current_dir.strip_prefix(&db_info.project_path)
+                {
                     format!("./{}", rel.display())
                 } else {
                     db_info.project_path.display().to_string()

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -33,8 +33,7 @@ mod tests {
                 let call_print = trimmed.starts_with("print!(")
                     || line.contains(" print!(")
                     || line.contains("\tprint!(");
-                let is_prefixed =
-                    line.contains("info_print!(") || line.contains("warn_print!(");
+                let is_prefixed = line.contains("info_print!(") || line.contains("warn_print!(");
                 let is_detection_code = line.contains("line.contains(");
                 (call_println || call_print) && !is_prefixed && !is_detection_code
             })
@@ -401,9 +400,7 @@ impl CodesearchService {
         // Convert to response format, applying compact mode and filter_path
         // Pre-compute normalized project root for stripping absolute paths
         let project_root_normalized = {
-            let root = crate::cache::normalize_path_str(
-                self.project_path.to_str().unwrap_or(""),
-            );
+            let root = crate::cache::normalize_path_str(self.project_path.to_str().unwrap_or(""));
             root.trim_end_matches('/').to_string()
         };
 
@@ -444,8 +441,6 @@ impl CodesearchService {
         let json = serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string());
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
-
-
 
     #[tool(
         description = "Find all references/usages of a symbol (function, class, method, variable) across the codebase. USE THIS INSTEAD OF GREP when you need to find where a symbol is used — for refactoring, impact analysis, or understanding call sites. Returns compact list of file paths, line numbers, and containing function signatures."
@@ -985,17 +980,17 @@ pub async fn run_mcp_server(
         }
 
         // Create minimal database structure to allow server to start immediately
-        let effective_path = path
-            .as_ref()
-            .cloned()
-            .unwrap_or(std::env::current_dir()?);
+        let effective_path = path.as_ref().cloned().unwrap_or(std::env::current_dir()?);
 
         // Use git root detection to place database in the correct location
-        let db_root = crate::index::find_git_root(&effective_path)?
-            .unwrap_or_else(|| effective_path.clone());
+        let db_root =
+            crate::index::find_git_root(&effective_path)?.unwrap_or_else(|| effective_path.clone());
         let db_path = db_root.join(".codesearch.db");
 
-        tracing::info!("📁 Creating minimal database structure at {}", db_path.display());
+        tracing::info!(
+            "📁 Creating minimal database structure at {}",
+            db_path.display()
+        );
 
         // Create directory
         std::fs::create_dir_all(&db_path)?;
@@ -1052,7 +1047,9 @@ pub async fn run_mcp_server(
         {
             Some(d) => d as usize,
             None => {
-                tracing::warn!("⚠️  Could not parse dimensions from metadata.json, using default 384");
+                tracing::warn!(
+                    "⚠️  Could not parse dimensions from metadata.json, using default 384"
+                );
                 384
             }
         }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -10,9 +10,9 @@ use crate::chunker::SemanticChunker;
 use crate::embed::{EmbeddingService, ModelType};
 use crate::file::FileWalker;
 use crate::fts::FtsStore;
-use crate::{info_print, warn_print};
 use crate::rerank::{rrf_fusion, vector_only, FusedResult, NeuralReranker, DEFAULT_RRF_K};
 use crate::vectordb::VectorStore;
+use crate::{info_print, warn_print};
 
 /// Configuration options for search operations
 #[derive(Debug, Clone)]
@@ -179,8 +179,6 @@ pub fn detect_structural_intent(query: &str) -> Option<crate::chunker::ChunkKind
     if !has_identifier {
         return None; // No specific identifier - don't apply kind boost
     }
-
-    
 
     if query_lower.contains("class ") {
         Some(ChunkKind::Class)
@@ -414,7 +412,10 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
     if !db_path.exists() {
         if options.create_index {
             // Automatically create index — use print_info which goes to stderr and respects quiet mode
-            crate::output::print_info(format_args!("{}", "🚀 No index found, creating one...".bright_cyan()));
+            crate::output::print_info(format_args!(
+                "{}",
+                "🚀 No index found, creating one...".bright_cyan()
+            ));
             let cancel_token = tokio_util::sync::CancellationToken::new();
             crate::index::index_quiet(path, false, cancel_token).await?;
             crate::output::print_info(format_args!("{}", "✅ Index created successfully!".green()));
@@ -893,11 +894,23 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
                 start_line: r.start_line,
                 end_line: r.end_line,
                 kind: r.kind.clone(),
-                content: if compact { None } else { Some(r.content.clone()) },
+                content: if compact {
+                    None
+                } else {
+                    Some(r.content.clone())
+                },
                 score: r.score,
                 signature: r.signature.clone(),
-                context_prev: if compact { None } else { r.context_prev.clone() },
-                context_next: if compact { None } else { r.context_next.clone() },
+                context_prev: if compact {
+                    None
+                } else {
+                    r.context_prev.clone()
+                },
+                context_next: if compact {
+                    None
+                } else {
+                    r.context_next.clone()
+                },
             })
             .collect();
 
@@ -948,7 +961,11 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
     println!("{}", "=".repeat(60));
     println!("Query: \"{}\"", query.bright_yellow());
     if let Some(pf) = options.per_file {
-        println!("Found {} results (showing up to {} per file)", results.len(), pf);
+        println!(
+            "Found {} results (showing up to {} per file)",
+            results.len(),
+            pf
+        );
     } else {
         println!("Found {} results", results.len());
     }


### PR DESCRIPTION
## Summary

- Fixed critical bug where `set_quiet(true)` was not restored on error paths in branch refresh, causing permanent logging silence
- Wrapped `refresh_index_with_stores()` body in async block to ensure cleanup always runs
- Enabled macOS build by default in release.yml with option to uncheck on manual release

## Changes

### Critical Bug Fix
- `src/index/manager.rs`: Wrapped `refresh_index_with_stores()` in async block to guarantee `set_quiet(false)` executes even when errors propagate via `?` operator
- Previously, 13 potential error paths could leave quiet mode `true` permanently, silencing all subsequent logging

### Release Workflow
- `.github/workflows/release.yml`: macOS build now enabled by default (checkbox checked)
- macOS build now runs automatically on tag pushes, with option to uncheck on manual workflow dispatch

### Code Quality & Cleanup
- `src/vectordb/store.rs`: Fixed deprecation warnings for `ignore_files` type
- `src/mcp/mod.rs`, `src/search/mod.rs`: Improved path filtering with `strip_prefix` pattern
- `src/index/manager.rs`: Added comprehensive integration tests for branch refresh logic
- Version bump: 0.1.197 → 0.1.200

## Testing

- [x] All unit tests pass
- [x] Branch refresh integration tests cover:
  - No metadata.json early return
  - Single ghost file deletion
  - Multiple ghost file deletion
  - Valid file preservation during refresh
  - Mixed ghost and real file handling
  - Empty codebase handling
- [x] Code compiles with no warnings
- [x] Clippy passes with no issues

## Breaking Changes

- [ ] None

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] No new warnings generated
- [x] Tests added/updated
- [x] All tests passing