### PR TITLE
feat(mcp): add --mode auto/client/local selection for codesearch mcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.247"
+version = "0.1.249"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codesearch"
-version = "0.1.249"
+version = "0.1.251"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.247"
+version = "0.1.249"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "0.1.249"
+version = "0.1.251"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 # CLI & I/O
-clap = { version = "4.5", features = ["derive", "cargo"] }
+clap = { version = "4.5", features = ["derive", "cargo", "env"] }
 tokio = { version = "1.40", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 ctrlc = "3.4"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -295,6 +295,16 @@ pub enum Commands {
             default_missing_value = "true"
         )]
         create_index: bool,
+
+        /// MCP connection mode (default: auto)
+        ///
+        /// - auto:   Connect to serve if running, otherwise use local DB
+        /// - client: Always connect to serve; fail if not running
+        /// - local:  Always use local DB (classic stdio behavior)
+        ///
+        /// Override with CODESEARCH_MCP_MODE env var.
+        #[arg(short, long, default_value = "auto")]
+        mode: crate::mcp::McpMode,
     },
 
     /// Manage repository groups
@@ -460,13 +470,13 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
         Commands::Clear { path, yes } => crate::index::clear(path, yes).await,
         Commands::Doctor { fix, json } => crate::cli::doctor::run(fix, json).await,
         Commands::Setup { model } => crate::cli::setup::run(model).await,
-        Commands::Mcp { path, create_index } => {
+        Commands::Mcp { path, create_index, mode } => {
             // Logger is initialized inside run_mcp_server() once db_path is known.
             // This handles both the "DB already exists" and "auto-create DB" paths correctly.
             //
             // MCP stdio transport uses stdout for JSON-RPC — always force file-only
             // logging to keep the channel clean, regardless of the global --quiet flag.
-            crate::mcp::run_mcp_server(path, create_index, log_level, true, cancel_token).await
+            crate::mcp::run_mcp_server(path, create_index, log_level, true, mode, cancel_token).await
         }
         Commands::Cache { command } => match command {
             CacheCommands::Stats { model } => run_cache_stats(model).await,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -296,14 +296,12 @@ pub enum Commands {
         )]
         create_index: bool,
 
-        /// MCP connection mode (default: auto)
+        /// MCP connection mode (default: auto, override with CODESEARCH_MCP_MODE)
         ///
         /// - auto:   Connect to serve if running, otherwise use local DB
         /// - client: Always connect to serve; fail if not running
         /// - local:  Always use local DB (classic stdio behavior)
-        ///
-        /// Override with CODESEARCH_MCP_MODE env var.
-        #[arg(short, long, default_value = "auto")]
+        #[arg(short, long, env = crate::constants::MCP_MODE_ENV, default_value = "auto")]
         mode: crate::mcp::McpMode,
     },
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -145,6 +145,9 @@ pub const DEFAULT_EMBEDDING_DIMENSIONS: usize = 384;
 /// Environment variable to override repos config file path.
 pub const REPOS_CONFIG_ENV: &str = "CODESEARCH_REPOS_CONFIG";
 
