### PR TITLE
✨ feat: new MCP tools (literal_search, find_definition, find_usages) + semantic_search hybrid rebrand

### DIFF
--- a/AGENTS_tool_improvement.md
+++ b/AGENTS_tool_improvement.md
@@ -1,0 +1,221 @@
+# AGENTS — Branch `feat/mcp-rebrand-hybrid-search`
+
+> Scoped instructions for any coding agent (OpenCode, Claude Code, Copilot) working on this branch. This file is self-contained: everything needed to execute the work is below. A parallel Branch B handles a separate concern and must not be touched here.
+
+## Why this branch exists
+
+Agents observing codesearch via MCP frequently fall back to `grep`, even for queries codesearch would handle well. Root cause diagnosis on `src/mcp/mod.rs` and `src/mcp/types.rs`:
+
+1. **Description framing.** `semantic_search` is advertised as *"Search code semantically using natural language"*. Agents read literal/identifier queries as "not natural language" and route away — despite the fact that the implementation already fuses vector + Tantivy FTS and boosts exact-identifier matches via `rrf_fusion_with_exact`.
+2. **`find_references` misrepresents its behavior.** The impl is `fts_store.search(&symbol, ...)` — a substring FTS search that returns definitions, comments, docstrings, and string literals alongside actual usages. After one noisy result, agents stop trusting it.
+3. **No confidence signal.** `semantic_search` returns `limit` results regardless of top RRF score. Agents cannot distinguish "strong match" from "grasping".
+4. **Over-long, negative `instructions` block.** The current `get_info().instructions` is ~150 lines and repeats "NEVER use grep". Negative framing backfires; agents route on concrete tool descriptions anyway.
+
+This branch makes **zero algorithm changes**. It is a tool-surface and description pass.
+
+## Scope — what to implement
+
+1. Rewrite `semantic_search` description as a hybrid tool (positive routing).
+2. Add optional `mode` parameter to `semantic_search` so callers can hint intent.
+3. Add a low-confidence signal to `semantic_search` responses.
+4. Split the current `find_references` into two new tools: `find_definition` and `find_usages`. Keep `find_references` as a deprecated alias.
+5. Shrink the server-wide `instructions` block and replace negative framing with a compact routing table.
+
+## Scope — what NOT to touch
+
+- `src/chunker/` — no changes to chunking.
+- `src/rerank/` — no changes to RRF fusion, `boost_kind`, etc.
+- `src/search/` — no changes to `detect_identifiers`, `detect_structural_intent`, `adapt_rrf_k`.
+- `src/embed/` — no embedding model changes.
+- `src/fts/tantivy_store.rs` — no new Tantivy query types in this branch. If you feel tempted to add `search_regex` or `search_phrase`, stop — that belongs in Branch B (`feat/mcp-literal-search-tool`).
+- Any new dependency in `Cargo.toml`.
+
+## File-by-file plan
+
+### `src/mcp/types.rs`
+
+Extend `SemanticSearchRequest`:
+
+```rust
+pub struct SemanticSearchRequest {
+    pub query: String,
+    pub limit: Option<usize>,
+    pub compact: Option<bool>,
+    pub filter_path: Option<String>,
+
+    /// Override auto-detection of query intent.
+    /// "auto" (default) | "semantic" | "lexical" | "hybrid"
+    /// - "semantic": skip FTS fusion, use vector results only
+    /// - "lexical":  skip embedding, use FTS path only
+    /// - "hybrid":   force full hybrid even if auto would choose a single path
+    pub mode: Option<String>,
+}
+```
+
+Add new request types:
+
+```rust
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindDefinitionRequest {
+    /// Symbol name (function, class, method, struct, trait, enum, type)
+    pub symbol: String,
+    /// Optional filter to a specific kind. If omitted, all definition kinds are searched.
+    /// Accepted: "Function" | "Class" | "Method" | "Struct" | "Trait" | "Enum" | "TypeAlias" | "Interface"
+    pub kind: Option<String>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindUsagesRequest {
+    pub symbol: String,
+    pub limit: Option<usize>,
+}
+```
+
+Extend the semantic-search response wrapper with low-confidence signaling. Preferred: wrap the existing `Vec<SearchResultItem>` in a response struct rather than adding fields to every item.
+
+```rust
+#[derive(Debug, Serialize)]
+pub struct SemanticSearchResponse {
+    pub results: Vec<SearchResultItem>,
+    /// Set when the top RRF score is below the confidence threshold.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub low_confidence: Option<bool>,
+    /// Populated alongside `low_confidence`. Suggests a better-suited tool for this query.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_tool: Option<String>,
+}
+```
+
+### `src/mcp/mod.rs` — `semantic_search`
+
+Replace the `#[tool(description = ...)]` with this exact text:
+
+```
+Hybrid code search over tree-sitter AST chunks: vector embeddings + Tantivy FTS + exact-identifier boosting, fused with RRF.
+
+USE FOR:
+- Conceptual queries ("where is auth handled", "how do we log errors")
+- Identifier lookups — function/class/variable names are boosted via exact-match FTS
+- Mixed natural-language + symbol queries
+
+DO NOT USE FOR:
+- Finding a symbol's definition specifically — use `find_definition`
+- Finding all call-sites of a symbol — use `find_usages`
+
+OPTIONAL `mode`: "auto" (default) | "semantic" | "lexical" | "hybrid".
+Returns metadata only by default (compact=true). Set compact=false for inline content.
+```
+
+Handler changes:
+
+- Parse `request.mode.as_deref().unwrap_or("auto")`.
+- `"semantic"` → return vector results directly, skip FTS fusion.
+- `"lexical"` → skip `embed_query`; call FTS directly and return those.
+- `"hybrid"` | `"auto"` → keep current hybrid behavior unchanged.
+- After fusion and boosting, inspect `results.first().map(|r| r.score)`:
+  - If present and `< 0.02` (constant, name it `LOW_CONFIDENCE_THRESHOLD` at module scope with a brief comment), set `low_confidence = true`.
+  - `suggested_tool`: if `detect_identifiers(&request.query)` is non-empty → `"find_definition"`; otherwise → `"literal_search"` (tool will exist after Branch B merges; the hint is informational meanwhile).
+- Return `SemanticSearchResponse` instead of raw `Vec<SearchResultItem>`.
+
+### `src/mcp/mod.rs` — new `find_definition` tool
+
+```
+Locate the definition of a symbol (function, class, method, struct, trait, enum, type).
+Uses FTS + chunk-kind filter to exclude usages, comments, and string literals.
+
+USE FOR: "where is X defined", "show me the declaration of X".
+DO NOT USE FOR: finding all call-sites → use `find_usages`.
+```
+
+Impl outline:
+
+- FTS search on `request.symbol`, `limit * 3` hits.
+- Resolve `chunk_id` → full chunk via `VectorStore::get_chunk` (pattern already used in existing `find_references`).
+- Filter by `kind ∈ {"Function", "Class", "Method", "Struct", "Trait", "Enum", "TypeAlias", "Interface"}`.
+- If `request.kind` is provided, further restrict to that exact kind.
+- Return `Vec<ReferenceItem>` (reuse existing struct) truncated to `limit`.
+
+### `src/mcp/mod.rs` — new `find_usages` tool
+
+```
+Find call-sites and other usages of a symbol across the codebase.
+Uses FTS; excludes the chunks that are the symbol's own definition.
+
+USE FOR: impact analysis, refactoring, "who calls X".
+DO NOT USE FOR: finding the definition itself → use `find_definition`.
+```
+
+Impl outline:
+
+- FTS search on `request.symbol`.
+- For each hit, fetch the chunk.
+- Exclude hits where `kind` is a definition kind **and** the chunk's `signature` contains the symbol name verbatim at a likely definition position (e.g. `fn <symbol>(`, `class <symbol>`, `struct <symbol>`, `def <symbol>(`). Best-effort substring check is acceptable for v1 — document the limitation in a comment.
+- Return `Vec<ReferenceItem>`.
+
+### `src/mcp/mod.rs` — `find_references` (deprecated alias)
+
+Keep the tool registered so existing agent configs don't break. New description:
+
+```
+DEPRECATED. Use `find_definition` to locate a symbol's declaration, or `find_usages` to find call-sites.
+This tool is retained as an alias for `find_usages` and may be removed in a future version.
+```
+
+Implementation: delegate to the new `find_usages` handler. No behavioral change from the agent's perspective beyond the description.
+
+### `src/mcp/mod.rs` — `get_info().instructions`
+
+Replace the current ~150-line block with ≤ 50 lines. Required structure:
+
+```
+codesearch — semantic + lexical code search MCP server.
+
+TOOLS:
+| Tool              | Use for                                              |
+|-------------------|------------------------------------------------------|
+| semantic_search   | Conceptual queries, identifier + natural-language mix |
+| find_definition   | Where is symbol X defined                             |
+| find_usages       | Who uses / calls symbol X                             |
+| index_status      | Verify the index is ready                             |
+| find_databases    | Discover available indexes                            |
+
+Indexing is done via CLI: `codesearch index`. The MCP server cannot index.
+
+Current project: {project}
+Current database: {db} ({exists})
+Model: {model} ({dims}d)
+```
+
+Drop every occurrence of "NEVER use grep". The routing table is self-explanatory.
+
+## Acceptance criteria
+
+All of these must hold before PR merge:
+
+- `cargo test --all` passes.
+- `cargo clippy --all-targets -- -D warnings` passes.
+- New unit test in `src/mcp/mod.rs` tests module: `find_definition("CodesearchService")` returns at least one result, and all results have `kind == "Struct"` (or the project's equivalent chunk kind for a Rust struct definition).
+- New unit test: `find_usages("authenticate")` on a fixture project does **not** include the chunk whose `signature` starts with `fn authenticate(` (or language equivalent).
+- New unit test: `semantic_search` with a deliberately nonsensical query (e.g. `"xyzzy_nonexistent_quux"`) returns a response with `low_confidence == Some(true)`.
+- New unit test: `semantic_search` with `mode = Some("lexical")` does not invoke the embedding service. Verify via a trace-level log assertion or a test double.
+- Existing `test_mcp_no_raw_stdout_calls` still passes (do not break the JSON-RPC contract).
+- `get_info().instructions` output is ≤ 50 lines (simple line count in a test).
+- Manual: start the server against a real repo, run the 20-query benchmark against main. No regression on conceptual queries.
+
+## Commit hygiene
+
+- Small commits, one logical change each.
+- Conventional-commit style (`feat(mcp): ...`, `refactor(mcp): ...`, `test(mcp): ...`, `docs(mcp): ...`).
+- Author identity = Filip Develter personal GitHub (`flupkede`). Verify `git config user.email` before first commit.
+
+## PR expectations
+
+- Title: `feat(mcp): rebrand semantic_search as hybrid, split find_references`
+- Target base: `main`
+- Description should include a before/after table of tool names and one-line descriptions.
+- Link this AGENTS file in the PR body.
+
+## What comes after this branch
+
+A separate branch `feat/mcp-literal-search-tool` will add a dedicated `literal_search` tool exposing Tantivy regex/phrase/field capabilities without an embedding call. That branch is explicitly out of scope here — do not pre-empt it.

--- a/AGENTS_tool_improvement.md
+++ b/AGENTS_tool_improvement.md
@@ -1,0 +1,192 @@
+# AGENTS — Branch `feat/mcp-literal-search-tool`
+
+> Scoped instructions for any coding agent (OpenCode, Claude Code, Copilot) working on this branch. This file is self-contained: everything needed to execute the work is below. A parallel Branch A (`feat/mcp-rebrand-hybrid-search`) handles a separate concern and is expected to have merged before this branch is rebased onto `main`.
+
+## Why this branch exists
+
+Agents observing codesearch via MCP fall back to `grep` for pure literal lookups: error codes, TODO tags, env var names, URLs, hardcoded strings, regex patterns. The reason is simple — **there is no MCP tool that exposes literal/regex search without going through the semantic pipeline.**
+
+Internally, `semantic_search` does fuse Tantivy FTS results, but:
+
+- Every call pays the embedding cost (~50-200ms) even for pure literal queries.
+- Tantivy's regex, phrase, and field-scoped capabilities are hidden behind the natural-language framing.
+- Non-identifier literals (error strings with spaces, URLs, regex patterns) are not picked up by `detect_identifiers`, so they get no exact-match boost — and are then diluted by vector neighbours in RRF fusion.
+
+This branch adds one dedicated tool: `literal_search`. No changes to semantic search, ranking, or indexing.
+
+## Prerequisite
+
+This branch assumes Branch A (`feat/mcp-rebrand-hybrid-search`) has merged to `main`. In Branch A, `semantic_search` sets `suggested_tool = "literal_search"` when the query has no detected identifiers and top score is low — so `literal_search` must exist as an advertised tool once Branch A's hint takes effect. If this branch is opened while Branch A is still in review, rebase onto `main` after A merges before final PR.
+
+## Scope — what to implement
+
+1. Add `search_regex` and `search_phrase` methods on `FtsStore`.
+2. Add `LiteralSearchRequest` / `LiteralSearchResultItem` types.
+3. Add a new `literal_search` MCP tool that:
+   - skips the embedding service entirely,
+   - routes the query to `search_exact`, `search_phrase`, or `search_regex` based on input flags,
+   - supports `file_glob` and `language` post-filters,
+   - supports `format = "json" | "grep"` output.
+
+## Scope — what NOT to touch
+
+- `semantic_search`, `find_definition`, `find_usages`, `find_references`, `index_status`, `find_databases` — do not modify.
+- The embedding pipeline (`src/embed/`).
+- The chunker (`src/chunker/`).
+- The ranker (`src/rerank/`, `src/search/`).
+- The vector store (`src/vectordb/`) — read-only access only, via existing APIs.
+- `Cargo.toml` — no new dependencies; Tantivy already provides everything needed.
+
+## File-by-file plan
+
+### `src/fts/tantivy_store.rs`
+
+Add two public methods to `FtsStore`. Signatures:
+
+```rust
+/// Search using a regex pattern over the content field.
+/// Pattern syntax is Tantivy's (Rust-regex-compatible).
+/// Returns hits ordered by BM25 score.
+pub fn search_regex(
+    &self,
+    pattern: &str,
+    limit: usize,
+) -> Result<Vec<FtsResult>>;
+
+/// Search for an exact phrase (consecutive tokens) over the content field.
+/// The phrase is tokenised with the same analyser as indexed content.
+pub fn search_phrase(
+    &self,
+    phrase: &str,
+    limit: usize,
+) -> Result<Vec<FtsResult>>;
+```
+
+Implementation notes:
+
+- `search_regex` uses `tantivy::query::RegexQuery::from_pattern(pattern, content_field)`.
+- `search_phrase` uses `tantivy::query::PhraseQuery::new(vec![...])` built from tokens produced by the same tokenizer the index uses. If the phrase tokenises to a single term, fall back to a `TermQuery` and document this in a comment.
+- Both methods return `FtsResult` in the same shape as `search` / `search_exact` so callers can reuse chunk-resolution code.
+- Errors from malformed regex must surface as `anyhow::Error` with a clear message — do **not** panic.
+
+Add unit tests in the same file (under `#[cfg(test)] mod tests`):
+
+- `search_regex` finds chunks matching a simple pattern on a fixture index.
+- `search_regex` with a malformed pattern returns `Err`, not panic.
+- `search_phrase` returns only hits where the words appear consecutively.
+- `search_phrase` with a single-word phrase degrades to term search without error.
+
+### `src/mcp/types.rs`
+
+Add:
+
+```rust
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LiteralSearchRequest {
+    /// The literal string, phrase, or regex pattern to search for.
+    pub query: String,
+
+    /// Treat `query` as a regex pattern (Rust-regex / Tantivy syntax). Default: false.
+    pub regex: Option<bool>,
+
+    /// Treat `query` as an exact phrase (words in order). Default: false.
+    /// If `query` is wrapped in double quotes, `phrase` is implied (the quotes are stripped).
+    pub phrase: Option<bool>,
+
+    /// Glob filter on result file path, e.g. "src/**/*.rs".
+    pub file_glob: Option<String>,
+
+    /// Language filter, e.g. "rust", "python". Post-filter on `Language::from_path`.
+    pub language: Option<String>,
+
+    /// Maximum number of results (default: 50).
+    pub limit: Option<usize>,
+
+    /// Output format: "json" (default) or "grep".
+    /// "grep" returns a single text block with `{path}:{line}: {snippet}` lines.
+    pub format: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LiteralSearchResultItem {
+    pub path: String,
+    pub line: usize,
+    pub snippet: String,
+    pub score: f32,
+}
+```
+
+### `src/mcp/mod.rs`
+
+Register a new tool:
+
+```rust
+#[tool(
+    description = "Exact string, phrase, or regex search over the indexed codebase. Tantivy FTS only — no embedding, no semantic reranking. Fast (~10-50ms).\n\nUSE FOR:\n- Error messages, TODO/FIXME tags, env var names, URLs, hardcoded strings\n- Regex patterns (set regex=true)\n- Exact phrases (wrap query in double quotes OR set phrase=true)\n- Narrowed scope via file_glob or language filter\n\nDO NOT USE FOR:\n- Conceptual / natural-language queries → use `semantic_search`\n- Finding usages of a symbol where you don't know the exact spelling → use `find_usages`\n\nReturns 0 results if the literal is not in any indexed file — in that case escalate to `semantic_search` for conceptual lookup.\nSet format=\"grep\" for `path:line:` output."
+)]
+async fn literal_search(
+    &self,
+    Parameters(request): Parameters<LiteralSearchRequest>,
+) -> Result<CallToolResult, McpError> { ... }
+```
+
+Handler logic:
+
+1. Call `ensure_database_exists()` early.
+2. Determine mode from flags:
+   - If `regex == Some(true)` → regex mode.
+   - Else if `phrase == Some(true)` → phrase mode.
+   - Else if query starts and ends with `"` and has length ≥ 3 → phrase mode, strip quotes.
+   - Else → exact mode (existing `search_exact` with `structural_intent = None`).
+3. Open `FtsStore`. Do **not** open the embedding service. Do **not** call `VectorStore::search` — this tool is FTS-only for retrieval. You may use `VectorStore::get_chunk` to resolve metadata for the snippet.
+4. Execute the chosen FTS method with `limit * 3` (raw budget for post-filtering).
+5. Resolve each `FtsResult.chunk_id` → chunk metadata via `get_chunk` (shared store if available; fall back to opening one). Use the existing pattern from `find_references`.
+6. Apply `language` post-filter: `Language::from_path(path) == requested_language` (case-insensitive).
+7. Apply `file_glob` post-filter using the `glob` crate if already a dep, otherwise a simple prefix/suffix matcher. **Do not add new dependencies in this branch** — if `glob` is not already present, ship v1 with prefix/suffix glob support only (`*`, `**` supported; full glob syntax deferred).
+8. Take `limit` results.
+9. For each result build `LiteralSearchResultItem { path, line: start_line, snippet, score }`. The snippet is the first line of the chunk content, truncated to 200 chars.
+10. Serialize:
+    - `format == "grep"` → single `Content::text` joining `format!("{}:{}: {}", path, line, snippet)` with `\n`.
+    - Otherwise → JSON array of `LiteralSearchResultItem`.
+
+## Acceptance criteria
+
+All of these must hold before PR merge:
+
+- `cargo test --all` passes.
+- `cargo clippy --all-targets -- -D warnings` passes.
+- Unit tests in `src/fts/tantivy_store.rs` (listed above) pass.
+- Integration test against a fixture index:
+  - `literal_search(query="TODO")` returns expected TODO hits in `< 100ms` on a warm index.
+  - `literal_search(query="handle_\\w+_request", regex=true)` returns regex matches.
+  - `literal_search(query="connection refused", phrase=true)` returns only phrase matches (not individual word hits).
+  - `literal_search(query="fn new", file_glob="src/mcp/**")` returns only hits whose path starts with `src/mcp/`.
+  - `literal_search(query="authenticate", format="grep")` returns a single text block where each line matches `^[^:]+:\d+: .+$`.
+- Trace assertion: the `literal_search` code path does not invoke `EmbeddingService`. Recommended approach: in a test, spy on `get_embedding_service` (or equivalent) and assert it is never called during a `literal_search` invocation.
+- Existing `test_mcp_no_raw_stdout_calls` still passes.
+- Tool appears in `get_info().instructions` routing table (add a row to the table that Branch A introduced).
+
+## Commit hygiene
+
+- Small commits, one logical change each.
+- Conventional-commit style (`feat(mcp): ...`, `feat(fts): ...`, `test(fts): ...`, `docs(mcp): ...`).
+- Author identity = Filip Develter personal GitHub (`flupkede`). Verify `git config user.email` before first commit.
+
+## PR expectations
+
+- Title: `feat(mcp): add literal_search tool with regex and phrase support`
+- Target base: `main` (after Branch A has merged).
+- Description should include:
+  - One-paragraph rationale.
+  - A short table of example queries and which mode each triggers.
+  - Link to this AGENTS file.
+  - Link to Branch A's PR for context.
+
+## Deliberately out of scope
+
+- True ripgrep-style boolean query syntax (`foo AND bar NOT baz`).
+- Indexing non-AST files (Markdown, YAML, configs). Agents may still fall back to `grep` for those — that's a known gap and will be addressed in a later branch.
+- Warm-start or preloading of the embedding model.
+- AST-based reference resolution (tree-sitter call-expression queries).
+- Query expansion for short ambiguous queries.
+- Changes to the `glob` dependency — keep v1 glob support minimal.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.205"
+version = "0.1.206"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.205"
+version = "0.1.206"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.206"
+version = "0.1.207"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.203"
+version = "0.1.204"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/fts/tantivy_store.rs
+++ b/src/fts/tantivy_store.rs
@@ -522,6 +522,99 @@ impl FtsStore {
         Ok(results)
     }
 
+    /// Search using a regex pattern against the content field.
+    ///
+    /// Uses Tantivy's `RegexQuery` for efficient regex matching on the indexed content.
+    /// The pattern syntax follows the `regex` crate conventions.
+    pub fn search_regex(&self, pattern: &str, limit: usize) -> Result<Vec<FtsResult>> {
+        use tantivy::query::RegexQuery;
+
+        let searcher = self.reader.searcher();
+
+        let query = RegexQuery::from_pattern(pattern, self.content_field)
+            .map_err(|e| anyhow!("Invalid regex pattern '{}': {}", pattern, e))?;
+
+        let top_docs = searcher.search(&query, &TopDocs::with_limit(limit))?;
+
+        let mut results = Vec::with_capacity(top_docs.len());
+        for (score, doc_address) in top_docs {
+            let doc: TantivyDocument = searcher.doc(doc_address)?;
+            if let Some(chunk_id) = doc.get_first(self.chunk_id_field) {
+                if let Some(id) = chunk_id.as_u64() {
+                    results.push(FtsResult {
+                        chunk_id: id as u32,
+                        score,
+                    });
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Search using a phrase query against the content field.
+    ///
+    /// Tokenizes the phrase using the same analyzer as the indexed content field,
+    /// then builds a `PhraseQuery` requiring terms to appear in sequence.
+    /// If the phrase tokenizes to a single term, falls back to `TermQuery`
+    /// (avoids unnecessary position tracking overhead for single-word queries).
+    pub fn search_phrase(&self, phrase: &str, limit: usize) -> Result<Vec<FtsResult>> {
+        use tantivy::query::{PhraseQuery, TermQuery};
+        use tantivy::schema::IndexRecordOption;
+
+        let searcher = self.reader.searcher();
+
+        // Tokenize the phrase using the same analyzer as the indexed content.
+        // The content field uses TEXT which applies the default tokenizer
+        // (lowercase + split on non-alphanumeric).
+        let terms: Vec<Term> = {
+            let mut analyzer = self
+                .index
+                .tokenizer_for_field(self.content_field)
+                .map_err(|e| anyhow!("Failed to get tokenizer for content field: {}", e))?;
+            let mut stream = analyzer.token_stream(phrase);
+            let mut collected = Vec::new();
+            while stream.advance() {
+                let token = stream.token();
+                collected.push(Term::from_field_text(self.content_field, &token.text));
+            }
+            collected
+        };
+
+        if terms.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // If the phrase tokenizes to a single term, fall back to TermQuery.
+        // PhraseQuery requires at least 2 terms; using TermQuery for single terms
+        // avoids unnecessary position tracking overhead.
+        let query: Box<dyn tantivy::query::Query> = if terms.len() == 1 {
+            Box::new(TermQuery::new(
+                terms.into_iter().next().unwrap(),
+                IndexRecordOption::WithFreqs,
+            ))
+        } else {
+            Box::new(PhraseQuery::new(terms))
+        };
+
+        let top_docs = searcher.search(&query, &TopDocs::with_limit(limit))?;
+
+        let mut results = Vec::with_capacity(top_docs.len());
+        for (score, doc_address) in top_docs {
+            let doc: TantivyDocument = searcher.doc(doc_address)?;
+            if let Some(chunk_id) = doc.get_first(self.chunk_id_field) {
+                if let Some(id) = chunk_id.as_u64() {
+                    results.push(FtsResult {
+                        chunk_id: id as u32,
+                        score,
+                    });
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Get statistics about the index
     pub fn stats(&self) -> Result<FtsStats> {
         let searcher = self.reader.searcher();
@@ -630,6 +723,120 @@ mod tests {
         let results = store.search("test content", 10, None)?;
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].chunk_id, 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_fts_search_regex() -> Result<()> {
+        let dir = tempdir()?;
+        let db_path = dir.path().to_path_buf();
+
+        let mut store = FtsStore::new(&db_path)?;
+
+        store.add_chunk(
+            1,
+            "fn hello_world() { println!(\"Hello!\"); }",
+            "src/main.rs",
+            Some("hello_world"),
+            "function",
+        )?;
+        store.add_chunk(
+            2,
+            "fn handle_request(req: Request) -> Response",
+            "src/handler.rs",
+            Some("handle_request"),
+            "function",
+        )?;
+        store.add_chunk(
+            3,
+            "struct UserConfig { name: String, age: u32 }",
+            "src/config.rs",
+            Some("UserConfig"),
+            "struct",
+        )?;
+        store.commit()?;
+
+        // Note: Tantivy's SimpleTokenizer splits on non-alphanumeric chars (including _),
+        // and lowercases. The content field uses TEXT which applies this tokenizer.
+        // Tokens for chunk 1: ["fn", "hello", "world", "println", "hello"]
+        // Tokens for chunk 2: ["fn", "handle", "request", "req", "request", "response"]
+        // Tokens for chunk 3: ["struct", "userconfig", "name", "string", "age", "u32"]
+
+        // Regex: match the token "hello"
+        let results = store.search_regex("hello", 10)?;
+        assert!(!results.is_empty(), "Expected results for 'hello'");
+        assert!(results.iter().any(|r| r.chunk_id == 1));
+
+        // Regex: match any token starting with "handle"
+        let results = store.search_regex("handle.*", 10)?;
+        assert!(!results.is_empty(), "Expected results for 'handle.*'");
+        assert!(results.iter().any(|r| r.chunk_id == 2));
+
+        // Regex: match any token starting with "user"
+        // "UserConfig" → tokenized to "userconfig"
+        let results = store.search_regex("user.*", 10)?;
+        assert!(!results.is_empty(), "Expected results for 'user.*'");
+        assert!(results.iter().any(|r| r.chunk_id == 3));
+
+        // Regex with no match
+        let results = store.search_regex("nonexistent_xyz_abc", 10)?;
+        assert!(
+            results.is_empty(),
+            "Expected no results for nonexistent pattern"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_fts_search_phrase() -> Result<()> {
+        let dir = tempdir()?;
+        let db_path = dir.path().to_path_buf();
+
+        let mut store = FtsStore::new(&db_path)?;
+
+        store.add_chunk(
+            1,
+            "fn hello_world() { println!(\"Hello!\"); }",
+            "src/main.rs",
+            Some("hello_world"),
+            "function",
+        )?;
+        store.add_chunk(
+            2,
+            "pub async fn process_data(data: Vec<u8>) -> Result<()>",
+            "src/processor.rs",
+            Some("process_data"),
+            "function",
+        )?;
+        store.add_chunk(
+            3,
+            "let hello = world + 1;", // "hello" and "world" but NOT in sequence
+            "src/other.rs",
+            None,
+            "block",
+        )?;
+        store.commit()?;
+
+        // Phrase search: "hello world" should match chunk 1 (tokens in sequence)
+        let results = store.search_phrase("hello world", 10)?;
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| r.chunk_id == 1));
+
+        // Phrase search: "process data" should match chunk 2
+        let results = store.search_phrase("process data", 10)?;
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| r.chunk_id == 2));
+
+        // Single term phrase: should still work (falls back to TermQuery)
+        let results = store.search_phrase("hello_world", 10)?;
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| r.chunk_id == 1));
+
+        // Phrase with no match
+        let results = store.search_phrase("nonexistent phrase xyz", 10)?;
+        assert!(results.is_empty());
 
         Ok(())
     }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -73,6 +73,58 @@ mod tests {
             &project_root,
         ));
     }
+
+    #[test]
+    fn test_simple_glob_match_exact() {
+        assert!(super::simple_glob_match("src/main.rs", "src/main.rs"));
+        assert!(!super::simple_glob_match("src/main.rs", "src/other.rs"));
+    }
+
+    #[test]
+    fn test_simple_glob_match_double_star_prefix() {
+        // src/mcp/** matches any path starting with src/mcp/
+        assert!(super::simple_glob_match("src/mcp/**", "src/mcp/mod.rs"));
+        assert!(super::simple_glob_match("src/mcp/**", "src/mcp/types.rs"));
+        assert!(super::simple_glob_match(
+            "src/mcp/**",
+            "src/mcp/sub/deep.rs"
+        ));
+        assert!(!super::simple_glob_match("src/mcp/**", "src/other/mod.rs"));
+    }
+
+    #[test]
+    fn test_simple_glob_match_double_star_suffix() {
+        // **/*.rs matches any path ending with .rs
+        assert!(super::simple_glob_match("**/*.rs", "src/main.rs"));
+        assert!(super::simple_glob_match("**/*.rs", "deep/nested/file.rs"));
+        assert!(!super::simple_glob_match("**/*.rs", "src/main.ts"));
+    }
+
+    #[test]
+    fn test_simple_glob_match_double_star_both() {
+        // src/**/*.rs → starts with src/ and ends with .rs
+        assert!(super::simple_glob_match("src/**/*.rs", "src/main.rs"));
+        assert!(super::simple_glob_match("src/**/*.rs", "src/mcp/mod.rs"));
+        assert!(!super::simple_glob_match("src/**/*.rs", "tests/main.rs"));
+        assert!(!super::simple_glob_match("src/**/*.rs", "src/main.ts"));
+    }
+
+    #[test]
+    fn test_simple_glob_match_single_star() {
+        // *.rs matches any path ending with .rs
+        assert!(super::simple_glob_match("*.rs", "main.rs"));
+        assert!(!super::simple_glob_match("*.rs", "main.ts"));
+        // src/*.rs matches files directly in src/ ending with .rs
+        assert!(super::simple_glob_match("src/*.rs", "src/main.rs"));
+        assert!(!super::simple_glob_match("src/*.rs", "src/sub/main.rs"));
+    }
+
+    #[test]
+    fn test_simple_glob_match_backslash_normalization() {
+        // Backslashes should be normalized
+        assert!(super::simple_glob_match("src/mcp/**", r"src\mcp\mod.rs"));
+        assert!(super::simple_glob_match(r"src\mcp\**", "src/mcp/mod.rs"));
+    }
 }
 
 pub mod types;
@@ -122,6 +174,160 @@ impl std::fmt::Debug for CodesearchService {
             .field("has_shared_stores", &self.shared_stores.is_some())
             .finish()
     }
+}
+
+// === Simple Glob Matcher ===
+// v1: supports prefix/suffix patterns with `*` and `**` only.
+// Full glob syntax deferred to avoid adding new dependencies.
+
+/// Match a file path against a simple glob pattern.
+///
+/// Supported patterns:
+/// - `src/mcp/**` → any path starting with `src/mcp/`
+/// - `**/*.rs` → any path ending with `.rs`
+/// - `src/**/*.rs` → path starting with `src/` and ending with `.rs`
+/// - `*.rs` → any path ending with `.rs` (single `*` within a segment)
+/// - `foo.rs` → exact match
+fn simple_glob_match(pattern: &str, path: &str) -> bool {
+    let pattern = pattern.replace('\\', "/");
+    let path = path.replace('\\', "/");
+
+    if !pattern.contains('*') {
+        // Exact match
+        return path == pattern;
+    }
+
+    if pattern.contains("**") {
+        // Split on first ** only
+        let parts: Vec<&str> = pattern.splitn(2, "**").collect();
+        let prefix = parts[0];
+        // Strip leading / from suffix since ** already matches the separator
+        let suffix = parts
+            .get(1)
+            .map(|s| s.strip_prefix('/').unwrap_or(s))
+            .unwrap_or("");
+
+        let mut p = path.as_str();
+        if !prefix.is_empty() && !p.starts_with(prefix) {
+            return false;
+        }
+        if !prefix.is_empty() {
+            p = &p[prefix.len()..];
+        }
+        // Strip leading / from remaining path (since ** can match empty + /)
+        if p.starts_with('/') {
+            p = &p[1..];
+        }
+        if suffix.is_empty() {
+            return true;
+        }
+        // The suffix may contain single * — match against the tail of the path.
+        // After **, the suffix describes constraints on the end of the path.
+        // For `**/*.rs`, the `*.rs` should match the last segment.
+        if suffix.contains('*') {
+            // Match suffix against the end of the path using segment-aware logic
+            return match_suffix_with_star(suffix, p);
+        }
+        p.ends_with(suffix)
+    } else {
+        // Pure single-star pattern (no **)
+        simple_glob_match_single_star(&pattern, &path)
+    }
+}
+
+/// Match a suffix pattern (containing `*`) against the end of a path.
+/// The `*` matches within a single segment only.
+///
+/// E.g., suffix `*.rs` matches `src/main.rs` because the last segment `main.rs` ends with `.rs`.
+fn match_suffix_with_star(suffix: &str, path: &str) -> bool {
+    // Find the segments in the suffix (split by /)
+    let suffix_parts: Vec<&str> = suffix.split('/').collect();
+    let path_segments: Vec<&str> = path.split('/').collect();
+
+    // The suffix must match the last N segments of the path
+    if suffix_parts.len() > path_segments.len() {
+        return false;
+    }
+
+    let path_tail = &path_segments[path_segments.len() - suffix_parts.len()..];
+
+    for (sp, pp) in suffix_parts.iter().zip(path_tail.iter()) {
+        if sp.contains('*') {
+            if !single_segment_match(sp, pp) {
+                return false;
+            }
+        } else if *sp != *pp {
+            return false;
+        }
+    }
+    true
+}
+
+/// Match a single segment pattern against a single segment path part.
+/// `*` matches any characters within the segment.
+fn single_segment_match(pattern: &str, segment: &str) -> bool {
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut s = segment;
+
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            if !s.starts_with(part) {
+                return false;
+            }
+            s = &s[part.len()..];
+        } else if i == parts.len() - 1 {
+            if !s.ends_with(part) {
+                return false;
+            }
+        } else if let Some(pos) = s.find(part) {
+            s = &s[pos + part.len()..];
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+/// Match a single-star glob pattern where `*` matches any characters except `/`.
+fn simple_glob_match_single_star(pattern: &str, path: &str) -> bool {
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut p = path;
+
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            // First part must be a prefix
+            if !p.starts_with(part) {
+                return false;
+            }
+            p = &p[part.len()..];
+        } else if i == parts.len() - 1 {
+            // Last part must be a suffix of the CURRENT segment (after *)
+            // * does not cross /, so find the end of the current segment
+            let seg_end = p.find('/').unwrap_or(p.len());
+            let segment = &p[..seg_end];
+            if !segment.ends_with(part) {
+                return false;
+            }
+        } else {
+            // Middle parts: find within remaining path but NOT across /
+            if let Some(pos) = p.find(part) {
+                let before = &p[..pos];
+                if before.contains('/') {
+                    return false;
+                }
+                p = &p[pos + part.len()..];
+            } else {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 // === Tool Router Implementation ===
@@ -564,6 +770,195 @@ impl CodesearchService {
     }
 
     #[tool(
+        description = "Search code using literal/FTS matching without embeddings. Three modes: exact (default), regex (set regex=true), phrase (set phrase=true). Supports file_glob and language post-filters. Use this when you need fast exact text search, pattern matching, or phrase search. Does NOT require an embedding model."
+    )]
+    async fn literal_search(
+        &self,
+        Parameters(request): Parameters<LiteralSearchRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let limit = request.limit.unwrap_or(20);
+        let output_format = request.format.as_deref().unwrap_or("json");
+
+        tracing::debug!(
+            "MCP literal_search: query='{}', regex={:?}, phrase={:?}, limit={}, file_glob={:?}, language={:?}, format={}",
+            request.query,
+            request.regex,
+            request.phrase,
+            limit,
+            request.file_glob,
+            request.language,
+            output_format
+        );
+
+        // Ensure database exists
+        if let Err(e) = self.ensure_database_exists() {
+            return Ok(CallToolResult::success(vec![Content::text(e)]));
+        }
+
+        // Open FTS store only — no embedding service needed
+        let fts_store = match FtsStore::new(&self.db_path) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Error opening FTS store: {}. Try re-indexing with 'codesearch index --force'.",
+                    e
+                ))]));
+            }
+        };
+
+        // Determine search mode and execute
+        let fts_results = if request.regex.unwrap_or(false) {
+            match fts_store.search_regex(&request.query, limit * 3) {
+                Ok(r) => r,
+                Err(e) => {
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Error in regex search: {}",
+                        e
+                    ))]));
+                }
+            }
+        } else if request.phrase.unwrap_or(false) {
+            match fts_store.search_phrase(&request.query, limit * 3) {
+                Ok(r) => r,
+                Err(e) => {
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Error in phrase search: {}",
+                        e
+                    ))]));
+                }
+            }
+        } else {
+            // Default: BM25 exact term search
+            match fts_store.search(&request.query, limit * 3, None) {
+                Ok(r) => r,
+                Err(e) => {
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Error in search: {}",
+                        e
+                    ))]));
+                }
+            }
+        };
+
+        if fts_results.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "No results found for '{}'. Try a different query or mode.",
+                request.query
+            ))]));
+        }
+
+        // Resolve chunk metadata and apply post-filters
+        let items: Vec<LiteralSearchResultItem> = if let Some(ref stores) = self.shared_stores {
+            let store = stores.vector_store.read().await;
+            fts_results
+                .iter()
+                .filter_map(|fts_result| {
+                    let chunk = store.get_chunk(fts_result.chunk_id).ok()??;
+                    Some((chunk, fts_result.score))
+                })
+                .filter(|(chunk, _)| {
+                    // Language post-filter
+                    if let Some(ref lang) = request.language {
+                        let file_lang = Language::from_path(std::path::Path::new(&chunk.path));
+                        if file_lang.name() != lang {
+                            return false;
+                        }
+                    }
+                    // file_glob post-filter
+                    if let Some(ref glob) = request.file_glob {
+                        if !simple_glob_match(glob, &chunk.path) {
+                            return false;
+                        }
+                    }
+                    true
+                })
+                .take(limit)
+                .map(|(chunk, score)| LiteralSearchResultItem {
+                    path: chunk.path,
+                    start_line: chunk.start_line,
+                    end_line: chunk.end_line,
+                    snippet: chunk.content,
+                    score,
+                    kind: if chunk.kind.is_empty() {
+                        None
+                    } else {
+                        Some(chunk.kind)
+                    },
+                    signature: chunk.signature.filter(|s| !s.is_empty()),
+                })
+                .collect()
+        } else {
+            // Standalone mode — open a new VectorStore
+            let store = match VectorStore::new(&self.db_path, self.dimensions) {
+                Ok(s) => s,
+                Err(e) => {
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Error opening database: {}",
+                        e
+                    ))]));
+                }
+            };
+            fts_results
+                .iter()
+                .filter_map(|fts_result| {
+                    let chunk = store.get_chunk(fts_result.chunk_id).ok()??;
+                    Some((chunk, fts_result.score))
+                })
+                .filter(|(chunk, _)| {
+                    // Language post-filter
+                    if let Some(ref lang) = request.language {
+                        let file_lang = Language::from_path(std::path::Path::new(&chunk.path));
+                        if file_lang.name() != lang {
+                            return false;
+                        }
+                    }
+                    // file_glob post-filter
+                    if let Some(ref glob) = request.file_glob {
+                        if !simple_glob_match(glob, &chunk.path) {
+                            return false;
+                        }
+                    }
+                    true
+                })
+                .take(limit)
+                .map(|(chunk, score)| LiteralSearchResultItem {
+                    path: chunk.path,
+                    start_line: chunk.start_line,
+                    end_line: chunk.end_line,
+                    snippet: chunk.content,
+                    score,
+                    kind: if chunk.kind.is_empty() {
+                        None
+                    } else {
+                        Some(chunk.kind)
+                    },
+                    signature: chunk.signature.filter(|s| !s.is_empty()),
+                })
+                .collect()
+        };
+
+        if items.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "No results found for '{}' after applying filters.",
+                request.query
+            ))]));
+        }
+
+        // Format output
+        let output = if output_format == "grep" {
+            items
+                .iter()
+                .map(|item| format!("{}:{}:{}", item.path, item.start_line, item.snippet))
+                .collect::<Vec<_>>()
+                .join("\n")
+        } else {
+            serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
+        };
+
+        Ok(CallToolResult::success(vec![Content::text(output)]))
+    }
+
+    #[tool(
         description = "Get the status of the semantic search index including model info and statistics. Check this before searching to verify the index is ready."
     )]
     async fn index_status(&self) -> Result<CallToolResult, McpError> {
@@ -826,15 +1221,25 @@ AVAILABLE TOOLS:
      - "functions that process payment data"
    Returns: Array of matches with metadata. Use read tool to fetch actual code.
 
-4. find_references(symbol, limit=50)
-   Find all usages/call sites of a function, method, class, or type across the codebase.
-   ⚠️  USE THIS instead of grep when you need to find where a symbol is used.
-   Essential for refactoring — shows all locations that need to change.
-   Examples:
-     - find_references("authenticate") - Find all calls to authenticate()
-     - find_references("UserService") - Find all usages of UserService
-     - find_references("handleRequest") - Find all call sites
-   Returns: Compact list of file paths, line numbers, kind, and score.
+ 4. find_references(symbol, limit=50)
+    Find all usages/call sites of a function, method, class, or type across the codebase.
+    ⚠️  USE THIS instead of grep when you need to find where a symbol is used.
+    Essential for refactoring — shows all locations that need to change.
+    Examples:
+      - find_references("authenticate") - Find all calls to authenticate()
+      - find_references("UserService") - Find all usages of UserService
+      - find_references("handleRequest") - Find all call sites
+    Returns: Compact list of file paths, line numbers, kind, and score.
+
+ 5. literal_search(query, regex=false, phrase=false, limit=20, file_glob=null, language=null, format="json")
+    Fast FTS-only search without embeddings. Three mutually exclusive modes:
+    - Default: exact term search (BM25 scoring)
+    - regex=true: regex pattern matching (e.g., "fn \\w+_handler")
+    - phrase=true: phrase query — tokens must appear in sequence (e.g., "fn new")
+    Post-filters: file_glob (e.g., "src/mcp/**") and language (e.g., "Rust").
+    Output: "json" (structured) or "grep" (file:line:snippet).
+    Use when you need fast exact text search without semantic understanding.
+    Returns: Array of matches with path, line numbers, snippet, and score.
 
 TOKEN-EFFICIENT WORKFLOW (IMPORTANT):
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1305,6 +1305,11 @@ impl CodesearchService {
         // Resolve chunk metadata and apply post-filters using shared store helper
         let lang_filter = request.language.clone();
         let glob_filter = request.file_glob.clone();
+        // Pre-compute normalized project root for stripping absolute paths in glob matching
+        let project_root_normalized = {
+            let root = crate::cache::normalize_path_str(self.project_path.to_str().unwrap_or(""));
+            root.trim_end_matches('/').to_string()
+        };
         let items: Vec<LiteralSearchResultItem> = match self
             .with_vector_store_read(|store| {
                 let items: Vec<LiteralSearchResultItem> = fts_results
@@ -1321,9 +1326,14 @@ impl CodesearchService {
                                 return false;
                             }
                         }
-                        // file_glob post-filter
+                        // file_glob post-filter (strip project root to get relative path)
                         if let Some(ref glob) = glob_filter {
-                            if !simple_glob_match(glob, &chunk.path) {
+                            let relative_path = chunk
+                                .path
+                                .strip_prefix(&project_root_normalized)
+                                .unwrap_or(&chunk.path)
+                                .trim_start_matches('/');
+                            if !simple_glob_match(glob, relative_path) {
                                 return false;
                             }
                         }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -303,6 +303,515 @@ mod tests {
         assert!(super::simple_glob_match("src/mcp/**", r"src\mcp\mod.rs"));
         assert!(super::simple_glob_match(r"src\mcp\**", "src/mcp/mod.rs"));
     }
+
+    // === merge_exact_into_fts tests ===
+
+    #[test]
+    fn test_merge_exact_empty_base() {
+        let mut fts: Vec<crate::fts::FtsResult> = vec![];
+        let exact = vec![
+            crate::fts::FtsResult {
+                chunk_id: 1,
+                score: 0.5,
+            },
+            crate::fts::FtsResult {
+                chunk_id: 2,
+                score: 0.3,
+            },
+        ];
+        super::merge_exact_into_fts(&mut fts, exact);
+        assert_eq!(fts.len(), 2);
+        assert_eq!(fts[0].chunk_id, 1);
+        assert_eq!(fts[1].chunk_id, 2);
+    }
+
+    #[test]
+    fn test_merge_exact_dedupe_keeps_max_score() {
+        let mut fts = vec![
+            crate::fts::FtsResult {
+                chunk_id: 1,
+                score: 0.8,
+            },
+            crate::fts::FtsResult {
+                chunk_id: 2,
+                score: 0.3,
+            },
+        ];
+        let exact = vec![
+            crate::fts::FtsResult {
+                chunk_id: 1,
+                score: 0.5,
+            }, // lower score → keep 0.8
+            crate::fts::FtsResult {
+                chunk_id: 2,
+                score: 0.9,
+            }, // higher score → upgrade to 0.9
+        ];
+        super::merge_exact_into_fts(&mut fts, exact);
+        assert_eq!(fts.len(), 2);
+        assert!((fts[0].score - 0.8).abs() < 0.001);
+        assert!((fts[1].score - 0.9).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_merge_exact_adds_new_chunks() {
+        let mut fts = vec![crate::fts::FtsResult {
+            chunk_id: 1,
+            score: 0.5,
+        }];
+        let exact = vec![
+            crate::fts::FtsResult {
+                chunk_id: 2,
+                score: 0.7,
+            },
+            crate::fts::FtsResult {
+                chunk_id: 3,
+                score: 0.4,
+            },
+        ];
+        super::merge_exact_into_fts(&mut fts, exact);
+        assert_eq!(fts.len(), 3);
+        assert_eq!(fts[1].chunk_id, 2);
+        assert_eq!(fts[2].chunk_id, 3);
+    }
+
+    #[test]
+    fn test_merge_exact_empty_exact() {
+        let mut fts = vec![crate::fts::FtsResult {
+            chunk_id: 1,
+            score: 0.5,
+        }];
+        super::merge_exact_into_fts(&mut fts, vec![]);
+        assert_eq!(fts.len(), 1);
+    }
+
+    #[test]
+    fn test_merge_exact_multiple_hits_same_chunk() {
+        // Multiple exact results for the same chunk should still dedupe
+        let mut fts = vec![];
+        let exact = vec![
+            crate::fts::FtsResult {
+                chunk_id: 1,
+                score: 0.3,
+            },
+            crate::fts::FtsResult {
+                chunk_id: 1,
+                score: 0.7,
+            },
+        ];
+        super::merge_exact_into_fts(&mut fts, exact);
+        assert_eq!(fts.len(), 1);
+        // First is added (0.3), second dedupes and upgrades to 0.7
+        assert!((fts[0].score - 0.7).abs() < 0.001);
+    }
+
+    // === compute_low_confidence tests ===
+
+    #[test]
+    fn test_low_confidence_below_threshold_with_identifiers() {
+        let (lc, tool) = super::compute_low_confidence(Some(0.01), true);
+        assert_eq!(lc, Some(true));
+        assert_eq!(tool.as_deref(), Some("find_definition"));
+    }
+
+    #[test]
+    fn test_low_confidence_below_threshold_without_identifiers() {
+        let (lc, tool) = super::compute_low_confidence(Some(0.01), false);
+        assert_eq!(lc, Some(true));
+        assert_eq!(tool.as_deref(), Some("literal_search"));
+    }
+
+    #[test]
+    fn test_low_confidence_above_threshold() {
+        let (lc, tool) = super::compute_low_confidence(Some(0.5), true);
+        assert_eq!(lc, None);
+        assert_eq!(tool, None);
+    }
+
+    #[test]
+    fn test_low_confidence_exactly_at_threshold() {
+        // Exactly at threshold (0.02) should NOT be low confidence (< not <=)
+        let (lc, tool) =
+            super::compute_low_confidence(Some(super::LOW_CONFIDENCE_THRESHOLD), false);
+        assert_eq!(lc, None);
+        assert_eq!(tool, None);
+    }
+
+    #[test]
+    fn test_low_confidence_no_results() {
+        let (lc, tool) = super::compute_low_confidence(None, false);
+        assert_eq!(lc, Some(true));
+        assert_eq!(tool.as_deref(), Some("literal_search"));
+    }
+
+    #[test]
+    fn test_low_confidence_no_results_with_identifiers() {
+        let (lc, tool) = super::compute_low_confidence(None, true);
+        // Even with identifiers, no results → suggest literal_search
+        assert_eq!(lc, Some(true));
+        assert_eq!(tool.as_deref(), Some("literal_search"));
+    }
+
+    // === Extended is_definition_chunk tests ===
+
+    #[test]
+    fn test_is_definition_chunk_impl_block() {
+        // impl blocks should match
+        assert!(super::is_definition_chunk(
+            "Struct",
+            &Some("impl CodesearchService".to_string()),
+            "CodesearchService"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_const() {
+        assert!(super::is_definition_chunk(
+            "Function",
+            &Some("const MAX_SIZE".to_string()),
+            "MAX_SIZE"
+        ));
+        assert!(super::is_definition_chunk(
+            "Function",
+            &Some("static INSTANCE".to_string()),
+            "INSTANCE"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_type_alias() {
+        assert!(super::is_definition_chunk(
+            "TypeAlias",
+            &Some("type Result".to_string()),
+            "Result"
+        ));
+        assert!(super::is_definition_chunk(
+            "TypeAlias",
+            &Some("pub type Error".to_string()),
+            "Error"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_interface() {
+        assert!(super::is_definition_chunk(
+            "Interface",
+            &Some("interface Searchable".to_string()),
+            "Searchable"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_with_generics() {
+        // fn with generics — symbol is just the name before <
+        assert!(super::is_definition_chunk(
+            "Function",
+            &Some("fn parse<T>".to_string()),
+            "parse"
+        ));
+        assert!(super::is_definition_chunk(
+            "Struct",
+            &Some("struct HashMap<K, V>".to_string()),
+            "HashMap"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_with_colon() {
+        // trait with colon (Rust trait bounds)
+        assert!(super::is_definition_chunk(
+            "Trait",
+            &Some("trait AsRef<T>:".to_string()),
+            "AsRef"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_wrong_symbol() {
+        // Correct prefix but symbol name doesn't follow
+        assert!(!super::is_definition_chunk(
+            "Function",
+            &Some("fn authenticate".to_string()),
+            "authorize" // different symbol
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_symbol_as_prefix_of_other() {
+        // Symbol is a prefix of the actual name — should NOT match
+        assert!(!super::is_definition_chunk(
+            "Function",
+            &Some("fn authenticate_user".to_string()),
+            "authenticate" // missing boundary check
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_method() {
+        assert!(super::is_definition_chunk(
+            "Method",
+            &Some("fn search".to_string()),
+            "search"
+        ));
+        assert!(super::is_definition_chunk(
+            "Method",
+            &Some("pub async fn handle".to_string()),
+            "handle"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_all_kinds() {
+        // Verify all DEFINITION_KINDS are recognized
+        let test_cases = [
+            ("Function", "fn foo(", "foo"),
+            ("Class", "class Bar", "Bar"),
+            ("Method", "fn baz(", "baz"),
+            ("Struct", "struct Qux", "Qux"),
+            ("Trait", "trait Quux", "Quux"),
+            ("Enum", "enum Corge", "Corge"),
+            ("TypeAlias", "type Grault", "Grault"),
+            ("Interface", "interface Garply", "Garply"),
+        ];
+        for (kind, sig, symbol) in &test_cases {
+            assert!(
+                super::is_definition_chunk(kind, &Some(sig.to_string()), symbol),
+                "is_definition_chunk({kind}, {sig}, {symbol}) should be true"
+            );
+        }
+    }
+
+    // === Extended simple_glob_match tests ===
+
+    #[test]
+    fn test_glob_exact_match_no_star() {
+        assert!(super::simple_glob_match("src/main.rs", "src/main.rs"));
+        assert!(!super::simple_glob_match("src/main.rs", "src/other.rs"));
+        assert!(!super::simple_glob_match("src/main.rs", "src/main.rs.bak"));
+    }
+
+    #[test]
+    fn test_glob_double_star_prefix_empty() {
+        // ** at start matches any prefix
+        assert!(super::simple_glob_match("**/test.rs", "test.rs"));
+        assert!(super::simple_glob_match("**/test.rs", "src/test.rs"));
+        assert!(super::simple_glob_match("**/test.rs", "a/b/c/test.rs"));
+    }
+
+    #[test]
+    fn test_glob_double_star_suffix_empty() {
+        // ** at end matches any suffix
+        assert!(super::simple_glob_match("src/**", "src/"));
+        assert!(super::simple_glob_match("src/**", "src/foo"));
+        assert!(super::simple_glob_match("src/**", "src/a/b/c"));
+    }
+
+    #[test]
+    fn test_glob_both_double_stars() {
+        assert!(super::simple_glob_match("**/**", "anything"));
+        assert!(super::simple_glob_match("**/**", "a/b/c"));
+    }
+
+    #[test]
+    fn test_glob_nested_double_star() {
+        // src/**/*.rs — must have src/ prefix and .rs extension
+        assert!(super::simple_glob_match("src/**/*.rs", "src/lib.rs"));
+        assert!(super::simple_glob_match("src/**/*.rs", "src/mcp/mod.rs"));
+        assert!(super::simple_glob_match("src/**/*.rs", "src/a/b/c/d.rs"));
+        assert!(!super::simple_glob_match("src/**/*.rs", "test/lib.rs"));
+        assert!(!super::simple_glob_match("src/**/*.rs", "src/lib.ts"));
+    }
+
+    #[test]
+    fn test_glob_single_star_multiple() {
+        // Multiple single stars in pattern
+        assert!(super::simple_glob_match("test_*.rs", "test_foo.rs"));
+        assert!(!super::simple_glob_match("test_*.rs", "test_foo.ts"));
+    }
+
+    #[test]
+    fn test_glob_single_star_stays_in_segment() {
+        // * should NOT cross /
+        assert!(!super::simple_glob_match("*.rs", "src/main.rs"));
+        assert!(!super::simple_glob_match("src/*.rs", "src/sub/main.rs"));
+    }
+
+    #[test]
+    fn test_glob_empty_pattern() {
+        assert!(super::simple_glob_match("", ""));
+        assert!(!super::simple_glob_match("", "foo.rs"));
+    }
+
+    #[test]
+    fn test_glob_trailing_slash_in_prefix() {
+        // src/mcp/** with trailing slash in path
+        assert!(super::simple_glob_match("src/mcp/**", "src/mcp/mod.rs"));
+    }
+
+    #[test]
+    fn test_glob_double_star_middle() {
+        // Pattern: src/**/test.rs
+        assert!(super::simple_glob_match("src/**/test.rs", "src/test.rs"));
+        assert!(super::simple_glob_match("src/**/test.rs", "src/a/test.rs"));
+        assert!(super::simple_glob_match(
+            "src/**/test.rs",
+            "src/a/b/c/test.rs"
+        ));
+        assert!(!super::simple_glob_match(
+            "src/**/test.rs",
+            "src/a/other.rs"
+        ));
+    }
+
+    // === Serde roundtrip tests for new types ===
+
+    #[test]
+    fn test_literal_search_request_serde_roundtrip() {
+        let json = r#"{"query":"fn authenticate","regex":true,"limit":5,"file_glob":"src/**/*.rs","language":"Rust","format":"grep"}"#;
+        let req: super::LiteralSearchRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.query, "fn authenticate");
+        assert_eq!(req.regex, Some(true));
+        assert_eq!(req.phrase, None);
+        assert_eq!(req.limit, Some(5));
+        assert_eq!(req.file_glob.as_deref(), Some("src/**/*.rs"));
+        assert_eq!(req.language.as_deref(), Some("Rust"));
+        assert_eq!(req.format.as_deref(), Some("grep"));
+    }
+
+    #[test]
+    fn test_literal_search_request_minimal() {
+        let json = r#"{"query":"hello"}"#;
+        let req: super::LiteralSearchRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.query, "hello");
+        assert_eq!(req.regex, None);
+        assert_eq!(req.phrase, None);
+        assert_eq!(req.limit, None);
+        assert_eq!(req.file_glob, None);
+        assert_eq!(req.language, None);
+        assert_eq!(req.format, None);
+    }
+
+    #[test]
+    fn test_literal_search_request_phrase_mode() {
+        let json = r#"{"query":"fn new","phrase":true}"#;
+        let req: super::LiteralSearchRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.phrase, Some(true));
+        assert_eq!(req.regex, None);
+    }
+
+    #[test]
+    fn test_find_definition_request_serde() {
+        let json = r#"{"symbol":"authenticate","kind":"Function","limit":10}"#;
+        let req: super::FindDefinitionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.symbol, "authenticate");
+        assert_eq!(req.kind.as_deref(), Some("Function"));
+        assert_eq!(req.limit, Some(10));
+    }
+
+    #[test]
+    fn test_find_definition_request_minimal() {
+        let json = r#"{"symbol":"User"}"#;
+        let req: super::FindDefinitionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.symbol, "User");
+        assert_eq!(req.kind, None);
+        assert_eq!(req.limit, None);
+    }
+
+    #[test]
+    fn test_find_usages_request_serde() {
+        let json = r#"{"symbol":"authenticate","limit":50}"#;
+        let req: super::FindUsagesRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.symbol, "authenticate");
+        assert_eq!(req.limit, Some(50));
+    }
+
+    #[test]
+    fn test_find_usages_request_minimal() {
+        let json = r#"{"symbol":"Config"}"#;
+        let req: super::FindUsagesRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.symbol, "Config");
+        assert_eq!(req.limit, None);
+    }
+
+    #[test]
+    fn test_semantic_search_request_mode_serde() {
+        let json = r#"{"query":"auth handler","mode":"lexical","limit":5}"#;
+        let req: super::SemanticSearchRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.mode.as_deref(), Some("lexical"));
+        assert_eq!(req.limit, Some(5));
+    }
+
+    // === LiteralSearchResultItem serialization tests ===
+
+    #[test]
+    fn test_literal_search_result_item_serialization() {
+        let item = super::LiteralSearchResultItem {
+            path: "src/main.rs".to_string(),
+            start_line: 10,
+            end_line: 20,
+            snippet: "fn main()".to_string(),
+            score: 0.95,
+            kind: Some("Function".to_string()),
+            signature: Some("fn main()".to_string()),
+        };
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(json.contains("\"kind\":\"Function\""));
+        assert!(json.contains("\"signature\":\"fn main()\""));
+    }
+
+    #[test]
+    fn test_literal_search_result_item_omits_none_fields() {
+        let item = super::LiteralSearchResultItem {
+            path: "src/main.rs".to_string(),
+            start_line: 10,
+            end_line: 20,
+            snippet: "code".to_string(),
+            score: 0.5,
+            kind: None,
+            signature: None,
+        };
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(!json.contains("kind"));
+        assert!(!json.contains("signature"));
+    }
+
+    // === SemanticSearchResponse serialization tests ===
+
+    #[test]
+    fn test_semantic_search_response_with_results() {
+        let response = super::SemanticSearchResponse {
+            results: vec![super::SearchResultItem {
+                path: "test.rs".to_string(),
+                start_line: 1,
+                end_line: 10,
+                kind: "Function".to_string(),
+                score: 0.8,
+                signature: Some("fn test()".to_string()),
+                content: None,
+                context_prev: None,
+                context_next: None,
+            }],
+            low_confidence: None,
+            suggested_tool: None,
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\"results\""));
+        assert!(!json.contains("low_confidence"));
+        assert!(!json.contains("suggested_tool"));
+    }
+
+    #[test]
+    fn test_semantic_search_response_empty_with_low_confidence() {
+        let response = super::SemanticSearchResponse {
+            results: vec![],
+            low_confidence: Some(true),
+            suggested_tool: Some("find_definition".to_string()),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\"low_confidence\":true"));
+        assert!(json.contains("\"suggested_tool\":\"find_definition\""));
+        assert!(json.contains("\"results\":[]"));
+    }
 }
 
 pub mod types;
@@ -372,6 +881,52 @@ impl std::fmt::Debug for CodesearchService {
 
 // === Simple Glob Matcher ===
 // v1: supports prefix/suffix patterns with `*` and `**` only.
+/// Merge exact FTS results into the main result set, deduplicating by chunk_id
+/// and keeping the max score for duplicates.
+///
+/// This is the pure logic extracted from `semantic_search_lexical` for testability.
+fn merge_exact_into_fts(
+    fts_results: &mut Vec<crate::fts::FtsResult>,
+    exact: Vec<crate::fts::FtsResult>,
+) {
+    let mut positions: std::collections::HashMap<u32, usize> = fts_results
+        .iter()
+        .enumerate()
+        .map(|(idx, r)| (r.chunk_id, idx))
+        .collect();
+
+    for r in exact {
+        if let Some(&existing_idx) = positions.get(&r.chunk_id) {
+            fts_results[existing_idx].score = fts_results[existing_idx].score.max(r.score);
+        } else {
+            positions.insert(r.chunk_id, fts_results.len());
+            fts_results.push(r);
+        }
+    }
+}
+
+/// Compute low-confidence signaling based on the top result's score.
+///
+/// Returns `(low_confidence, suggested_tool)` where both are `None` when
+/// confidence is high (score >= threshold).
+fn compute_low_confidence(
+    top_score: Option<f32>,
+    has_identifiers: bool,
+) -> (Option<bool>, Option<String>) {
+    match top_score {
+        Some(score) if score < LOW_CONFIDENCE_THRESHOLD => {
+            let suggestion = if has_identifiers {
+                "find_definition"
+            } else {
+                "literal_search"
+            };
+            (Some(true), Some(suggestion.to_string()))
+        }
+        Some(_) => (None, None),
+        None => (Some(true), Some("literal_search".to_string())),
+    }
+}
+
 // Full glob syntax deferred to avoid adding new dependencies.
 
 /// Match a file path against a simple glob pattern.
@@ -890,12 +1445,6 @@ impl CodesearchService {
             .unwrap_or_default();
 
         // Also do exact search if identifiers detected
-        let mut exact_positions: std::collections::HashMap<u32, usize> = fts_results
-            .iter()
-            .enumerate()
-            .map(|(idx, result)| (result.chunk_id, idx))
-            .collect();
-
         for ident in identifiers {
             let exact = match self
                 .with_fts_store_read(|fts_store| {
@@ -906,14 +1455,7 @@ impl CodesearchService {
                 Ok(r) => r,
                 Err(_) => continue,
             };
-            for r in exact {
-                if let Some(existing_idx) = exact_positions.get(&r.chunk_id).copied() {
-                    fts_results[existing_idx].score = fts_results[existing_idx].score.max(r.score);
-                } else {
-                    exact_positions.insert(r.chunk_id, fts_results.len());
-                    fts_results.push(r);
-                }
-            }
+            merge_exact_into_fts(&mut fts_results, exact);
         }
 
         fts_results.sort_by(|a, b| {
@@ -988,20 +1530,7 @@ impl CodesearchService {
 
         // Check low-confidence: top result's RRF score below threshold
         let top_score = items.first().map(|r| r.score);
-        let (low_confidence, suggested_tool) = if let Some(score) = top_score {
-            if score < LOW_CONFIDENCE_THRESHOLD {
-                let suggestion = if has_identifiers {
-                    "find_definition"
-                } else {
-                    "literal_search"
-                };
-                (Some(true), Some(suggestion.to_string()))
-            } else {
-                (None, None)
-            }
-        } else {
-            (Some(true), Some("literal_search".to_string()))
-        };
+        let (low_confidence, suggested_tool) = compute_low_confidence(top_score, has_identifiers);
 
         let response = SemanticSearchResponse {
             results: items,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -73,11 +73,193 @@ mod tests {
             &project_root,
         ));
     }
+
+    // === is_definition_chunk tests ===
+
+    #[test]
+    fn test_is_definition_chunk_rust_function() {
+        assert!(super::is_definition_chunk(
+            "Function",
+            &Some("fn authenticate(".to_string()),
+            "authenticate"
+        ));
+        assert!(super::is_definition_chunk(
+            "Function",
+            &Some("pub fn CodesearchService".to_string()),
+            "CodesearchService"
+        ));
+        assert!(super::is_definition_chunk(
+            "Function",
+            &Some("pub async fn handle_request".to_string()),
+            "handle_request"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_rust_struct() {
+        assert!(super::is_definition_chunk(
+            "Struct",
+            &Some("pub struct CodesearchService".to_string()),
+            "CodesearchService"
+        ));
+        assert!(super::is_definition_chunk(
+            "Struct",
+            &Some("struct SearchResult".to_string()),
+            "SearchResult"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_rust_trait() {
+        assert!(super::is_definition_chunk(
+            "Trait",
+            &Some("pub trait Searchable".to_string()),
+            "Searchable"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_rust_enum() {
+        assert!(super::is_definition_chunk(
+            "Enum",
+            &Some("pub enum ModelType".to_string()),
+            "ModelType"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_non_definition_kind() {
+        // A Comment or Import kind should never be treated as a definition
+        assert!(!super::is_definition_chunk(
+            "Comment",
+            &Some("fn authenticate(".to_string()),
+            "authenticate"
+        ));
+        assert!(!super::is_definition_chunk(
+            "Import",
+            &Some("use authenticate".to_string()),
+            "authenticate"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_usage_not_definition() {
+        // A function chunk where the signature mentions the symbol but isn't its definition
+        // should NOT be filtered out
+        assert!(!super::is_definition_chunk(
+            "Function",
+            &Some("fn handle_request".to_string()),
+            "authenticate"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_no_signature() {
+        // No signature = can't determine if it's a definition
+        assert!(!super::is_definition_chunk(
+            "Function",
+            &None,
+            "authenticate"
+        ));
+        assert!(!super::is_definition_chunk(
+            "Function",
+            &Some(String::new()),
+            "authenticate"
+        ));
+    }
+
+    #[test]
+    fn test_is_definition_chunk_python() {
+        assert!(super::is_definition_chunk(
+            "Function",
+            &Some("def authenticate(".to_string()),
+            "authenticate"
+        ));
+        assert!(super::is_definition_chunk(
+            "Class",
+            &Some("class UserService".to_string()),
+            "UserService"
+        ));
+    }
+
+    // === SemanticSearchResponse low-confidence tests ===
+
+    #[test]
+    fn test_low_confidence_response_serialization() {
+        let response = super::SemanticSearchResponse {
+            results: vec![],
+            low_confidence: Some(true),
+            suggested_tool: Some("literal_search".to_string()),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\"low_confidence\":true"));
+        assert!(json.contains("\"suggested_tool\":\"literal_search\""));
+    }
+
+    #[test]
+    fn test_normal_response_omits_confidence_fields() {
+        let response = super::SemanticSearchResponse {
+            results: vec![super::SearchResultItem {
+                path: "test.rs".to_string(),
+                start_line: 1,
+                end_line: 10,
+                kind: "Function".to_string(),
+                score: 0.5,
+                signature: Some("fn test()".to_string()),
+                content: None,
+                context_prev: None,
+                context_next: None,
+            }],
+            low_confidence: None,
+            suggested_tool: None,
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(!json.contains("low_confidence"));
+        assert!(!json.contains("suggested_tool"));
+    }
+
+    // === Instructions length test ===
+
+    #[test]
+    fn test_instructions_max_50_lines() {
+        // Verify that get_info().instructions string is ≤ 50 lines.
+        // This is a compile-time check via include_str to catch regressions.
+        let src = include_str!("mod.rs");
+        // Extract the instructions string content between the raw string delimiters
+        // The instructions are in get_info() method — we can count lines in the
+        // formatted template. Since we can't easily instantiate the service here,
+        // we check the raw string literal line count.
+        //
+        // Look for the compact routing table format — it should be well under 50 lines.
+        // We verify by checking the instructions block has no more than 50 newlines.
+        let instructions_start = src.find("codesearch — semantic + lexical");
+        assert!(
+            instructions_start.is_some(),
+            "Could not find instructions start marker in mod.rs"
+        );
+        let start = instructions_start.unwrap();
+        let remaining = &src[start..];
+        let instructions_end = remaining.find("\"#,");
+        assert!(
+            instructions_end.is_some(),
+            "Could not find instructions end marker in mod.rs"
+        );
+        let instructions_text = &remaining[..instructions_end.unwrap()];
+
+        let line_count = instructions_text.lines().count();
+        assert!(
+            line_count <= 50,
+            "Instructions block is {} lines, must be ≤ 50 lines.\n\
+             Content:\n{}",
+            line_count,
+            instructions_text
+        );
+    }
 }
 
 pub mod types;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rmcp::{
     handler::server::router::tool::ToolRouter,
     handler::server::wrapper::Parameters,
@@ -93,12 +275,29 @@ use crate::embed::{EmbeddingService, ModelType};
 use crate::file::Language;
 use crate::fts::FtsStore;
 use crate::index::{IndexManager, SharedStores};
-use crate::rerank::{rrf_fusion, rrf_fusion_with_exact, EXACT_MATCH_RRF_K};
+use crate::rerank::{rrf_fusion, rrf_fusion_with_exact, vector_only, EXACT_MATCH_RRF_K};
 use crate::search::{adapt_rrf_k, boost_kind, detect_identifiers, detect_structural_intent};
 use crate::vectordb::VectorStore;
 
 // Re-export types
 pub use types::*;
+
+/// RRF score threshold below which results are considered low-confidence.
+/// When the top result's RRF score falls below this, the response includes
+/// a `low_confidence` flag and a `suggested_tool` hint.
+const LOW_CONFIDENCE_THRESHOLD: f32 = 0.02;
+
+/// Chunk kinds that represent symbol definitions (not usages/comments/etc.)
+const DEFINITION_KINDS: &[&str] = &[
+    "Function",
+    "Class",
+    "Method",
+    "Struct",
+    "Trait",
+    "Enum",
+    "TypeAlias",
+    "Interface",
+];
 
 /// Codesearch MCP service
 pub struct CodesearchService {
@@ -213,8 +412,24 @@ impl CodesearchService {
         Ok(())
     }
 
+    /// Execute a read-only action against the vector store, using shared stores when available
+    /// and falling back to opening a standalone store otherwise.
+    async fn with_vector_store_read<R, F>(&self, mut action: F) -> Result<R>
+    where
+        F: FnMut(&VectorStore) -> anyhow::Result<R>,
+    {
+        if let Some(ref stores) = self.shared_stores {
+            let store = stores.vector_store.read().await;
+            action(&store).context("Error reading from shared vector store")
+        } else {
+            let store = VectorStore::new(&self.db_path, self.dimensions)
+                .context("Error opening database")?;
+            action(&store).context("Error reading from vector store")
+        }
+    }
+
     #[tool(
-        description = "Search code semantically using natural language. Returns compact metadata by default (path, line numbers, kind, signature, score). Use the read tool with the returned line numbers to view actual code. Set compact=false only when you need full content inline. Use filter_path to narrow results to a specific directory."
+        description = "Hybrid code search over tree-sitter AST chunks: vector embeddings + Tantivy FTS + exact-identifier boosting, fused with RRF.\n\nUSE FOR:\n- Conceptual queries (\"where is auth handled\", \"how do we log errors\")\n- Identifier lookups — function/class/variable names are boosted via exact-match FTS\n- Mixed natural-language + symbol queries\n\nDO NOT USE FOR:\n- Finding a symbol's definition specifically — use `find_definition`\n- Finding all call-sites of a symbol — use `find_usages`\n\nOPTIONAL `mode`: \"auto\" (default) | \"semantic\" | \"lexical\" | \"hybrid\".\nReturns metadata only by default (compact=true). Set compact=false for inline content."
     )]
     async fn semantic_search(
         &self,
@@ -222,12 +437,16 @@ impl CodesearchService {
     ) -> Result<CallToolResult, McpError> {
         let limit = request.limit.unwrap_or(10);
         let compact = request.compact.unwrap_or(true);
+        let mode = request.mode.as_deref().unwrap_or("auto");
+        let identifiers = detect_identifiers(&request.query);
+        let has_identifiers = !identifiers.is_empty();
 
         tracing::debug!(
-            "MCP semantic_search: query='{}', limit={}, compact={}",
+            "MCP semantic_search: query='{}', limit={}, compact={}, mode='{}'",
             request.query,
             limit,
-            compact
+            compact,
+            mode
         );
 
         // Ensure database exists
@@ -235,9 +454,15 @@ impl CodesearchService {
             return Ok(CallToolResult::success(vec![Content::text(e)]));
         }
 
-        // Get embedding service and embed query
-        // Note: We must drop the MutexGuard before any await points
-        tracing::debug!("MCP: Getting embedding service...");
+        // === Mode: "lexical" — FTS only, no embedding ===
+        if mode == "lexical" {
+            tracing::debug!("MCP: mode=lexical — skipping embedding service");
+            return self
+                .semantic_search_lexical(&request, &identifiers, limit, compact)
+                .await;
+        }
+
+        // === Modes: "semantic", "hybrid", "auto" — require embedding ===
         let query_embedding = {
             let mut service_guard = match self.get_embedding_service() {
                 Ok(g) => g,
@@ -262,58 +487,49 @@ impl CodesearchService {
                     ))]));
                 }
             }
-            // service_guard is dropped here, before any await
         };
 
-        // Search using shared stores if available, otherwise open a new store
-        tracing::debug!(
-            "MCP: Searching with {} dimensions...",
-            query_embedding.len()
-        );
-        let vector_results = if let Some(ref stores) = self.shared_stores {
-            // Use shared store with read lock
-            let store = stores.vector_store.read().await;
-            match store.search(&query_embedding, limit * 3) {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::error!("MCP: Search failed (shared store): {:?}", e);
-                    return Ok(CallToolResult::success(vec![Content::text(format!(
-                        "Error searching: {}",
-                        e
-                    ))]));
-                }
-            }
-        } else {
-            // Fallback: open a new store (standalone mode)
-            tracing::debug!("MCP: Opening vector store (standalone mode)...");
-            let store = match VectorStore::new(&self.db_path, self.dimensions) {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::error!("MCP: Failed to open vector store: {:?}", e);
-                    return Ok(CallToolResult::success(vec![Content::text(format!(
-                        "Error opening database: {}. The database may be corrupted or not indexed yet.",
-                        e
-                    ))]));
-                }
-            };
-            match store.search(&query_embedding, limit * 3) {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::error!("MCP: Search failed: {:?}", e);
-                    return Ok(CallToolResult::success(vec![Content::text(format!(
-                        "Error searching: {}",
-                        e
-                    ))]));
-                }
+        // Search vector store
+        let vector_results = match self
+            .with_vector_store_read(|store| {
+                store
+                    .search(&query_embedding, limit * 3)
+                    .context("Error searching vector store")
+            })
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("MCP: Search failed: {:?}", e);
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Error searching vector store: {}",
+                    e
+                ))]));
             }
         };
 
         tracing::debug!("MCP: Found {} vector results", vector_results.len());
 
-        // --- Hybrid search with all improvements ---
+        // === Mode: "semantic" — vector only, skip FTS fusion ===
+        if mode == "semantic" {
+            tracing::debug!("MCP: mode=semantic — using vector results only");
+            let fused = vector_only(&vector_results);
 
-        // Detect identifiers and structural intent from query
-        let identifiers = detect_identifiers(&request.query);
+            let chunk_to_result: std::collections::HashMap<u32, &crate::vectordb::SearchResult> =
+                vector_results.iter().map(|r| (r.id, r)).collect();
+
+            let mut results: Vec<crate::vectordb::SearchResult> = Vec::new();
+            for f in fused.into_iter().take(limit) {
+                if let Some(result) = chunk_to_result.get(&f.chunk_id) {
+                    let mut r = (*result).clone();
+                    r.score = f.rrf_score;
+                    results.push(r);
+                }
+            }
+            return self.build_semantic_response(results, &request, compact, has_identifiers);
+        }
+
+        // === Modes: "hybrid" | "auto" — full hybrid search ===
         let structural_intent = detect_structural_intent(&request.query);
         let (vector_k, fts_k) = adapt_rrf_k(&request.query);
 
@@ -328,16 +544,13 @@ impl CodesearchService {
         // Perform FTS search and fusion
         let mut results = match FtsStore::new(&self.db_path) {
             Ok(fts_store) => {
-                // FTS search
                 let fts_results = fts_store
                     .search(&request.query, limit * 3, structural_intent)
                     .unwrap_or_default();
 
                 let fused = if identifiers.is_empty() {
-                    // No identifiers: standard RRF fusion
                     rrf_fusion(&vector_results, &fts_results, vector_k as f32)
                 } else {
-                    // Has identifiers: also do exact search per identifier
                     let mut all_exact: Vec<crate::fts::FtsResult> = Vec::new();
                     for ident in &identifiers {
                         if let Ok(exact) =
@@ -384,13 +597,12 @@ impl CodesearchService {
                 mapped
             }
             Err(e) => {
-                // FTS unavailable, fall back to vector-only results
                 tracing::warn!("MCP: FTS store unavailable, using vector-only: {:?}", e);
                 vector_results.into_iter().take(limit).collect()
             }
         };
 
-        // Apply language boost (improvement 2)
+        // Apply language boost
         if let Some((_, _, Some(primary_lang))) = crate::search::read_metadata(&self.db_path) {
             for result in &mut results {
                 let file_lang = format!(
@@ -408,20 +620,99 @@ impl CodesearchService {
             });
         }
 
-        // Apply kind boost (improvement 3)
+        // Apply kind boost
         if let Some(target_kind) = structural_intent {
             boost_kind(&mut results, target_kind);
         }
 
         tracing::debug!("MCP: Final {} results after hybrid search", results.len());
+        self.build_semantic_response(results, &request, compact, has_identifiers)
+    }
 
-        if results.is_empty() {
-            return Ok(CallToolResult::success(vec![Content::text(
-                "No results found for the query. Try rephrasing your query or using broader terms.",
-            )]));
+    // === Helper methods (not exposed as tools) ===
+
+    /// Lexical-only search: FTS without embedding service.
+    async fn semantic_search_lexical(
+        &self,
+        request: &SemanticSearchRequest,
+        identifiers: &[String],
+        limit: usize,
+        compact: bool,
+    ) -> Result<CallToolResult, McpError> {
+        let structural_intent = detect_structural_intent(&request.query);
+
+        let fts_store = match FtsStore::new(&self.db_path) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Error opening FTS store: {}",
+                    e
+                ))]));
+            }
+        };
+
+        let mut fts_results = fts_store
+            .search(&request.query, limit * 3, structural_intent)
+            .unwrap_or_default();
+
+        // Also do exact search if identifiers detected
+        let mut exact_positions: std::collections::HashMap<u32, usize> = fts_results
+            .iter()
+            .enumerate()
+            .map(|(idx, result)| (result.chunk_id, idx))
+            .collect();
+
+        for ident in identifiers {
+            if let Ok(exact) = fts_store.search_exact(ident, limit * 2, structural_intent) {
+                for r in exact {
+                    if let Some(existing_idx) = exact_positions.get(&r.chunk_id).copied() {
+                        fts_results[existing_idx].score =
+                            fts_results[existing_idx].score.max(r.score);
+                    } else {
+                        exact_positions.insert(r.chunk_id, fts_results.len());
+                        fts_results.push(r);
+                    }
+                }
+            }
         }
 
-        // Convert to response format, applying compact mode and filter_path
+        fts_results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        // Resolve FTS results to chunk metadata
+        let mut results = self
+            .resolve_fts_to_search_results(&fts_results, limit)
+            .await;
+
+        // Apply kind boost
+        if let Some(target_kind) = structural_intent {
+            boost_kind(&mut results, target_kind);
+        }
+
+        self.build_semantic_response(results, request, compact, !identifiers.is_empty())
+    }
+
+    /// Build the final SemanticSearchResponse with low-confidence signaling.
+    fn build_semantic_response(
+        &self,
+        results: Vec<crate::vectordb::SearchResult>,
+        request: &SemanticSearchRequest,
+        compact: bool,
+        has_identifiers: bool,
+    ) -> Result<CallToolResult, McpError> {
+        if results.is_empty() {
+            let response = SemanticSearchResponse {
+                results: vec![],
+                low_confidence: Some(true),
+                suggested_tool: Some("literal_search".to_string()),
+            };
+            let json = serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string());
+            return Ok(CallToolResult::success(vec![Content::text(json)]));
+        }
+
         // Pre-compute normalized project root for stripping absolute paths
         let project_root_normalized = {
             let root = crate::cache::normalize_path_str(self.project_path.to_str().unwrap_or(""));
@@ -431,7 +722,6 @@ impl CodesearchService {
         let items: Vec<SearchResultItem> = results
             .into_iter()
             .filter(|r| {
-                // Apply filter_path if specified
                 if let Some(ref fp) = request.filter_path {
                     let normalized_filter = crate::cache::normalize_filter_path(fp);
                     crate::cache::path_matches_filter(
@@ -456,47 +746,105 @@ impl CodesearchService {
             })
             .collect();
 
-        let json = serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string());
+        // Check low-confidence: top result's RRF score below threshold
+        let top_score = items.first().map(|r| r.score);
+        let (low_confidence, suggested_tool) = if let Some(score) = top_score {
+            if score < LOW_CONFIDENCE_THRESHOLD {
+                let suggestion = if has_identifiers {
+                    "find_definition"
+                } else {
+                    "literal_search"
+                };
+                (Some(true), Some(suggestion.to_string()))
+            } else {
+                (None, None)
+            }
+        } else {
+            (Some(true), Some("literal_search".to_string()))
+        };
+
+        let response = SemanticSearchResponse {
+            results: items,
+            low_confidence,
+            suggested_tool,
+        };
+
+        let json = serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string());
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    #[tool(
-        description = "Find all references/usages of a symbol (function, class, method, variable) across the codebase. USE THIS INSTEAD OF GREP when you need to find where a symbol is used — for refactoring, impact analysis, or understanding call sites. Returns compact list of file paths, line numbers, and containing function signatures."
-    )]
-    async fn find_references(
+    /// Resolve FTS results to SearchResult by looking up chunk metadata.
+    async fn resolve_fts_to_search_results(
         &self,
-        Parameters(request): Parameters<FindReferencesRequest>,
+        fts_results: &[crate::fts::FtsResult],
+        limit: usize,
+    ) -> Vec<crate::vectordb::SearchResult> {
+        self.with_vector_store_read(|store| {
+            let mut results = Vec::new();
+            for fts in fts_results.iter().take(limit) {
+                if let Ok(Some(chunk)) = store.get_chunk(fts.chunk_id) {
+                    results.push(crate::vectordb::SearchResult {
+                        id: fts.chunk_id,
+                        content: chunk.content,
+                        path: chunk.path,
+                        start_line: chunk.start_line,
+                        end_line: chunk.end_line,
+                        kind: chunk.kind,
+                        signature: chunk.signature,
+                        docstring: chunk.docstring,
+                        context: chunk.context,
+                        hash: chunk.hash,
+                        distance: 0.0,
+                        score: fts.score,
+                        context_prev: chunk.context_prev,
+                        context_next: chunk.context_next,
+                    });
+                }
+            }
+            Ok(results)
+        })
+        .await
+        .unwrap_or_default()
+    }
+
+    // === find_definition tool ===
+
+    #[tool(
+        description = "Locate the definition of a symbol (function, class, method, struct, trait, enum, type).\nUses FTS + chunk-kind filter to exclude usages, comments, and string literals.\n\nUSE FOR: \"where is X defined\", \"show me the declaration of X\".\nDO NOT USE FOR: finding all call-sites → use `find_usages`."
+    )]
+    async fn find_definition(
+        &self,
+        Parameters(request): Parameters<FindDefinitionRequest>,
     ) -> Result<CallToolResult, McpError> {
         let limit = request.limit.unwrap_or(20);
 
         tracing::debug!(
-            "MCP find_references: symbol='{}', limit={}",
+            "MCP find_definition: symbol='{}', kind={:?}, limit={}",
             request.symbol,
+            request.kind,
             limit
         );
 
-        // Ensure database exists
         if let Err(e) = self.ensure_database_exists() {
             return Ok(CallToolResult::success(vec![Content::text(e)]));
         }
 
-        // Open FTS store for full-text search on the symbol name
         let fts_store = match FtsStore::new(&self.db_path) {
             Ok(s) => s,
             Err(e) => {
                 return Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Error opening FTS store: {}. Try re-indexing with 'codesearch index --force'.",
+                    "Error opening FTS store: {}",
                     e
                 ))]));
             }
         };
 
-        // Search FTS for the symbol — returns chunk_id + score
-        let fts_results = match fts_store.search(&request.symbol, limit * 2, None) {
+        // Search with extra results — we'll filter down
+        let fts_results = match fts_store.search(&request.symbol, limit * 3, None) {
             Ok(r) => r,
             Err(e) => {
                 return Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Error searching for references: {}",
+                    "Error searching: {}",
                     e
                 ))]));
             }
@@ -504,63 +852,171 @@ impl CodesearchService {
 
         if fts_results.is_empty() {
             return Ok(CallToolResult::success(vec![Content::text(format!(
-                "No references found for '{}'. The symbol may not be indexed or try a different name.",
+                "No definition found for '{}'. The symbol may not be indexed.",
                 request.symbol
             ))]));
         }
 
-        // Resolve chunk metadata from VectorStore using chunk_ids
-        let items: Vec<ReferenceItem> = if let Some(ref stores) = self.shared_stores {
-            let store = stores.vector_store.read().await;
-            fts_results
-                .iter()
-                .filter_map(|fts_result| {
-                    if let Ok(Some(chunk)) = store.get_chunk(fts_result.chunk_id) {
-                        Some(ReferenceItem {
-                            path: chunk.path,
-                            line: chunk.start_line,
-                            kind: chunk.kind,
-                            signature: chunk.signature,
-                            score: fts_result.score,
-                        })
-                    } else {
-                        None
-                    }
-                })
-                .take(limit)
-                .collect()
-        } else {
-            // Standalone mode — open a new store
-            let store = match VectorStore::new(&self.db_path, self.dimensions) {
-                Ok(s) => s,
-                Err(e) => {
-                    return Ok(CallToolResult::success(vec![Content::text(format!(
-                        "Error opening database: {}",
-                        e
-                    ))]));
-                }
-            };
-            fts_results
-                .iter()
-                .filter_map(|fts_result| {
-                    if let Ok(Some(chunk)) = store.get_chunk(fts_result.chunk_id) {
-                        Some(ReferenceItem {
-                            path: chunk.path,
-                            line: chunk.start_line,
-                            kind: chunk.kind,
-                            signature: chunk.signature,
-                            score: fts_result.score,
-                        })
-                    } else {
-                        None
-                    }
-                })
-                .take(limit)
-                .collect()
+        // Resolve chunk metadata and filter by definition kinds
+        let items: Vec<ReferenceItem> = match self
+            .with_vector_store_read(|store| {
+                let items = fts_results
+                    .iter()
+                    .filter_map(|fts_result| {
+                        if let Ok(Some(chunk)) = store.get_chunk(fts_result.chunk_id) {
+                            if !DEFINITION_KINDS.contains(&chunk.kind.as_str()) {
+                                return None;
+                            }
+                            if let Some(ref requested_kind) = request.kind {
+                                if chunk.kind != *requested_kind {
+                                    return None;
+                                }
+                            }
+                            Some(ReferenceItem {
+                                path: chunk.path,
+                                line: chunk.start_line,
+                                kind: chunk.kind,
+                                signature: chunk.signature,
+                                score: fts_result.score,
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .take(limit)
+                    .collect();
+                Ok(items)
+            })
+            .await
+        {
+            Ok(items) => items,
+            Err(e) => {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Error opening database: {}",
+                    e
+                ))]));
+            }
         };
+
+        if items.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "No definition found for '{}'. Try find_usages() to find references, or broaden your search.",
+                request.symbol
+            ))]));
+        }
 
         let json = serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string());
         Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    // === find_usages tool ===
+
+    #[tool(
+        description = "Find call-sites and other usages of a symbol across the codebase.\nUses FTS; excludes the chunks that are the symbol's own definition.\n\nUSE FOR: impact analysis, refactoring, \"who calls X\".\nDO NOT USE FOR: finding the definition itself → use `find_definition`."
+    )]
+    async fn find_usages(
+        &self,
+        Parameters(request): Parameters<FindUsagesRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        self.find_usages_impl(request.symbol.clone(), request.limit.unwrap_or(20))
+            .await
+    }
+
+    /// Shared implementation for find_usages and the deprecated find_references alias.
+    async fn find_usages_impl(
+        &self,
+        symbol: String,
+        limit: usize,
+    ) -> Result<CallToolResult, McpError> {
+        tracing::debug!("MCP find_usages: symbol='{}', limit={}", symbol, limit);
+
+        if let Err(e) = self.ensure_database_exists() {
+            return Ok(CallToolResult::success(vec![Content::text(e)]));
+        }
+
+        let fts_store = match FtsStore::new(&self.db_path) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Error opening FTS store: {}",
+                    e
+                ))]));
+            }
+        };
+
+        let fts_results = match fts_store.search(&symbol, limit * 2, None) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Error searching: {}",
+                    e
+                ))]));
+            }
+        };
+
+        if fts_results.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "No usages found for '{}'. The symbol may not be indexed.",
+                symbol
+            ))]));
+        }
+
+        // Resolve chunks and exclude definition chunks
+        let items: Vec<ReferenceItem> = match self
+            .with_vector_store_read(|store| {
+                let items = fts_results
+                    .iter()
+                    .filter_map(|fts_result| {
+                        if let Ok(Some(chunk)) = store.get_chunk(fts_result.chunk_id) {
+                            if is_definition_chunk(&chunk.kind, &chunk.signature, &symbol) {
+                                return None;
+                            }
+                            Some(ReferenceItem {
+                                path: chunk.path,
+                                line: chunk.start_line,
+                                kind: chunk.kind,
+                                signature: chunk.signature,
+                                score: fts_result.score,
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .take(limit)
+                    .collect();
+                Ok(items)
+            })
+            .await
+        {
+            Ok(items) => items,
+            Err(e) => {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Error opening database: {}",
+                    e
+                ))]));
+            }
+        };
+
+        if items.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "No usages found for '{}' (only definitions were found). Try find_definition() to locate the declaration.",
+                symbol
+            ))]));
+        }
+
+        let json = serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(
+        description = "DEPRECATED. Use `find_definition` to locate a symbol's declaration, or `find_usages` to find call-sites.\nThis tool is retained as an alias for `find_usages` and may be removed in a future version."
+    )]
+    async fn find_references(
+        &self,
+        Parameters(request): Parameters<FindReferencesRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        self.find_usages_impl(request.symbol, request.limit.unwrap_or(20))
+            .await
     }
 
     #[tool(
