### PR TITLE
✨ feat: add literal_search MCP tool with regex, phrase, and BM25 modes

### DIFF
--- a/AGENTS_tool_improvement.md
+++ b/AGENTS_tool_improvement.md
@@ -1,0 +1,192 @@
+# AGENTS — Branch `feat/mcp-literal-search-tool`
+
+> Scoped instructions for any coding agent (OpenCode, Claude Code, Copilot) working on this branch. This file is self-contained: everything needed to execute the work is below. A parallel Branch A (`feat/mcp-rebrand-hybrid-search`) handles a separate concern and is expected to have merged before this branch is rebased onto `main`.
+
+## Why this branch exists
+
+Agents observing codesearch via MCP fall back to `grep` for pure literal lookups: error codes, TODO tags, env var names, URLs, hardcoded strings, regex patterns. The reason is simple — **there is no MCP tool that exposes literal/regex search without going through the semantic pipeline.**
+
+Internally, `semantic_search` does fuse Tantivy FTS results, but:
+
+- Every call pays the embedding cost (~50-200ms) even for pure literal queries.
+- Tantivy's regex, phrase, and field-scoped capabilities are hidden behind the natural-language framing.
+- Non-identifier literals (error strings with spaces, URLs, regex patterns) are not picked up by `detect_identifiers`, so they get no exact-match boost — and are then diluted by vector neighbours in RRF fusion.
+
+This branch adds one dedicated tool: `literal_search`. No changes to semantic search, ranking, or indexing.
+
+## Prerequisite
+
+This branch assumes Branch A (`feat/mcp-rebrand-hybrid-search`) has merged to `main`. In Branch A, `semantic_search` sets `suggested_tool = "literal_search"` when the query has no detected identifiers and top score is low — so `literal_search` must exist as an advertised tool once Branch A's hint takes effect. If this branch is opened while Branch A is still in review, rebase onto `main` after A merges before final PR.
+
+## Scope — what to implement
+
+1. Add `search_regex` and `search_phrase` methods on `FtsStore`.
+2. Add `LiteralSearchRequest` / `LiteralSearchResultItem` types.
+3. Add a new `literal_search` MCP tool that:
+   - skips the embedding service entirely,
+   - routes the query to `search_exact`, `search_phrase`, or `search_regex` based on input flags,
+   - supports `file_glob` and `language` post-filters,
+   - supports `format = "json" | "grep"` output.
+
+## Scope — what NOT to touch
+
+- `semantic_search`, `find_definition`, `find_usages`, `find_references`, `index_status`, `find_databases` — do not modify.
+- The embedding pipeline (`src/embed/`).
+- The chunker (`src/chunker/`).
+- The ranker (`src/rerank/`, `src/search/`).
+- The vector store (`src/vectordb/`) — read-only access only, via existing APIs.
+- `Cargo.toml` — no new dependencies; Tantivy already provides everything needed.
+
+## File-by-file plan
+
+### `src/fts/tantivy_store.rs`
+
+Add two public methods to `FtsStore`. Signatures:
+
+```rust
+/// Search using a regex pattern over the content field.
+/// Pattern syntax is Tantivy's (Rust-regex-compatible).
+/// Returns hits ordered by BM25 score.
+pub fn search_regex(
+    &self,
+    pattern: &str,
+    limit: usize,
+) -> Result<Vec<FtsResult>>;
+
+/// Search for an exact phrase (consecutive tokens) over the content field.
+/// The phrase is tokenised with the same analyser as indexed content.
+pub fn search_phrase(
+    &self,
+    phrase: &str,
+    limit: usize,
+) -> Result<Vec<FtsResult>>;
+```
+
+Implementation notes:
+
+- `search_regex` uses `tantivy::query::RegexQuery::from_pattern(pattern, content_field)`.
+- `search_phrase` uses `tantivy::query::PhraseQuery::new(vec![...])` built from tokens produced by the same tokenizer the index uses. If the phrase tokenises to a single term, fall back to a `TermQuery` and document this in a comment.
+- Both methods return `FtsResult` in the same shape as `search` / `search_exact` so callers can reuse chunk-resolution code.
+- Errors from malformed regex must surface as `anyhow::Error` with a clear message — do **not** panic.
+
+Add unit tests in the same file (under `#[cfg(test)] mod tests`):
+
+- `search_regex` finds chunks matching a simple pattern on a fixture index.
+- `search_regex` with a malformed pattern returns `Err`, not panic.
+- `search_phrase` returns only hits where the words appear consecutively.
+- `search_phrase` with a single-word phrase degrades to term search without error.
+
+### `src/mcp/types.rs`
+
+Add:
+
+```rust
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LiteralSearchRequest {
+    /// The literal string, phrase, or regex pattern to search for.
+    pub query: String,
+
+    /// Treat `query` as a regex pattern (Rust-regex / Tantivy syntax). Default: false.
+    pub regex: Option<bool>,
+
+    /// Treat `query` as an exact phrase (words in order). Default: false.
+    /// If `query` is wrapped in double quotes, `phrase` is implied (the quotes are stripped).
+    pub phrase: Option<bool>,
+
+    /// Glob filter on result file path, e.g. "src/**/*.rs".
+    pub file_glob: Option<String>,
+
+    /// Language filter, e.g. "rust", "python". Post-filter on `Language::from_path`.
+    pub language: Option<String>,
+
+    /// Maximum number of results (default: 50).
+    pub limit: Option<usize>,
+
+    /// Output format: "json" (default) or "grep".
+    /// "grep" returns a single text block with `{path}:{line}: {snippet}` lines.
+    pub format: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LiteralSearchResultItem {
+    pub path: String,
+    pub line: usize,
+    pub snippet: String,
+    pub score: f32,
+}
+```
+
+### `src/mcp/mod.rs`
+
+Register a new tool:
+
+```rust
+#[tool(
+    description = "Exact string, phrase, or regex search over the indexed codebase. Tantivy FTS only — no embedding, no semantic reranking. Fast (~10-50ms).\n\nUSE FOR:\n- Error messages, TODO/FIXME tags, env var names, URLs, hardcoded strings\n- Regex patterns (set regex=true)\n- Exact phrases (wrap query in double quotes OR set phrase=true)\n- Narrowed scope via file_glob or language filter\n\nDO NOT USE FOR:\n- Conceptual / natural-language queries → use `semantic_search`\n- Finding usages of a symbol where you don't know the exact spelling → use `find_usages`\n\nReturns 0 results if the literal is not in any indexed file — in that case escalate to `semantic_search` for conceptual lookup.\nSet format=\"grep\" for `path:line:` output."
+)]
+async fn literal_search(
+    &self,
+    Parameters(request): Parameters<LiteralSearchRequest>,
+) -> Result<CallToolResult, McpError> { ... }
+```
+
+Handler logic:
+
+1. Call `ensure_database_exists()` early.
+2. Determine mode from flags:
+   - If `regex == Some(true)` → regex mode.
+   - Else if `phrase == Some(true)` → phrase mode.
+   - Else if query starts and ends with `"` and has length ≥ 3 → phrase mode, strip quotes.
+   - Else → exact mode (existing `search_exact` with `structural_intent = None`).
+3. Open `FtsStore`. Do **not** open the embedding service. Do **not** call `VectorStore::search` — this tool is FTS-only for retrieval. You may use `VectorStore::get_chunk` to resolve metadata for the snippet.
+4. Execute the chosen FTS method with `limit * 3` (raw budget for post-filtering).
+5. Resolve each `FtsResult.chunk_id` → chunk metadata via `get_chunk` (shared store if available; fall back to opening one). Use the existing pattern from `find_references`.
+6. Apply `language` post-filter: `Language::from_path(path) == requested_language` (case-insensitive).
+7. Apply `file_glob` post-filter using the `glob` crate if already a dep, otherwise a simple prefix/suffix matcher. **Do not add new dependencies in this branch** — if `glob` is not already present, ship v1 with prefix/suffix glob support only (`*`, `**` supported; full glob syntax deferred).
+8. Take `limit` results.
+9. For each result build `LiteralSearchResultItem { path, line: start_line, snippet, score }`. The snippet is the first line of the chunk content, truncated to 200 chars.
+10. Serialize:
+    - `format == "grep"` → single `Content::text` joining `format!("{}:{}: {}", path, line, snippet)` with `\n`.
+    - Otherwise → JSON array of `LiteralSearchResultItem`.
+
+## Acceptance criteria
+
+All of these must hold before PR merge:
+
+- `cargo test --all` passes.
+- `cargo clippy --all-targets -- -D warnings` passes.
+- Unit tests in `src/fts/tantivy_store.rs` (listed above) pass.
+- Integration test against a fixture index:
+  - `literal_search(query="TODO")` returns expected TODO hits in `< 100ms` on a warm index.
+  - `literal_search(query="handle_\\w+_request", regex=true)` returns regex matches.
+  - `literal_search(query="connection refused", phrase=true)` returns only phrase matches (not individual word hits).
+  - `literal_search(query="fn new", file_glob="src/mcp/**")` returns only hits whose path starts with `src/mcp/`.
+  - `literal_search(query="authenticate", format="grep")` returns a single text block where each line matches `^[^:]+:\d+: .+$`.
+- Trace assertion: the `literal_search` code path does not invoke `EmbeddingService`. Recommended approach: in a test, spy on `get_embedding_service` (or equivalent) and assert it is never called during a `literal_search` invocation.
+- Existing `test_mcp_no_raw_stdout_calls` still passes.
+- Tool appears in `get_info().instructions` routing table (add a row to the table that Branch A introduced).
+
+## Commit hygiene
+
+- Small commits, one logical change each.
+- Conventional-commit style (`feat(mcp): ...`, `feat(fts): ...`, `test(fts): ...`, `docs(mcp): ...`).
+- Author identity = Filip Develter personal GitHub (`flupkede`). Verify `git config user.email` before first commit.
+
+## PR expectations
+
+- Title: `feat(mcp): add literal_search tool with regex and phrase support`
+- Target base: `main` (after Branch A has merged).
+- Description should include:
+  - One-paragraph rationale.
+  - A short table of example queries and which mode each triggers.
+  - Link to this AGENTS file.
+  - Link to Branch A's PR for context.
+
+## Deliberately out of scope
+
+- True ripgrep-style boolean query syntax (`foo AND bar NOT baz`).
+- Indexing non-AST files (Markdown, YAML, configs). Agents may still fall back to `grep` for those — that's a known gap and will be addressed in a later branch.
+- Warm-start or preloading of the embedding model.
+- AST-based reference resolution (tree-sitter call-expression queries).
+- Query expansion for short ambiguous queries.
+- Changes to the `glob` dependency — keep v1 glob support minimal.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.203"
+version = "0.1.204"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/fts/tantivy_store.rs
+++ b/src/fts/tantivy_store.rs
@@ -522,6 +522,99 @@ impl FtsStore {
         Ok(results)
     }
 