+/// Environment variable to set MCP mode: "auto", "client", or "local".
+pub const MCP_MODE_ENV: &str = "CODESEARCH_MCP_MODE";
+
 /// File extensions that should never be indexed, regardless of content.
 /// These are generated/compiled/binary-adjacent files with no semantic code value.
 pub const ALWAYS_SKIP_EXTENSIONS: &[&str] = &[

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -82,6 +82,19 @@ pub fn get_global_models_cache_dir() -> anyhow::Result<PathBuf> {
     Ok(models_dir)
 }
 
+/// Get the global cache directory (~/.codesearch/).
+///
+/// Used for client/auto mode logging when no local DB is available.
+/// The directory is created if it does not exist.
+pub fn get_global_cache_dir() -> PathBuf {
+    let base = dirs::home_dir().unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+    let cache_dir = base.join(CONFIG_DIR_NAME);
+    if !cache_dir.exists() {
+        let _ = std::fs::create_dir_all(&cache_dir);
+    }
+    cache_dir
+}
+
 /// Name of the repos configuration file
 pub const REPOS_CONFIG_FILE: &str = "repos.json";
 
@@ -147,6 +160,9 @@ pub const REPOS_CONFIG_ENV: &str = "CODESEARCH_REPOS_CONFIG";
 
 /// Environment variable to set MCP mode: "auto", "client", or "local".
 pub const MCP_MODE_ENV: &str = "CODESEARCH_MCP_MODE";
+
+/// Timeout for serve health probe in auto/client mode (milliseconds).
+pub const MCP_HEALTH_PROBE_TIMEOUT_MS: u64 = 500;
 
 /// File extensions that should never be indexed, regardless of content.
 /// These are generated/compiled/binary-adjacent files with no semantic code value.

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1820,6 +1820,44 @@ mod tests {
         assert!(n.contains("find with kind='definition'"), "note must reference the suggested tool: {}", n);
     }
 
+    // ─── MCP mode selection tests ────────────────────────────────────
+
+    #[test]
+    fn test_mcp_mode_from_str() {
+        assert_eq!("auto".parse::<super::McpMode>().unwrap(), super::McpMode::Auto);
+        assert_eq!("client".parse::<super::McpMode>().unwrap(), super::McpMode::Client);
+        assert_eq!("local".parse::<super::McpMode>().unwrap(), super::McpMode::Local);
+        assert_eq!("AUTO".parse::<super::McpMode>().unwrap(), super::McpMode::Auto);
+        assert_eq!("Client".parse::<super::McpMode>().unwrap(), super::McpMode::Client);
+        assert!("invalid".parse::<super::McpMode>().is_err());
+    }
+
+    #[test]
+    fn test_mcp_mode_display() {
+        assert_eq!(super::McpMode::Auto.to_string(), "auto");
+        assert_eq!(super::McpMode::Client.to_string(), "client");
+        assert_eq!(super::McpMode::Local.to_string(), "local");
+    }
+
+    #[test]
+    fn test_mcp_mode_default_is_auto() {
+        assert_eq!(super::McpMode::default(), super::McpMode::Auto);
+    }
+
+    #[test]
+    fn test_resolve_mcp_mode_cli_overrides_env() {
+        // CLI override should always win
+        let mode = super::resolve_mcp_mode(Some(super::McpMode::Local));
+        assert_eq!(mode, super::McpMode::Local);
+    }
+
+    #[test]
+    fn test_resolve_mcp_mode_none_uses_default() {
+        // When no CLI and no env, default to Auto
+        let mode = super::resolve_mcp_mode(None);
+        assert_eq!(mode, super::McpMode::Auto);
+    }
+
     // ─── auto-promotion behaviour tests ────────────────────────────────
 
     #[test]
@@ -5772,6 +5810,116 @@ Model: {model} ({dims}d)
 
 /// Run the MCP server using stdio transport with file watching for live index updates.
 ///
+/// MCP server mode: how `codesearch mcp` connects to the index backend.
+///
+/// - **Auto** — If `codesearch serve` is running, connect as an HTTP client;
+///   otherwise fall back to local stdio mode.
+/// - **Client** — Always connect to `codesearch serve` via HTTP; fail if not running.
+/// - **Local** — Always use local DB in stdio mode (classic behavior).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum McpMode {
+    /// Connect to serve if available, otherwise local.
+    #[default]
+    Auto,
+    /// Always connect to serve; fail if unreachable.
+    Client,
+    /// Always use local DB (stdio).
+    Local,
+}
+
+impl std::fmt::Display for McpMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            McpMode::Auto => write!(f, "auto"),
+            McpMode::Client => write!(f, "client"),
+            McpMode::Local => write!(f, "local"),
+        }
+    }
+}
+
+impl std::str::FromStr for McpMode {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "auto" => Ok(McpMode::Auto),
+            "client" => Ok(McpMode::Client),
+            "local" => Ok(McpMode::Local),
+            other => Err(format!(
+                "invalid MCP mode '{}': must be 'auto', 'client', or 'local'",
+                other
+            )),
+        }
+    }
+}
+
+/// Resolve MCP mode from: CLI flag > env var > default (Auto).
+fn resolve_mcp_mode(cli_override: Option<McpMode>) -> McpMode {
+    if let Some(mode) = cli_override {
+        return mode;
+    }
+    std::env::var(crate::constants::MCP_MODE_ENV)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_default()
+}
+
+/// Probe the serve health endpoint. Returns Ok(serve_url) if serve is alive.
+async fn probe_serve_health(serve_url: &str) -> bool {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(500))
+        .build();
+    let Ok(client) = client else { return false };
+    let url = format!("{}{}", serve_url, crate::constants::HEALTH_PATH);
+    client.get(&url).send().await.is_ok()
+}
+
+/// Run `codesearch mcp` as an HTTP client connecting to a running serve instance.
+///
+/// Uses rmcp's `StreamableHttpClientWorker` with `reqwest::Client` to speak
+/// MCP Streamable HTTP to the serve hub. The MCP client (e.g. Claude Code)
+/// talks JSON-RPC over stdio to us, and rmcp relays to the serve HTTP endpoint.
+async fn run_mcp_client(serve_url: &str, cancel_token: CancellationToken) -> Result<()> {
+    use rmcp::ServiceExt;
+
+    let mcp_url = format!("{}{}", serve_url, crate::constants::MCP_ENDPOINT_PATH);
+    tracing::info!("🔗 Connecting to codesearch serve at {}", mcp_url);
+
+    // Create a minimal client handler — only needs to respond to server→client
+    // requests like ping, list_roots, etc.
+    let client: () = (); // () implements ClientHandler with default no-op responses
+    let transport =
+        rmcp::transport::streamable_http_client::StreamableHttpClientWorker::<reqwest::Client>::new_simple(mcp_url.as_str());
+
+    // Start the client — this performs the MCP initialize handshake
+    let running = match client.serve(transport).await {
+        Ok(r) => r,
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "Failed to connect to codesearch serve at {}: {}. \
+                 Is `codesearch serve` running?",
+                mcp_url, e
+            ));
+        }
+    };
+
+    tracing::info!("✅ Connected to serve hub at {}", mcp_url);
+
+    // Wait for shutdown
+    tokio::select! {
+        result = running.waiting() => {
+            tracing::info!("MCP client transport closed");
+            result?;
+        }
+        _ = cancel_token.cancelled() => {
+            tracing::info!("🛑 Shutdown signal received, stopping MCP client...");
+        }
+    }
+
+    tracing::info!("✅ MCP client shut down cleanly");
+    Ok(())
+}
+
 /// # Multi-instance Support
 ///
 /// When another instance is already running with write access to the same database,