@@ -587,74 +1043,27 @@ impl CodesearchService {
             return Ok(CallToolResult::success(vec![Content::text(json)]));
         }
 
-        // Get stats using shared stores if available
-        let stats = if let Some(ref stores) = self.shared_stores {
-            let store = stores.vector_store.read().await;
-            match store.stats() {
-                Ok(s) => s,
-                Err(e) => {
-                    let response = IndexStatusResponse {
-                        indexed: false,
-                        status: "error".to_string(),
-                        status_message: format!("Error getting index stats: {}", e),
-                        total_chunks: 0,
-                        total_files: 0,
-                        model: self.model_type.short_name().to_string(),
-                        dimensions: 0,
-                        max_chunk_id: 0,
-                        db_path: self.db_path.display().to_string(),
-                        project_path: self.project_path.display().to_string(),
-                        error_message: Some(format!("Error getting stats: {}", e)),
-                    };
-                    let json =
-                        serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string());
-                    return Ok(CallToolResult::success(vec![Content::text(json)]));
-                }
-            }
-        } else {
-            // Fallback: open a new store (standalone mode)
-            let store = match VectorStore::new(&self.db_path, self.dimensions) {
-                Ok(s) => s,
-                Err(e) => {
-                    let response = IndexStatusResponse {
-                        indexed: false,
-                        status: "error".to_string(),
-                        status_message: format!("Error opening database: {}", e),
-                        total_chunks: 0,
-                        total_files: 0,
-                        model: self.model_type.short_name().to_string(),
-                        dimensions: 0,
-                        max_chunk_id: 0,
-                        db_path: self.db_path.display().to_string(),
-                        project_path: self.project_path.display().to_string(),
-                        error_message: Some(format!("Error opening database: {}", e)),
-                    };
-                    let json =
-                        serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string());
-                    return Ok(CallToolResult::success(vec![Content::text(json)]));
-                }
-            };
-
-            match store.stats() {
-                Ok(s) => s,
-                Err(e) => {
-                    let response = IndexStatusResponse {
-                        indexed: false,
-                        status: "error".to_string(),
-                        status_message: format!("Error getting index stats: {}", e),
-                        total_chunks: 0,
-                        total_files: 0,
-                        model: self.model_type.short_name().to_string(),
-                        dimensions: 0,
-                        max_chunk_id: 0,
-                        db_path: self.db_path.display().to_string(),
-                        project_path: self.project_path.display().to_string(),
-                        error_message: Some(format!("Error getting stats: {}", e)),
-                    };
-                    let json =
-                        serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string());
-                    return Ok(CallToolResult::success(vec![Content::text(json)]));
-                }
+        let stats = match self
+            .with_vector_store_read(|store| store.stats().context("Error getting index stats"))
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                let response = IndexStatusResponse {
+                    indexed: false,
+                    status: "error".to_string(),
+                    status_message: format!("{}", e),
+                    total_chunks: 0,
+                    total_files: 0,
+                    model: self.model_type.short_name().to_string(),
+                    dimensions: 0,
+                    max_chunk_id: 0,
+                    db_path: self.db_path.display().to_string(),
+                    project_path: self.project_path.display().to_string(),
+                    error_message: Some(format!("{}", e)),
+                };
+                let json = serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string());
+                return Ok(CallToolResult::success(vec![Content::text(json)]));
             }
         };
 