+    /// Search using a regex pattern against the content field.
+    ///
+    /// Uses Tantivy's `RegexQuery` for efficient regex matching on the indexed content.
+    /// The pattern syntax follows the `regex` crate conventions.
+    pub fn search_regex(&self, pattern: &str, limit: usize) -> Result<Vec<FtsResult>> {
+        use tantivy::query::RegexQuery;
+
+        let searcher = self.reader.searcher();
+
+        let query = RegexQuery::from_pattern(pattern, self.content_field)
+            .map_err(|e| anyhow!("Invalid regex pattern '{}': {}", pattern, e))?;
+
+        let top_docs = searcher.search(&query, &TopDocs::with_limit(limit))?;
+
+        let mut results = Vec::with_capacity(top_docs.len());
+        for (score, doc_address) in top_docs {
+            let doc: TantivyDocument = searcher.doc(doc_address)?;
+            if let Some(chunk_id) = doc.get_first(self.chunk_id_field) {
+                if let Some(id) = chunk_id.as_u64() {
+                    results.push(FtsResult {
+                        chunk_id: id as u32,
+                        score,
+                    });
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Search using a phrase query against the content field.
+    ///
+    /// Tokenizes the phrase using the same analyzer as the indexed content field,
+    /// then builds a `PhraseQuery` requiring terms to appear in sequence.
+    /// If the phrase tokenizes to a single term, falls back to `TermQuery`
+    /// (avoids unnecessary position tracking overhead for single-word queries).
+    pub fn search_phrase(&self, phrase: &str, limit: usize) -> Result<Vec<FtsResult>> {
+        use tantivy::query::{PhraseQuery, TermQuery};
+        use tantivy::schema::IndexRecordOption;
+
+        let searcher = self.reader.searcher();
+
+        // Tokenize the phrase using the same analyzer as the indexed content.
+        // The content field uses TEXT which applies the default tokenizer
+        // (lowercase + split on non-alphanumeric).
+        let terms: Vec<Term> = {
+            let mut analyzer = self
+                .index
+                .tokenizer_for_field(self.content_field)
+                .map_err(|e| anyhow!("Failed to get tokenizer for content field: {}", e))?;
+            let mut stream = analyzer.token_stream(phrase);
+            let mut collected = Vec::new();
+            while stream.advance() {
+                let token = stream.token();
+                collected.push(Term::from_field_text(self.content_field, &token.text));
+            }
+            collected
+        };
+
+        if terms.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // If the phrase tokenizes to a single term, fall back to TermQuery.
+        // PhraseQuery requires at least 2 terms; using TermQuery for single terms
+        // avoids unnecessary position tracking overhead.
+        let query: Box<dyn tantivy::query::Query> = if terms.len() == 1 {
+            Box::new(TermQuery::new(
+                terms.into_iter().next().unwrap(),
+                IndexRecordOption::WithFreqs,
+            ))
+        } else {
+            Box::new(PhraseQuery::new(terms))
+        };
+
+        let top_docs = searcher.search(&query, &TopDocs::with_limit(limit))?;
+
+        let mut results = Vec::with_capacity(top_docs.len());
+        for (score, doc_address) in top_docs {
+            let doc: TantivyDocument = searcher.doc(doc_address)?;
+            if let Some(chunk_id) = doc.get_first(self.chunk_id_field) {
+                if let Some(id) = chunk_id.as_u64() {
+                    results.push(FtsResult {
+                        chunk_id: id as u32,
+                        score,
+                    });
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Get statistics about the index
     pub fn stats(&self) -> Result<FtsStats> {
         let searcher = self.reader.searcher();
@@ -630,6 +723,120 @@ mod tests {
         let results = store.search("test content", 10, None)?;
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].chunk_id, 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_fts_search_regex() -> Result<()> {
+        let dir = tempdir()?;
+        let db_path = dir.path().to_path_buf();
+
+        let mut store = FtsStore::new(&db_path)?;
+
+        store.add_chunk(
+            1,
+            "fn hello_world() { println!(\"Hello!\"); }",
+            "src/main.rs",
+            Some("hello_world"),
+            "function",
+        )?;
+        store.add_chunk(
+            2,
+            "fn handle_request(req: Request) -> Response",
+            "src/handler.rs",
+            Some("handle_request"),
+            "function",
+        )?;
+        store.add_chunk(
+            3,
+            "struct UserConfig { name: String, age: u32 }",
+            "src/config.rs",
+            Some("UserConfig"),
+            "struct",
+        )?;
+        store.commit()?;
+
+        // Note: Tantivy's SimpleTokenizer splits on non-alphanumeric chars (including _),
+        // and lowercases. The content field uses TEXT which applies this tokenizer.
+        // Tokens for chunk 1: ["fn", "hello", "world", "println", "hello"]
+        // Tokens for chunk 2: ["fn", "handle", "request", "req", "request", "response"]
+        // Tokens for chunk 3: ["struct", "userconfig", "name", "string", "age", "u32"]
+
+        // Regex: match the token "hello"
+        let results = store.search_regex("hello", 10)?;
+        assert!(!results.is_empty(), "Expected results for 'hello'");
+        assert!(results.iter().any(|r| r.chunk_id == 1));
+
+        // Regex: match any token starting with "handle"
+        let results = store.search_regex("handle.*", 10)?;
+        assert!(!results.is_empty(), "Expected results for 'handle.*'");
+        assert!(results.iter().any(|r| r.chunk_id == 2));
+
+        // Regex: match any token starting with "user"
+        // "UserConfig" → tokenized to "userconfig"
+        let results = store.search_regex("user.*", 10)?;
+        assert!(!results.is_empty(), "Expected results for 'user.*'");
+        assert!(results.iter().any(|r| r.chunk_id == 3));
+
+        // Regex with no match
+        let results = store.search_regex("nonexistent_xyz_abc", 10)?;
+        assert!(
+            results.is_empty(),
+            "Expected no results for nonexistent pattern"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_fts_search_phrase() -> Result<()> {
+        let dir = tempdir()?;
+        let db_path = dir.path().to_path_buf();
+
+        let mut store = FtsStore::new(&db_path)?;
+
+        store.add_chunk(
+            1,
+            "fn hello_world() { println!(\"Hello!\"); }",
+            "src/main.rs",
+            Some("hello_world"),
+            "function",
+        )?;
+        store.add_chunk(
+            2,
+            "pub async fn process_data(data: Vec<u8>) -> Result<()>",
+            "src/processor.rs",
+            Some("process_data"),
+            "function",
+        )?;
+        store.add_chunk(
+            3,
+            "let hello = world + 1;", // "hello" and "world" but NOT in sequence
+            "src/other.rs",
+            None,
+            "block",
+        )?;
+        store.commit()?;
+
+        // Phrase search: "hello world" should match chunk 1 (tokens in sequence)
+        let results = store.search_phrase("hello world", 10)?;
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| r.chunk_id == 1));
+
+        // Phrase search: "process data" should match chunk 2
+        let results = store.search_phrase("process data", 10)?;
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| r.chunk_id == 2));
+
+        // Single term phrase: should still work (falls back to TermQuery)
+        let results = store.search_phrase("hello_world", 10)?;
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| r.chunk_id == 1));
+
+        // Phrase with no match
+        let results = store.search_phrase("nonexistent phrase xyz", 10)?;
+        assert!(results.is_empty());
 
         Ok(())
     }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -73,6 +73,58 @@ mod tests {
             &project_root,
         ));
     }
+
+    #[test]
+    fn test_simple_glob_match_exact() {
+        assert!(super::simple_glob_match("src/main.rs", "src/main.rs"));
+        assert!(!super::simple_glob_match("src/main.rs", "src/other.rs"));
+    }
+
+    #[test]
+    fn test_simple_glob_match_double_star_prefix() {
+        // src/mcp/** matches any path starting with src/mcp/
+        assert!(super::simple_glob_match("src/mcp/**", "src/mcp/mod.rs"));
+        assert!(super::simple_glob_match("src/mcp/**", "src/mcp/types.rs"));
+        assert!(super::simple_glob_match(
+            "src/mcp/**",
+            "src/mcp/sub/deep.rs"
+        ));
+        assert!(!super::simple_glob_match("src/mcp/**", "src/other/mod.rs"));
+    }
+
+    #[test]
+    fn test_simple_glob_match_double_star_suffix() {
+        // **/*.rs matches any path ending with .rs
+        assert!(super::simple_glob_match("**/*.rs", "src/main.rs"));
+        assert!(super::simple_glob_match("**/*.rs", "deep/nested/file.rs"));
+        assert!(!super::simple_glob_match("**/*.rs", "src/main.ts"));
+    }
+
+    #[test]
+    fn test_simple_glob_match_double_star_both() {
+        // src/**/*.rs → starts with src/ and ends with .rs
+        assert!(super::simple_glob_match("src/**/*.rs", "src/main.rs"));
+        assert!(super::simple_glob_match("src/**/*.rs", "src/mcp/mod.rs"));
+        assert!(!super::simple_glob_match("src/**/*.rs", "tests/main.rs"));
+        assert!(!super::simple_glob_match("src/**/*.rs", "src/main.ts"));
+    }
+
+    #[test]
+    fn test_simple_glob_match_single_star() {
+        // *.rs matches any path ending with .rs
+        assert!(super::simple_glob_match("*.rs", "main.rs"));
+        assert!(!super::simple_glob_match("*.rs", "main.ts"));
+        // src/*.rs matches files directly in src/ ending with .rs
+        assert!(super::simple_glob_match("src/*.rs", "src/main.rs"));
+        assert!(!super::simple_glob_match("src/*.rs", "src/sub/main.rs"));
+    }
+
+    #[test]
+    fn test_simple_glob_match_backslash_normalization() {
+        // Backslashes should be normalized
+        assert!(super::simple_glob_match("src/mcp/**", r"src\mcp\mod.rs"));
+        assert!(super::simple_glob_match(r"src\mcp\**", "src/mcp/mod.rs"));
+    }
 }
 
 pub mod types;
@@ -122,6 +174,160 @@ impl std::fmt::Debug for CodesearchService {
             .field("has_shared_stores", &self.shared_stores.is_some())
             .finish()
     }
+}
+
+// === Simple Glob Matcher ===
+// v1: supports prefix/suffix patterns with `*` and `**` only.
+// Full glob syntax deferred to avoid adding new dependencies.
+
+/// Match a file path against a simple glob pattern.
+///
+/// Supported patterns:
+/// - `src/mcp/**` → any path starting with `src/mcp/`
+/// - `**/*.rs` → any path ending with `.rs`
+/// - `src/**/*.rs` → path starting with `src/` and ending with `.rs`
+/// - `*.rs` → any path ending with `.rs` (single `*` within a segment)
+/// - `foo.rs` → exact match
+fn simple_glob_match(pattern: &str, path: &str) -> bool {
+    let pattern = pattern.replace('\\', "/");
+    let path = path.replace('\\', "/");
+
+    if !pattern.contains('*') {
+        // Exact match
+        return path == pattern;
+    }
+
+    if pattern.contains("**") {
+        // Split on first ** only
+        let parts: Vec<&str> = pattern.splitn(2, "**").collect();
+        let prefix = parts[0];
+        // Strip leading / from suffix since ** already matches the separator
+        let suffix = parts
+            .get(1)
+            .map(|s| s.strip_prefix('/').unwrap_or(s))
+            .unwrap_or("");
+
+        let mut p = path.as_str();
+        if !prefix.is_empty() && !p.starts_with(prefix) {
+            return false;
+        }
+        if !prefix.is_empty() {
+            p = &p[prefix.len()..];
+        }
+        // Strip leading / from remaining path (since ** can match empty + /)
+        if p.starts_with('/') {
+            p = &p[1..];
+        }
+        if suffix.is_empty() {
+            return true;
+        }
+        // The suffix may contain single * — match against the tail of the path.
+        // After **, the suffix describes constraints on the end of the path.
+        // For `**/*.rs`, the `*.rs` should match the last segment.
+        if suffix.contains('*') {
+            // Match suffix against the end of the path using segment-aware logic
+            return match_suffix_with_star(suffix, p);
+        }
+        p.ends_with(suffix)
+    } else {
+        // Pure single-star pattern (no **)
+        simple_glob_match_single_star(&pattern, &path)
+    }
+}
+
+/// Match a suffix pattern (containing `*`) against the end of a path.
+/// The `*` matches within a single segment only.
+///
+/// E.g., suffix `*.rs` matches `src/main.rs` because the last segment `main.rs` ends with `.rs`.
+fn match_suffix_with_star(suffix: &str, path: &str) -> bool {
+    // Find the segments in the suffix (split by /)
+    let suffix_parts: Vec<&str> = suffix.split('/').collect();
+    let path_segments: Vec<&str> = path.split('/').collect();
+
+    // The suffix must match the last N segments of the path
+    if suffix_parts.len() > path_segments.len() {
+        return false;
+    }
+
+    let path_tail = &path_segments[path_segments.len() - suffix_parts.len()..];
+
+    for (sp, pp) in suffix_parts.iter().zip(path_tail.iter()) {
+        if sp.contains('*') {
+            if !single_segment_match(sp, pp) {
+                return false;
+            }
+        } else if *sp != *pp {
+            return false;
+        }
+    }
+    true
+}
+
+/// Match a single segment pattern against a single segment path part.
+/// `*` matches any characters within the segment.
+fn single_segment_match(pattern: &str, segment: &str) -> bool {
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut s = segment;
+
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            if !s.starts_with(part) {
+                return false;
+            }
+            s = &s[part.len()..];
+        } else if i == parts.len() - 1 {
+            if !s.ends_with(part) {
+                return false;
+            }
+        } else if let Some(pos) = s.find(part) {
+            s = &s[pos + part.len()..];
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+/// Match a single-star glob pattern where `*` matches any characters except `/`.
+fn simple_glob_match_single_star(pattern: &str, path: &str) -> bool {
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut p = path;
+
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            // First part must be a prefix
+            if !p.starts_with(part) {
+                return false;
+            }
+            p = &p[part.len()..];
+        } else if i == parts.len() - 1 {
+            // Last part must be a suffix of the CURRENT segment (after *)
+            // * does not cross /, so find the end of the current segment
+            let seg_end = p.find('/').unwrap_or(p.len());
+            let segment = &p[..seg_end];
+            if !segment.ends_with(part) {
+                return false;
+            }
+        } else {
+            // Middle parts: find within remaining path but NOT across /
+            if let Some(pos) = p.find(part) {
+                let before = &p[..pos];
+                if before.contains('/') {
+                    return false;
+                }
+                p = &p[pos + part.len()..];
+            } else {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 // === Tool Router Implementation ===
@@ -564,6 +770,195 @@ impl CodesearchService {
     }
 
     #[tool(
+        description = "Search code using literal/FTS matching without embeddings. Three modes: exact (default), regex (set regex=true), phrase (set phrase=true). Supports file_glob and language post-filters. Use this when you need fast exact text search, pattern matching, or phrase search. Does NOT require an embedding model."
+    )]
+    async fn literal_search(
+        &self,
+        Parameters(request): Parameters<LiteralSearchRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let limit = request.limit.unwrap_or(20);
+        let output_format = request.format.as_deref().unwrap_or("json");
+
+        tracing::debug!(
+            "MCP literal_search: query='{}', regex={:?}, phrase={:?}, limit={}, file_glob={:?}, language={:?}, format={}",
+            request.query,
+            request.regex,
+            request.phrase,
+            limit,
+            request.file_glob,
+            request.language,
+            output_format
+        );
+
+        // Ensure database exists
+        if let Err(e) = self.ensure_database_exists() {
+            return Ok(CallToolResult::success(vec![Content::text(e)]));
+        }
+
+        // Open FTS store only — no embedding service needed
+        let fts_store = match FtsStore::new(&self.db_path) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Error opening FTS store: {}. Try re-indexing with 'codesearch index --force'.",
+                    e
+                ))]));
+            }
+        };
+
+        // Determine search mode and execute
+        let fts_results = if request.regex.unwrap_or(false) {
+            match fts_store.search_regex(&request.query, limit * 3) {
+                Ok(r) => r,
+                Err(e) => {
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Error in regex search: {}",
+                        e
+                    ))]));
+                }
+            }
+        } else if request.phrase.unwrap_or(false) {
+            match fts_store.search_phrase(&request.query, limit * 3) {
+                Ok(r) => r,
+                Err(e) => {
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Error in phrase search: {}",
+                        e
+                    ))]));
+                }
+            }
+        } else {
+            // Default: BM25 exact term search
+            match fts_store.search(&request.query, limit * 3, None) {
+                Ok(r) => r,
+                Err(e) => {
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Error in search: {}",
+                        e
+                    ))]));
+                }
+            }
+        };
+
+        if fts_results.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "No results found for '{}'. Try a different query or mode.",
+                request.query
+            ))]));
+        }
+
+        // Resolve chunk metadata and apply post-filters
+        let items: Vec<LiteralSearchResultItem> = if let Some(ref stores) = self.shared_stores {
+            let store = stores.vector_store.read().await;
+            fts_results
+                .iter()
+                .filter_map(|fts_result| {
+                    let chunk = store.get_chunk(fts_result.chunk_id).ok()??;
+                    Some((chunk, fts_result.score))
+                })
+                .filter(|(chunk, _)| {
+                    // Language post-filter
+                    if let Some(ref lang) = request.language {
+                        let file_lang = Language::from_path(std::path::Path::new(&chunk.path));
+                        if file_lang.name() != lang {
+                            return false;
+                        }
+                    }
+                    // file_glob post-filter
+                    if let Some(ref glob) = request.file_glob {
+                        if !simple_glob_match(glob, &chunk.path) {
+                            return false;
+                        }
+                    }
+                    true
+                })
+                .take(limit)
+                .map(|(chunk, score)| LiteralSearchResultItem {
+                    path: chunk.path,
+                    start_line: chunk.start_line,
+                    end_line: chunk.end_line,
+                    snippet: chunk.content,
+                    score,
+                    kind: if chunk.kind.is_empty() {
+                        None
+                    } else {
+                        Some(chunk.kind)
+                    },
+                    signature: chunk.signature.filter(|s| !s.is_empty()),
+                })
+                .collect()
+        } else {
+            // Standalone mode — open a new VectorStore
+            let store = match VectorStore::new(&self.db_path, self.dimensions) {
+                Ok(s) => s,
+                Err(e) => {
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Error opening database: {}",
+                        e
+                    ))]));
+                }
+            };
+            fts_results
+                .iter()
+                .filter_map(|fts_result| {
+                    let chunk = store.get_chunk(fts_result.chunk_id).ok()??;
+                    Some((chunk, fts_result.score))
+                })
+                .filter(|(chunk, _)| {
+                    // Language post-filter
+                    if let Some(ref lang) = request.language {
+                        let file_lang = Language::from_path(std::path::Path::new(&chunk.path));
+                        if file_lang.name() != lang {
+                            return false;
+                        }
+                    }
+                    // file_glob post-filter
+                    if let Some(ref glob) = request.file_glob {
+                        if !simple_glob_match(glob, &chunk.path) {
+                            return false;
+                        }
+                    }
+                    true
+                })
+                .take(limit)
+                .map(|(chunk, score)| LiteralSearchResultItem {
+                    path: chunk.path,
+                    start_line: chunk.start_line,
+                    end_line: chunk.end_line,
+                    snippet: chunk.content,
+                    score,
+                    kind: if chunk.kind.is_empty() {
+                        None
+                    } else {
+                        Some(chunk.kind)
+                    },
+                    signature: chunk.signature.filter(|s| !s.is_empty()),
+                })
+                .collect()
+        };
+
+        if items.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "No results found for '{}' after applying filters.",
+                request.query
+            ))]));
+        }
+
+        // Format output
+        let output = if output_format == "grep" {
+            items
+                .iter()
+                .map(|item| format!("{}:{}:{}", item.path, item.start_line, item.snippet))
+                .collect::<Vec<_>>()
+                .join("\n")
+        } else {
+            serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
+        };
+
+        Ok(CallToolResult::success(vec![Content::text(output)]))
+    }
+
+    #[tool(
         description = "Get the status of the semantic search index including model info and statistics. Check this before searching to verify the index is ready."
     )]
     async fn index_status(&self) -> Result<CallToolResult, McpError> {
@@ -826,15 +1221,25 @@ AVAILABLE TOOLS:
      - "functions that process payment data"
    Returns: Array of matches with metadata. Use read tool to fetch actual code.
 
-4. find_references(symbol, limit=50)
-   Find all usages/call sites of a function, method, class, or type across the codebase.
-   ⚠️  USE THIS instead of grep when you need to find where a symbol is used.
-   Essential for refactoring — shows all locations that need to change.
-   Examples:
-     - find_references("authenticate") - Find all calls to authenticate()
-     - find_references("UserService") - Find all usages of UserService
-     - find_references("handleRequest") - Find all call sites
-   Returns: Compact list of file paths, line numbers, kind, and score.
+ 4. find_references(symbol, limit=50)
+    Find all usages/call sites of a function, method, class, or type across the codebase.
+    ⚠️  USE THIS instead of grep when you need to find where a symbol is used.
+    Essential for refactoring — shows all locations that need to change.
+    Examples:
+      - find_references("authenticate") - Find all calls to authenticate()
+      - find_references("UserService") - Find all usages of UserService
+      - find_references("handleRequest") - Find all call sites
+    Returns: Compact list of file paths, line numbers, kind, and score.
+
+ 5. literal_search(query, regex=false, phrase=false, limit=20, file_glob=null, language=null, format="json")
+    Fast FTS-only search without embeddings. Three mutually exclusive modes:
+    - Default: exact term search (BM25 scoring)
+    - regex=true: regex pattern matching (e.g., "fn \\w+_handler")
+    - phrase=true: phrase query — tokens must appear in sequence (e.g., "fn new")
+    Post-filters: file_glob (e.g., "src/mcp/**") and language (e.g., "Rust").
+    Output: "json" (structured) or "grep" (file:line:snippet).
+    Use when you need fast exact text search without semantic understanding.
+    Returns: Array of matches with path, line numbers, snippet, and score.
 
 TOKEN-EFFICIENT WORKFLOW (IMPORTANT):
 

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -99,6 +99,60 @@ pub struct DatabaseInfoResponse {
     pub model: String,
 }
 
+/// Request for literal/FTS-only search.
+///
+/// Three mutually exclusive modes (first match wins):
+/// - `regex=true` → regex search on indexed content
+/// - `phrase=true` → phrase query (tokens must appear in sequence)
+/// - default → exact term search (BM25)
+///
+/// No embedding service is used — this tool is fast and works without a model.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LiteralSearchRequest {
+    /// The search query (exact terms, regex pattern, or phrase depending on mode flags)
+    pub query: String,
+
+    /// Treat `query` as a regex pattern (e.g., "fn \\w+_handler")
+    pub regex: Option<bool>,
+
+    /// Treat `query` as a phrase (tokens must appear in sequence, e.g., "fn new")
+    pub phrase: Option<bool>,
+
+    /// Maximum number of results to return (default: 20)
+    pub limit: Option<usize>,
+
+    /// Only return results from files matching this glob pattern.
+    /// v1 supports prefix/suffix patterns with `*` and `**` (e.g., "src/mcp/**", "**/*.rs")
+    pub file_glob: Option<String>,
+
+    /// Only return results from files of this language (e.g., "Rust", "Python", "TypeScript")
+    pub language: Option<String>,
+
+    /// Output format: "json" (structured) or "grep" (file:line:snippet). Default: "json"
+    pub format: Option<String>,
+}
+
+/// Search result item - returned by literal_search
+#[derive(Debug, Serialize)]
+pub struct LiteralSearchResultItem {
+    /// File path (relative to project root)
+    pub path: String,
+    /// Start line number
+    pub start_line: usize,
+    /// End line number
+    pub end_line: usize,
+    /// Code snippet (content of the matching chunk)
+    pub snippet: String,
+    /// BM25 relevance score
+    pub score: f32,
+    /// Kind of chunk (e.g., "function", "struct", "class")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// Signature (e.g., function signature) if available
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+}
+
 /// Find databases response
 #[derive(Debug, Serialize)]
 pub struct FindDatabasesResponse {


### PR DESCRIPTION
## Summary

Add `literal_search` MCP tool: FTS-only search with three modes (BM25, phrase, regex), file glob and language post-filters, and JSON/grep output formats. Does not require an embedding service.

## Changes

### src/fts/tantivy_store.rs
- Added `search_regex(&self, pattern, limit)` — uses Tantivy's `RegexQuery::from_pattern()` on the content field
- Added `search_phrase(&self, phrase, limit)` — tokenizes phrase, builds `PhraseQuery`; falls back to `TermQuery` for single-token phrases
- Added unit tests for both new methods

### src/mcp/types.rs
- Added `LiteralSearchRequest { query, regex, phrase, limit, file_glob, language, format }`
- Added `LiteralSearchResultItem { path, start_line, end_line, snippet, score, kind, signature }`

### src/mcp/mod.rs
- Added `literal_search` tool handler with three search modes:
  - `regex=true` → `search_regex` (regex pattern matching on tokenized terms)
  - `phrase=true` → `search_phrase` (exact phrase matching)
  - default → `search` (BM25 relevance scoring)
- Post-filters: `language` (via `Language::from_path().name()`), `file_glob` (via `simple_glob_match`)
- Output formats: `format="json"` (structured, default) or `format="grep"` (file:line:snippet)
- Does NOT call `get_embedding_service()` — FTS only, works without embedding model
- Added `simple_glob_match()` with support for `*` (within segment), `**` (cross-segment), and exact match
- Updated `get_info().instructions` with literal_search entry

## Validation

✅ `cargo build` (debug)
✅ `cargo test --all` (184 lib + 195 bin = all pass, 12 ignored for embedding)
✅ `cargo clippy` (no new warnings)
✅ `cargo fmt`

## Design Notes

- **No embedding required**: literal_search is purely FTS-based, making it useful when no embedding model is configured
- **Glob matching v1**: Simple implementation supporting common patterns without external dependencies
- **Regex limitation**: Tantivy's `SimpleTokenizer` splits on non-alphanumeric chars (including `_`), so regex patterns match individual tokenized terms, not raw text