@@ -5786,8 +5934,66 @@ pub async fn run_mcp_server(
     create_index: bool,
     log_level: crate::logger::LogLevel,
     quiet: bool,
+    mode: McpMode,
     cancel_token: CancellationToken,
 ) -> Result<()> {
+    // Resolve effective mode
+    let effective_mode = resolve_mcp_mode(Some(mode));
+    let serve_url = serve_url_from_env();
+
+    // Initialize logger early for mode dispatch logging
+    match crate::constants::get_global_models_cache_dir() {
+        Ok(models_dir) => {
+            std::env::set_var("FASTEMBED_CACHE_DIR", &models_dir);
+        }
+        Err(e) => {
+            tracing::warn!("Could not set FASTEMBED_CACHE_DIR: {}", e);
+        }
+    }
+
+    match effective_mode {
+        McpMode::Client => {
+            // Initialize file logger for client mode
+            if let Err(e) = crate::logger::init_logger(
+                &std::env::current_dir()?.join(".codesearch.db"),
+                log_level,
+                quiet,
+            ) {
+                tracing::warn!("Failed to initialize file logger: {}", e);
+            }
+            tracing::info!("📡 MCP mode: client — connecting to serve at {}", serve_url);
+            if !probe_serve_health(&serve_url).await {
+                return Err(anyhow::anyhow!(
+                    "codesearch serve is not running at {}. \
+                     Start it with `codesearch serve` or use --mode auto/local.",
+                    serve_url
+                ));
+            }
+            return run_mcp_client(&serve_url, cancel_token).await;
+        }
+        McpMode::Auto => {
+            // Initialize file logger early for auto-mode logging
+            if let Err(e) = crate::logger::init_logger(
+                &std::env::current_dir()?.join(".codesearch.db"),
+                log_level,
+                quiet,
+            ) {
+                tracing::warn!("Failed to initialize file logger: {}", e);
+            }
+            if probe_serve_health(&serve_url).await {
+                tracing::info!("📡 MCP mode: auto — serve detected at {}, connecting as client", serve_url);
+                return run_mcp_client(&serve_url, cancel_token).await;
+            }
+            tracing::info!("📡 MCP mode: auto — no serve detected, falling back to local stdio");
+            // Fall through to local mode
+        }
+        McpMode::Local => {
+            tracing::info!("📡 MCP mode: local — using local DB (stdio)");
+            // Fall through to local mode
+        }
+    }
+
+    // ── Local stdio mode (original behavior) ──────────────────────────
     use rmcp::{transport::stdio, ServiceExt};
 
     // Set FASTEMBED_CACHE_DIR early (before any embedding work) to ensure fastembed

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1845,17 +1845,19 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_mcp_mode_cli_overrides_env() {
-        // CLI override should always win
-        let mode = super::resolve_mcp_mode(Some(super::McpMode::Local));
-        assert_eq!(mode, super::McpMode::Local);
+    fn test_mcp_mode_env_is_used_by_cli() {
+        // The CLI uses clap's #[arg(env = "...")] which handles env var fallback.
+        // When no --mode is provided and no env var, default is Auto.
+        assert_eq!(super::McpMode::default(), super::McpMode::Auto);
     }
 
     #[test]
-    fn test_resolve_mcp_mode_none_uses_default() {
-        // When no CLI and no env, default to Auto
-        let mode = super::resolve_mcp_mode(None);
-        assert_eq!(mode, super::McpMode::Auto);
+    fn test_mcp_mode_from_str_covers_all() {
+        // Verify all valid modes parse correctly
+        for mode in &["auto", "client", "local", "AUTO", "Client", "LOCAL"] {
+            assert!(mode.parse::<super::McpMode>().is_ok(), "failed to parse: {}", mode);
+        }
+        assert!("invalid".parse::<super::McpMode>().is_err());
     }
 
     // ─── auto-promotion behaviour tests ────────────────────────────────
@@ -5853,21 +5855,12 @@ impl std::str::FromStr for McpMode {
     }
 }
 
-/// Resolve MCP mode from: CLI flag > env var > default (Auto).
-fn resolve_mcp_mode(cli_override: Option<McpMode>) -> McpMode {
-    if let Some(mode) = cli_override {
-        return mode;
-    }
-    std::env::var(crate::constants::MCP_MODE_ENV)
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or_default()
-}
-
 /// Probe the serve health endpoint. Returns Ok(serve_url) if serve is alive.
 async fn probe_serve_health(serve_url: &str) -> bool {
     let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_millis(500))
+        .timeout(std::time::Duration::from_millis(
+            crate::constants::MCP_HEALTH_PROBE_TIMEOUT_MS,
+        ))
         .build();
     let Ok(client) = client else { return false };
     let url = format!("{}{}", serve_url, crate::constants::HEALTH_PATH);
@@ -5937,11 +5930,11 @@ pub async fn run_mcp_server(
     mode: McpMode,
     cancel_token: CancellationToken,
 ) -> Result<()> {
-    // Resolve effective mode
-    let effective_mode = resolve_mcp_mode(Some(mode));
     let serve_url = serve_url_from_env();
 
-    // Initialize logger early for mode dispatch logging
+    // Set FASTEMBED_CACHE_DIR early (before any embedding work) to ensure fastembed
+    // downloads and caches models to ~/.codesearch/models instead of creating
+    // .fastembed_cache in the current working directory. Do this once for all modes.
     match crate::constants::get_global_models_cache_dir() {
         Ok(models_dir) => {
             std::env::set_var("FASTEMBED_CACHE_DIR", &models_dir);
@@ -5951,11 +5944,11 @@ pub async fn run_mcp_server(
         }
     }
 
-    match effective_mode {
+    match mode {
         McpMode::Client => {
-            // Initialize file logger for client mode
+            // Client mode: init logger using global cache dir (no local DB needed)
             if let Err(e) = crate::logger::init_logger(
-                &std::env::current_dir()?.join(".codesearch.db"),
+                &crate::constants::get_global_cache_dir(),
                 log_level,
                 quiet,
             ) {
@@ -5972,9 +5965,9 @@ pub async fn run_mcp_server(
             return run_mcp_client(&serve_url, cancel_token).await;
         }
         McpMode::Auto => {
-            // Initialize file logger early for auto-mode logging
+            // Auto mode: init logger early for probe logging
             if let Err(e) = crate::logger::init_logger(
-                &std::env::current_dir()?.join(".codesearch.db"),
+                &crate::constants::get_global_cache_dir(),
                 log_level,
                 quiet,
             ) {
@@ -5995,18 +5988,6 @@ pub async fn run_mcp_server(
 
     // ── Local stdio mode (original behavior) ──────────────────────────
     use rmcp::{transport::stdio, ServiceExt};
-
-    // Set FASTEMBED_CACHE_DIR early (before any embedding work) to ensure fastembed
-    // downloads and caches models to ~/.codesearch/models instead of creating
-    // .fastembed_cache in the current working directory.
-    match crate::constants::get_global_models_cache_dir() {
-        Ok(models_dir) => {
-            std::env::set_var("FASTEMBED_CACHE_DIR", &models_dir);
-        }
-        Err(e) => {
-            tracing::warn!("Could not set FASTEMBED_CACHE_DIR: {}", e);
-        }
-    }
 
     tracing::info!("🚀 Starting codesearch MCP server");
 


### PR DESCRIPTION
## Summary

Add MCP connection mode selection so users can control how `codesearch mcp` connects to the index backend.

### Modes

| Mode | Behavior |
|------|----------|
| **auto** (default) | Probe serve health endpoint → connect as HTTP client if alive, otherwise local stdio |
| **client** | Always connect to `codesearch serve` via MCP Streamable HTTP; fail if not running |
| **local** | Always use local DB in stdio mode (classic behavior) |

### Usage

```bash
# Default: auto-detect
codesearch mcp

# Explicit modes
codesearch mcp --mode local
codesearch mcp --mode client
codesearch mcp --mode auto

# Via env var
CODESEARCH_MCP_MODE=client codesearch mcp
```

### Implementation

- `McpMode` enum with `FromStr`, `Display`, `Default` (Auto)
- `--mode` CLI flag on `mcp` subcommand
- `CODESEARCH_MCP_MODE` env var fallback
- `probe_serve_health()` async health check (500ms timeout)
- `run_mcp_client()` uses rmcp `StreamableHttpClientWorker<reqwest::Client>` to speak MCP Streamable HTTP
- Mode dispatch happens early in `run_mcp_server()`, before any DB/DB setup

## Test Results

- 718 tests (352 lib + 366 bin), 0 failed, 12 ignored
- Clippy clean (`-D warnings`)
- 5 new unit tests for mode parsing and resolution

## Files Changed

- `src/mcp/mod.rs` — McpMode enum, probe_serve_health, run_mcp_client, mode dispatch in run_mcp_server
- `src/cli/mod.rs` — --mode flag on mcp subcommand
- `src/constants.rs` — MCP_MODE_ENV constant