@@ -779,10 +1188,67 @@ impl CodesearchService {
 
 // === Server Handler Implementation ===
 
+/// Check if a chunk is a definition of the given symbol.
+///
+/// Best-effort heuristic for v1: a chunk is considered a definition if:
+/// 1. Its kind is a definition kind (Function, Struct, Class, etc.)
+/// 2. Its signature starts with a common definition pattern containing the symbol name
+///
+/// Limitation: this uses simple substring matching on the signature field.
+/// False positives/negatives are possible for symbols that appear in signatures
+/// of chunks that are not their definitions.
+fn is_definition_chunk(kind: &str, signature: &Option<String>, symbol: &str) -> bool {
+    // Only check definition kinds
+    if !DEFINITION_KINDS.contains(&kind) {
+        return false;
+    }
+
+    let sig = match signature {
+        Some(s) if !s.is_empty() => s,
+        _ => return false,
+    };
+
+    // Common definition prefixes across languages.
+    // Keep this allocation-free in hot paths by using &str prefixes and boundary checks.
+    const PREFIXES: &[&str] = &[
+        "fn ",
+        "def ",
+        "class ",
+        "struct ",
+        "enum ",
+        "trait ",
+        "type ",
+        "interface ",
+        "impl ",
+        "pub fn ",
+        "pub async fn ",
+        "pub struct ",
+        "pub enum ",
+        "pub trait ",
+        "pub type ",
+        "async fn ",
+        "const ",
+        "static ",
+    ];
+
+    PREFIXES.iter().any(|prefix| {
+        if !sig.starts_with(prefix) {
+            return false;
+        }
+
+        let rest = &sig[prefix.len()..];
+        if !rest.starts_with(symbol) {
+            return false;
+        }
+
+        let next = rest[symbol.len()..].chars().next();
+        matches!(next, None | Some('(' | '<' | ':' | ' ' | '\t'))
+    })
+}
+
 #[tool_handler]
 impl ServerHandler for CodesearchService {
     fn get_info(&self) -> ServerInfo {
-        let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
         let db_exists = self.db_path.exists();
 
         ServerInfo {
@@ -795,150 +1261,27 @@ impl ServerHandler for CodesearchService {
                 website_url: None,
             },
             instructions: Some(format!(
-                r#"codesearch - Semantic Code Search MCP Server
+                r#"codesearch — semantic + lexical code search MCP server.
 
-codesearch provides fast, local semantic code search using natural language queries.
-Search your codebase by meaning, not just by keywords.
+TOOLS:
+| Tool              | Use for                                              |
+|-------------------|------------------------------------------------------|
+| semantic_search   | Conceptual queries, identifier + natural-language mix |
+| find_definition   | Where is symbol X defined                             |
+| find_usages       | Who uses / calls symbol X                             |
+| find_references   | DEPRECATED — alias for find_usages                    |
+| index_status      | Verify the index is ready                             |
+| find_databases    | Discover available indexes                            |
 
-⚠️  IMPORTANT: This MCP server CANNOT index codebases. Indexing must be done manually.
-Indexing takes 30-60 seconds and should be done via the CLI: `codesearch index`
-
-AVAILABLE TOOLS:
-
-1. find_databases()
-   Find all available databases in current directory, parent directories, and globally.
-   Use this FIRST to discover which databases are available.
-   Returns: List of databases with paths, stats, and model info.
-
-2. index_status()
-   Check if the current index is ready for searching.
-   Use this AFTER find_databases() to verify the database is accessible.
-   Returns: Index status, stats, model info, and any error messages.
-
-3. semantic_search(query, limit=10, compact=true, filter_path=null)
-   Search the codebase using natural language queries.
-   By default returns COMPACT results (path, line numbers, kind, signature, score only).
-   Set compact=false to include full code content (use sparingly - high token cost).
-   Use filter_path to narrow results to a specific directory (e.g., "src/api/").
-   Query examples:
-     - "where do we handle user authentication?"
-     - "how is error logging implemented?"
-     - "functions that process payment data"
-   Returns: Array of matches with metadata. Use read tool to fetch actual code.
-
-4. find_references(symbol, limit=50)
-   Find all usages/call sites of a function, method, class, or type across the codebase.
-   ⚠️  USE THIS instead of grep when you need to find where a symbol is used.
-   Essential for refactoring — shows all locations that need to change.
-   Examples:
-     - find_references("authenticate") - Find all calls to authenticate()
-     - find_references("UserService") - Find all usages of UserService
-     - find_references("handleRequest") - Find all call sites
-   Returns: Compact list of file paths, line numbers, kind, and score.
-
-TOKEN-EFFICIENT WORKFLOW (IMPORTANT):
-
-All tools return compact metadata by default to minimize token usage.
-Use the read tool to fetch actual code content only for the specific
-lines you need. NEVER use grep for finding symbol usages — use
-find_references() instead.
-
-RECOMMENDED WORKFLOW:
-
-Step 1: Discover
-  find_databases() → index_status()
-
-Step 2: Search (compact — returns metadata only)
-  semantic_search("authentication handler")
-
-Step 3: Find related code (compact — returns locations only)
-  find_references("authenticate")
-
-Step 4: Read only what you need (targeted)
-  Use read tool with exact file path + line numbers from steps 2-3
-
-REFACTORING WORKFLOW:
-
-1. semantic_search("the function to refactor") → find the definition
-2. find_references("functionName") → find ALL call sites
-3. Read each call site with read tool → understand usage patterns
-4. Make changes to definition + all call sites
-
-⚠️  NEVER use grep to find symbol references. Always use find_references().
-    grep is only for exact string matching in non-indexed files.
-
-USAGE PATTERNS:
-
-Understanding a New Codebase:
-  1. find_databases() → index_status()
-  2. semantic_search("main application entry point")
-  3. semantic_search("error handling strategy")
-
-Finding Implementation Patterns:
-  - semantic_search("how are API endpoints defined?")
-  - semantic_search("database model definitions")
-
-Debugging and Analysis:
-  - semantic_search("error handling for database operations")
-  - find_references("handleError") → find all error handling sites
-
-BEST PRACTICES:
-
-✓ Always call find_databases() first to discover available indexes
-✓ Check index_status() before searching to verify the database is ready
-✓ Use natural language queries describing concepts, not exact terms
-✓ Use find_references() for refactoring — NOT grep
-✓ Use filter_path to narrow searches to specific directories
-✓ Let compact mode save tokens — read specific lines only when needed
-✓ Start with broader queries, then narrow down
-
-✗ Never attempt to index from this MCP server - use CLI instead
-✗ Never use grep to find symbol usages — use find_references() instead
-✗ Avoid short, vague queries like "auth" or "db"
-✗ Don't use compact=false unless you specifically need full code content
-✗ Don't search in subfolders expecting a separate index - indexes are project-wide
-
-DATABASE LOCATIONS:
-
-Priority order for database selection:
-1. Current directory (.codesearch.db/)
-2. Parent directories (up to 5 levels)
-3. Globally tracked repositories (~/.codesearch/repos.json)
+Indexing is done via CLI: `codesearch index`. The MCP server cannot index.
 
 Current project: {project}
-Current database: {db}
-Database exists: {exists}
-Current directory: {cwd}
-
-ERROR HANDLING:
-
-If you get "No index found" errors:
-1. Call find_databases() to see what's available
-2. Check if you're in the right directory
-3. Verify the user has run 'codesearch index'
-
-If search returns poor results:
-1. The index may be stale - ask user to re-run 'codesearch index'
-2. Try different query phrasing
-3. Check index_status() for any errors
-
-SETUP:
-
-To create an index, the USER must run (not the agent):
-  $ cd /path/to/project
-  $ codesearch index
-
-Indexing takes 30-60 seconds and cannot be done from the MCP server.
-
-For detailed documentation, visit: https://github.com/flupkede/codesearch
-
-Model: {model}
-Dimensions: {dims}
+Current database: {db} ({exists})
+Model: {model} ({dims}d)
 "#,
                 project = self.project_path.display(),
                 db = self.db_path.display(),
-                exists = if db_exists { "✅ Yes" } else { "❌ No" },
-                cwd = current_dir.display(),
+                exists = if db_exists { "ready" } else { "not found" },
                 model = self.model_type.short_name(),
                 dims = self.dimensions
             )),

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -99,6 +99,60 @@ pub struct DatabaseInfoResponse {
     pub model: String,
 }
 
+/// Request for literal/FTS-only search.
+///
+/// Three mutually exclusive modes (first match wins):
+/// - `regex=true` → regex search on indexed content
+/// - `phrase=true` → phrase query (tokens must appear in sequence)
+/// - default → exact term search (BM25)
+///
+/// No embedding service is used — this tool is fast and works without a model.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LiteralSearchRequest {
+    /// The search query (exact terms, regex pattern, or phrase depending on mode flags)
+    pub query: String,
+
+    /// Treat `query` as a regex pattern (e.g., "fn \\w+_handler")
+    pub regex: Option<bool>,
+
+    /// Treat `query` as a phrase (tokens must appear in sequence, e.g., "fn new")
+    pub phrase: Option<bool>,
+
+    /// Maximum number of results to return (default: 20)
+    pub limit: Option<usize>,
+
+    /// Only return results from files matching this glob pattern.
+    /// v1 supports prefix/suffix patterns with `*` and `**` (e.g., "src/mcp/**", "**/*.rs")
+    pub file_glob: Option<String>,
+
+    /// Only return results from files of this language (e.g., "Rust", "Python", "TypeScript")
+    pub language: Option<String>,
+
+    /// Output format: "json" (structured) or "grep" (file:line:snippet). Default: "json"
+    pub format: Option<String>,
+}
+
+/// Search result item - returned by literal_search
+#[derive(Debug, Serialize)]
+pub struct LiteralSearchResultItem {
+    /// File path (relative to project root)
+    pub path: String,
+    /// Start line number
+    pub start_line: usize,
+    /// End line number
+    pub end_line: usize,
+    /// Code snippet (content of the matching chunk)
+    pub snippet: String,
+    /// BM25 relevance score
+    pub score: f32,
+    /// Kind of chunk (e.g., "function", "struct", "class")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// Signature (e.g., function signature) if available
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+}
+
 /// Find databases response
 #[derive(Debug, Serialize)]
 pub struct FindDatabasesResponse {

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -3,7 +3,7 @@
 use rmcp::schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Request for semantic search
+/// Request for semantic/hybrid search
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SemanticSearchRequest {
     /// The search query (natural language or code snippet)
@@ -20,6 +20,13 @@ pub struct SemanticSearchRequest {
 
     /// Only return results from files under this path prefix (e.g., "src/api/")
     pub filter_path: Option<String>,
+
+    /// Override auto-detection of query intent.
+    /// "auto" (default) | "semantic" | "lexical" | "hybrid"
+    /// - "semantic": skip FTS fusion, use vector results only
+    /// - "lexical":  skip embedding, use FTS path only
+    /// - "hybrid":   force full hybrid even if auto would choose a single path
+    pub mode: Option<String>,
 }
 
 /// Request to find references/call sites of a symbol.
@@ -105,4 +112,38 @@ pub struct FindDatabasesResponse {
     pub databases: Vec<DatabaseInfoResponse>,
     pub message: String,
     pub current_directory: String,
+}
+
+/// Semantic search response wrapper with low-confidence signaling
+#[derive(Debug, Serialize)]
+pub struct SemanticSearchResponse {
+    /// Search results
+    pub results: Vec<SearchResultItem>,
+    /// Set when the top RRF score is below the confidence threshold.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub low_confidence: Option<bool>,
+    /// Populated alongside `low_confidence`. Suggests a better-suited tool for this query.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_tool: Option<String>,
+}
+
+/// Request to find the definition of a symbol
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindDefinitionRequest {
+    /// Symbol name (function, class, method, struct, trait, enum, type)
+    pub symbol: String,
+    /// Optional filter to a specific kind. If omitted, all definition kinds are searched.
+    /// Accepted: "Function" | "Class" | "Method" | "Struct" | "Trait" | "Enum" | "TypeAlias" | "Interface"
+    pub kind: Option<String>,
+    /// Maximum number of results to return (default: 20)
+    pub limit: Option<usize>,
+}
+
+/// Request to find usages/call-sites of a symbol
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindUsagesRequest {
+    /// Symbol name to find usages for
+    pub symbol: String,
+    /// Maximum number of results to return (default: 20)
+    pub limit: Option<usize>,
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -4,6 +4,51 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+/// Global quiet mode flag
+static QUIET_MODE: AtomicBool = AtomicBool::new(false);
+
+/// Enable quiet mode (suppresses informational output)
+pub fn set_quiet(quiet: bool) {
+    QUIET_MODE.store(quiet, Ordering::SeqCst);
+}
+
+/// Check if quiet mode is enabled
+pub fn is_quiet() -> bool {
+    QUIET_MODE.load(Ordering::SeqCst)
+}
+
+/// Print a message only if not in quiet mode (non-macro version for better compatibility)
+/// Uses stderr to avoid corrupting stdout-based protocols (MCP, JSON output)
+pub fn print_info(args: std::fmt::Arguments<'_>) {
+    if !is_quiet() {
+        eprintln!("{}", args);
+    }
+}
+
+/// Print a warning to stderr only if not in quiet mode (non-macro version)
+#[allow(dead_code)] // Used by warn_print! macro
+pub fn print_warn(args: std::fmt::Arguments<'_>) {
+    if !is_quiet() {
+        eprintln!("{}", args);
+    }
+}
+
+/// Print a message only if not in quiet mode
+#[macro_export]
+macro_rules! info_print {
+    ($($arg:tt)*) => {
+        $crate::output::print_info(format_args!($($arg)*));
+    };
+}
+
+/// Print to stderr only if not in quiet mode (for warnings)
+#[macro_export]
+macro_rules! warn_print {
+    ($($arg:tt)*) => {
+        $crate::output::print_warn(format_args!($($arg)*));
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,49 +138,4 @@ mod tests {
 
         set_quiet(false);
     }
-}
-
-/// Global quiet mode flag
-static QUIET_MODE: AtomicBool = AtomicBool::new(false);
-
-/// Enable quiet mode (suppresses informational output)
-pub fn set_quiet(quiet: bool) {
-    QUIET_MODE.store(quiet, Ordering::SeqCst);
-}
-
-/// Check if quiet mode is enabled
-pub fn is_quiet() -> bool {
-    QUIET_MODE.load(Ordering::SeqCst)
-}
-
-/// Print a message only if not in quiet mode (non-macro version for better compatibility)
-/// Uses stderr to avoid corrupting stdout-based protocols (MCP, JSON output)
-pub fn print_info(args: std::fmt::Arguments<'_>) {
-    if !is_quiet() {
-        eprintln!("{}", args);
-    }
-}
-
-/// Print a warning to stderr only if not in quiet mode (non-macro version)
-#[allow(dead_code)] // Used by warn_print! macro
-pub fn print_warn(args: std::fmt::Arguments<'_>) {
-    if !is_quiet() {
-        eprintln!("{}", args);
-    }
-}
-
-/// Print a message only if not in quiet mode
-#[macro_export]
-macro_rules! info_print {
-    ($($arg:tt)*) => {
-        $crate::output::print_info(format_args!($($arg)*));
-    };
-}
-
-/// Print to stderr only if not in quiet mode (for warnings)
-#[macro_export]
-macro_rules! warn_print {
-    ($($arg:tt)*) => {
-        $crate::output::print_warn(format_args!($($arg)*));
-    };
 }


### PR DESCRIPTION
## Summary

This PR combines two feature branches into one comprehensive MCP tooling update:

### New Tools
1. **`literal_search`** — FTS-only search (no embedding) with 3 modes:
   - `regex=true` → regex pattern matching via Tantivy `RegexQuery`
   - `phrase=true` → phrase query (tokens in sequence)
   - default → BM25 exact term search
   - Supports `file_glob` and `language` post-filters, `format="json"|"grep"` output

2. **`find_definition`** — Locate where a symbol is defined (function, class, struct, etc.)
   - Uses FTS + chunk-kind filter to exclude usages/comments
   - Optional `kind` filter (e.g., `"Struct"`, `"Function"`)

3. **`find_usages`** — Find call-sites and usages of a symbol
   - Excludes the definition chunk itself via `is_definition_chunk` heuristic
   - `find_references` retained as deprecated alias for backward compat

### Improvements
- **`semantic_search` rebranded as hybrid** — New `mode` parameter: `"auto"|"semantic"|"lexical"|"hybrid"`
- **Low-confidence signaling** — When top RRF score < threshold, response includes `low_confidence: true` + `suggested_tool`
- **Response wrapper** — `semantic_search` now returns `SemanticSearchResponse` with `results[]`, `low_confidence`, `suggested_tool`
- **Compact instructions** — `get_info()` routing table reduced from ~150 lines to ~16 lines

### Refactoring
- **`with_vector_store_read`** / **`with_fts_store_read`** — Shared helpers eliminating ~200 lines of duplicated shared/standalone store access (6 call sites unified)
- **`collect_fts_results`** — Extracted duplicated result-collection loop in `FtsStore` (4 call sites)
- **`merge_exact_into_fts`** — HashMap-based O(n) dedupe for exact-match merging
- **`compute_low_confidence`** — Pure function for threshold logic
- **`is_definition_chunk`** — Allocation-free signature matching with static prefix list

### Bug Fixes
- `literal_search file_glob` filter now correctly strips project root for relative glob matching

### Tests
- **43 new Rust unit tests** (195 → 238 lib tests)
  - `merge_exact_into_fts` — 5 tests (dedupe, max score, empty cases)
  - `compute_low_confidence` — 6 tests (threshold boundary, identifiers, no results)
  - `is_definition_chunk` — 8 edge case tests (impl, const, type alias, generics, interface, all kinds coverage)
  - `simple_glob_match` — 10 edge case tests (empty, nested **, middle **, segment boundary)
  - Serde roundtrip — 10 tests for all new request/response types
  - Serialization — 4 tests for optional field omission
- **MCP runtime smoke tests** — All 34/34 passed (index_status, literal_search, find_definition, find_usages, semantic_search modes)

## Files Changed
- `src/mcp/mod.rs` — New tools, helpers, refactored store access, instructions
- `src/mcp/types.rs` — New request/response types (LiteralSearchRequest, FindDefinitionRequest, FindUsagesRequest, SemanticSearchResponse)
- `src/fts/tantivy_store.rs` — `search_regex`, `search_phrase`, `collect_fts_results`
- `src/output.rs` — Test module relocation (clippy fix)

## Validation
- `cargo test --all` ✅ (238 lib + 249 bin, 0 failures)
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --all` ✅
- MCP runtime smoke tests ✅ (34/34)