### PR TITLE
fix(serve): multi-repo quality fixes + proxy auto-reconnect + serve logging

### DIFF
--- a/AGENTS_fix-serve-multi-repo.md
+++ b/AGENTS_fix-serve-multi-repo.md
@@ -1,0 +1,465 @@
+# Fix: Multi-repo serve quality issues
+
+**Branch:** `feature/fix-serve-multi-repo`
+**Prioriteit:** Hoog — alle issues beïnvloeden dagelijks gebruik
+**Eigenaar:** OpenCode
+
+---
+
+## 1. Overzicht
+
+Vijf problemen geïdentificeerd na eerste multi-repo test op 2026-04-27:
+
+| # | Probleem | Ernst |
+|---|----------|-------|
+| 1 | Dubbele zoekresultaten (FTS dedup werkt niet op content) | Hoog |
+| 2 | `explore` path met project-alias prefix werkt niet | Medium |
+| 3 | File watchers starten simultaan, blokkeren elkaar | Hoog |
+| 4 | Alle repos laden tegelijk → LMDB map_full + memory spike | Hoog |
+| 5 | `repos.json` wordt niet automatisch gevuld bij eerste gebruik | Medium |
+
+Bewijs uit serve logs (2026-04-27T12:24):
+```
+INFO  Processing 436 changed files...
+INFO  Embedding 6612 chunks...
+WARN  MDB_MAP_FULL error in insert_chunks_with_ids(), resizing to 2048MB
+ERROR Initial refresh for 'BOIN.Aprimo.refactor' failed: an environment is already opened with different options
+```
+
+---
+
+## 2. Fix 1 — Dubbele resultaten in search (FTS + vector)
+
+### Root cause
+
+`search/mod.rs` dedupliceert op `chunk_id` (lijn ~657). Historische index-snapshots
+produceren nieuwe chunk_ids voor dezelfde content (zelfde path + start_line + end_line
+maar ander chunk_id). Die dubbels overleven de chunk_id-dedup en komen als
+aparte resultaten terug.
+
+`chunks_for_file` in `vectordb/store.rs` heeft al de correcte fix (dedup op
+`(start_line, end_line)`, hoogste chunk_id wint). Die logica ontbreekt in het
+search pad.
+
+### Fix
+
+In `src/search/mod.rs`, na het ophalen van resultaten maar voor het teruggeven:
+
+```rust
+// Bestaande dedup op chunk_id:
+if seen_exact_ids.insert(exact_match.chunk_id) { ... }
+
+// TOEVOEGEN: dedup op (path, start_line, end_line) — elimineert historische snapshots
+// die verschillende chunk_ids hebben maar identieke locatie.
+// Strategie: behoud hoogste chunk_id (meest recente snapshot).
+```
+
+Concrete implementatie:
+```rust
+// Na de chunk_id-dedup, voeg een tweede pass toe:
+let mut seen_locations: HashMap<(String, u32, u32), u64> = HashMap::new();
+// key = (path, start_line, end_line), value = chunk_id
+
+results.retain(|r| {
+    let key = (r.path.clone(), r.start_line, r.end_line);
+    match seen_locations.entry(key) {
+        Entry::Vacant(e) => { e.insert(r.chunk_id); true }
+        Entry::Occupied(mut e) => {
+            if r.chunk_id > *e.get() {
+                *e.get_mut() = r.chunk_id;
+                // verwijder eerder toegevoegd resultaat met lager chunk_id
+                // (dit vereist twee-pass of een sort-first aanpak)
+                false
+            } else {
+                false
+            }
+        }
+    }
+});
+```
+
+**Aanbevolen aanpak (eenvoudiger):** sort resultaten op chunk_id descending vóór
+dedup, dan is de eerste encounter altijd de meest recente:
+
+```rust
+results.sort_by(|a, b| b.chunk_id.cmp(&a.chunk_id));
+let mut seen_locations: HashSet<(String, u32, u32)> = HashSet::new();
+results.retain(|r| seen_locations.insert((r.path.clone(), r.start_line, r.end_line)));
+// Daarna re-sort op score voor output
+results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+```
+
+Dit geldt voor zowel literal als semantic search. Pas toe in alle zoekpaden die
+een `Vec<SearchResult>` produceren.
+
+### Locaties
+
+- `src/search/mod.rs` — literal search resultaten (rond lijn 649-660)
+- `src/search/mod.rs` — semantic/hybrid RRF resultaten (zelfde patroon)
+- Controleer ook `src/fts/tantivy_store.rs` of FTS zelf al op locatie dedupliceert
+
+---
+
+## 3. Fix 2 — `explore` path met project-alias prefix
+
+### Root cause
+
+`explore(target="HUSQ.Aprimo/src/...", project="HUSQ.Aprimo")` geeft geen resultaten.
+`explore(target="src/...", project="HUSQ.Aprimo")` werkt wel.
+
+Serve-logs bevestigen: beide calls worden ontvangen maar de eerste vindt geen chunks.
+De path matching in `chunks_for_file` vergelijkt het opgegeven target met de opgeslagen
+paden. In multi-repo mode slaat de index paden op met project-alias prefix
+(`HUSQ.Aprimo/src/...`). De explore handler strip die prefix niet.
+
+### Fix
+
+In de `explore` MCP handler (`src/mcp/mod.rs`), voor de `chunks_for_file` call:
+
+```rust
+// Strip project alias prefix als die aanwezig is in het target pad.
+// Bv. "HUSQ.Aprimo/src/foo.cs" met project="HUSQ.Aprimo" → "src/foo.cs"
+let normalized_target = if let Some(alias) = &request.project {
+    target.strip_prefix(&format!("{}/", alias))
+           .unwrap_or(&target)
+           .to_string()
+} else {
+    target
+};
+```
+
+Alternatief: strip altijd de eerste path-component als die overeenkomt met een
+bekende repo alias. Kies de eenvoudigste aanpak die de agent-UX verbetert.
+
+### Locatie
+
+`src/mcp/mod.rs` — explore tool handler
+
+---
+
+## 4. Fix 3 + 4 — Sequentiële FSW startup en geheugencontrole
+
+### Root cause (3)
+
+`codesearch serve` start voor alle geregistreerde repos tegelijk een `IndexManager`
+met file watcher. Als één repo 436 gewijzigde bestanden heeft en 6612 chunks
+moet embedden, blokkeert dat de initialisatie van alle volgende repos.
+
+### Root cause (4)
+
+Alle repos openen tegelijk hun LMDB environments. Als twee repos hun map_size
+anders initialiseren (bv. na een resize op de ene), krijgt de tweede een
+`already opened with different options` error omdat LMDB map-size globaal is
+per proces.
+
+Huidige logs:
+```
+WARN  MDB_MAP_FULL → resize to 2048MB (attempt 1/3)
+ERROR BOIN.Aprimo.refactor failed: already opened with different options
+```
+
+### Fix
+
+**Stap 1: Sequentiële initialisatie**
+
+In `src/serve/mod.rs`, vervang parallelle repo initialisatie door sequentieel:
+
+```rust
+// Was (conceptueel — alle repos tegelijk):
+let handles: Vec<_> = repos.iter().map(|r| tokio::spawn(init_repo(r))).collect();
+join_all(handles).await;
+
+// Wordt:
+for repo in &repos {
+    if let Err(e) = init_repo(repo).await {
+        tracing::error!("Failed to init {}: {}", repo.alias, e);
+        // Log en ga verder — één falende repo mag de rest niet blokkeren
+    }
+}
+```
+
+**Stap 2: Gestaffelde FSW startup**
+
+Na sequentiële init, voeg een kleine vertraging toe tussen het starten van elke
+file watcher (bv. 500ms) om burst I/O te vermijden:
+
+```rust
+for repo in &repos {
+    start_file_watcher(repo).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+}
+```
+
+**Stap 3: LMDB map-size consistentie**
+
+Zorg dat alle repos bij initialisatie dezelfde initiële map-size gebruiken
+(bv. altijd starten met `max(current_size, MIN_MAP_SIZE_MB)`). Als één repo
+al geresize heeft, moet de volgende repo dat kunnen detecteren via de LMDB
+info file voordat hij opent.
+
+Check `src/vectordb/store.rs` — LMDB open logica — en zorg dat map-size
+gelezen wordt uit de bestaande database voor hij geopend wordt.
+
+### Locaties
+
+- `src/serve/mod.rs` — repo initialisatie loop
+- `src/vectordb/store.rs` — LMDB open/resize logica
+
+---
+
+## 5. Fix 5 — Auto-discovery van repos.json bij eerste gebruik
+
+### Probleem
+
+Gebruikers die codesearch al hadden vóór multi-repo support (voor v1.0) hebben
+geen `repos.json`. Bij `codesearch serve` worden hun bestaande indexes niet
+gevonden.
+
+### Fix
+
+Bij `codesearch serve` opstarten, **vóór** het laden van `repos.json`:
+
+```rust
+fn ensure_repos_json_populated(repos_path: &Path) -> Result<()> {
+    let config = load_repos_json(repos_path)?;
+
+    if config.repos.is_empty() {
+        tracing::info!("repos.json is empty — scanning for existing indexes...");
+        let discovered = discover_codesearch_databases()?;
+        if !discovered.is_empty() {
+            tracing::info!("Found {} existing indexes, populating repos.json", discovered.len());
+            let mut updated = config;
+            for (alias, path) in discovered {
+                updated.repos.insert(alias, path);
+            }
+            save_repos_json(repos_path, &updated)?;
+        }
+    }
+    Ok(())
+}
+```
+
+`discover_codesearch_databases()` zoekt:
+1. Bekende standaard locaties: `~/source/repos/`, `~/WorkArea/`, `~/projects/`
+2. Huidige working directory en parents (git root detection)
+3. Elke directory met een `.codesearch.db` subdir
+
+Alias afleiding: gebruik de directory naam van de repo root.
+
+**Scope beperking:** scan maximaal 3 directory niveaus diep vanuit elke
+startlocatie. Geen volledige schijfscan.
+
+**Versie check (optioneel):** als de `repos.json` een versie veld heeft
+(`"version": 1`), kan de auto-discovery overgeslagen worden voor bestaande
+geconfigureerde setups.
+
+### Locatie
+
+- `src/serve/mod.rs` — opstartlogica
+- `src/db_discovery/mod.rs` — bestaande discovery module uitbreiden
+
+---
+
+## 6. Definition of Done
+
+- [ ] `cargo check --all-targets` clean
+- [ ] `cargo clippy --all-targets -- -D warnings` clean
+- [ ] `cargo test --lib` groen
+- [ ] Test: literal search op HUSQ.Aprimo geeft geen dubbele resultaten meer
+- [ ] Test: `explore(target="HUSQ.Aprimo/src/...", project="HUSQ.Aprimo")` werkt
+- [ ] Test: `codesearch serve` met 10+ repos start zonder LMDB errors
+- [ ] Test: `codesearch serve` op machine zonder repos.json ontdekt en vult auto
+- [ ] Test: `get_chunk(chunk_id=X, project="HUSQ.Aprimo")` geeft correct HUSQ chunk terug
+- [ ] Test: `get_chunk(chunk_id=X)` zonder project werkt nog (backwards compat)
+
+---
+
+## 9. Niet in scope
+
+- Globale chunk ID coordinatie (te complex, optie A is voldoende)
+- UI voor repos.json beheer
+
+---
+
+## 10. Fix 7 — `codesearch index --force` terwijl serve draait
+
+### Root cause
+
+`codesearch serve` houdt een `.writer.lock` én heeft LMDB/Tantivy bestanden
+memory-mapped open. `codesearch index --force` op een actieve serve-repo faalt
+om twee redenen:
+
+1. `is_database_locked()` detecteert de lock → valt terug naar readonly → kan niet schrijven
+2. Windows: memory-mapped files kunnen niet verwijderd worden → `--force` delete faalt met access denied
+
+Resultaat: gebruiker krijgt een cryptische fout of stille mislukking.
+
+### Fix — `index --force` delegeert naar serve via HTTP als serve actief is
+
+**Nieuwe serve endpoint:**
+
+```
+POST /repos/{alias}/reindex
+Body: { "force": true }
+Response: { "job_id": "uuid", "status": "started" }
+
+GET /repos/{alias}/reindex/{job_id}
+Response: { "status": "running"|"done"|"failed", "progress": "...", "error": null }
+```
+
+Serve voert de reindex intern uit:
+1. Pauzeer file watcher voor deze repo
+2. Release writer lock tijdelijk (close LMDB/Tantivy handles)
+3. Voer `index --force` uit op de repo path
+4. Heropen database met verse index
+5. Hervat file watcher
+
+Tijdens reindex: serve beantwoordt queries op deze repo met een tijdelijke error:
+`{ "error": "reindex in progress, retry in a moment" }`
+
+**`codesearch index --force` aanpassing:**
+
+```rust
+// In src/index/mod.rs, index_with_options():
+// Vóór de lock acquisitie, controleer of serve actief is voor deze repo.
+
+if force {
+    if let Some(serve_url) = detect_running_serve() {
+        if let Some(alias) = find_repo_alias_in_serve(&serve_url, &db_path).await? {
+            tracing::info!("codesearch serve is running — delegating --force reindex to serve");
+            return delegate_reindex_to_serve(&serve_url, &alias).await;
+        }
+    }
+    // Geen serve actief: normale --force rebuild
+}
+```
+
+`detect_running_serve()` doet een snelle GET `/health` op de standaard poort
+(39725). Als serve antwoordt, stuur de reindex opdracht door.
+
+`delegate_reindex_to_serve()` poll GET `/repos/{alias}/reindex/{job_id}` elke
+2 seconden en toont voortgang in de terminal totdat status `done` of `failed` is.
+
+### Gebruikservaring na fix
+
+```bash
+# Serve draait, gebruiker voert uit:
+$ codesearch index --force
+
+🔗 codesearch serve is running — delegating reindex to serve...
+⏳ Reindexing HUSQ.Aprimo (436 files)...
+📦 Embedding 6612 chunks...
+✅ Reindex complete (23.4s) — serve is using fresh index
+```
+
+### Locaties
+
+- `src/serve/mod.rs` — nieuw `/repos/{alias}/reindex` endpoint + job tracking
+- `src/index/mod.rs` — detect_running_serve + delegate logica vóór lock acquisitie
+- `src/constants.rs` — endpoint path constante `REINDEX_ENDPOINT_PATH`
+
+### Review-opmerkingen
+
+- Job tracking kan simpel in-memory zijn (HashMap<Uuid, ReindexJob>) —
+  geen persistentie nodig want reindex duurt zelden langer dan de serve uptime
+- Concurrent reindex requests voor dezelfde alias afwijzen met 409 Conflict
+- Als serve tijdens reindex crasht, is de repo mogelijk in inconsistente staat.
+  Mitigatie: werk op een tijdelijke database copy, swap atomisch na voltooiing.
+  Dit is optioneel voor v1 maar aanbevolen voor v2.
+
+---
+
+## 11. Definitief Definition of Done
+
+### Root cause
+
+Chunk IDs zijn uniek per database maar niet globaal. In serve_hub mode:
+```
+search(project="HUSQ.Aprimo") → chunk_id 23246
+get_chunk(23246)               → serve zoekt eerste repo met dat id → BOIN.Aprimo ❌
+```
+
+### Fix — `project` parameter op `get_chunk` (optioneel, backwards compatible)
+
+In `src/mcp/mod.rs`, de `get_chunk` tool definitie:
+
+```rust
+#[derive(Deserialize, JsonSchema)]
+struct GetChunkRequest {
+    chunk_id: u64,
+    context_lines: Option<u32>,
+    // NIEUW: optionele project parameter voor multi-repo routing
+    project: Option<String>,
+}
+```
+
+In de handler: als `project` aanwezig is, route direct naar die repo's database.
+Als `project` afwezig is, gedraag zoals vandaag (eerste match — backwards compat).
+
+In de tool description toevoegen:
+```
+In multi-repo (serve) mode: always pass `project` to ensure the correct
+repository is queried. chunk_ids are local to each repository database.
+```
+
+Dit is de eenvoudigste fix en backwards compatible.
+
+### Migratiepad voor dubbels
+
+Een `codesearch index --force` op elke repo verwijdert alle historische snapshots
+en elimineert dubbele chunk IDs aan de bron. Dit is de aanbevolen migratie voor
+bestaande indexes vóór de upgrade naar multi-repo serve:
+
+```bash
+# Voor elke repo:
+codesearch index --force /path/to/repo
+```
+
+Fix 1 (dedup op locatie) blijft nuttig als vangnet maar is na een --force rebuild
+niet meer strikt noodzakelijk.
+
+### Locaties
+
+- `src/mcp/mod.rs` — get_chunk tool handler en request struct
+- `src/serve/mod.rs` — routing logica voor project-scoped chunk lookup
+
+---
+
+## 12. Definition of Done
+
+- [ ] `cargo check --all-targets` clean
+- [ ] `cargo clippy --all-targets -- -D warnings` clean
+- [ ] `cargo test --lib` groen
+- [ ] `cargo build --release` clean
+- [ ] Test: literal + semantic search op HUSQ.Aprimo geeft geen dubbele resultaten
+- [ ] Test: `explore(target="HUSQ.Aprimo/src/...", project="HUSQ.Aprimo")` werkt
+- [ ] Test: `codesearch serve` met 10+ repos start zonder LMDB errors
+- [ ] Test: `codesearch serve` op machine zonder repos.json ontdekt en vult auto
+- [ ] Test: `get_chunk(chunk_id=X, project="HUSQ.Aprimo")` geeft correct HUSQ chunk
+- [ ] Test: `get_chunk(chunk_id=X)` zonder project werkt nog (backwards compat)
+- [ ] Test: `codesearch index --force` terwijl serve draait → delegeert naar serve
+- [ ] Test: serve toont voortgang tijdens reindex, andere repos blijven beschikbaar
+
+---
+
+## 13. Niet in scope
+
+- Globale chunk ID coordinatie (te complex, optie A is voldoende)
+- UI voor repos.json beheer
+- Atomische database swap bij reindex crash (v2)
+
+---
+
+## 14. Commit message voorstel
+
+```
+fix(serve): multi-repo quality — dedup, explore paths, sequential init,
+           auto-discovery, get_chunk routing, reindex delegation
+
+1. search: dedup on (path, start_line, end_line) — kills historical snapshot dupes
+2. explore: strip project-alias prefix from target path
+3. serve: sequential FSW startup, LMDB map-size consistency
+4. serve: auto-discover .codesearch.db on empty repos.json
+5. get_chunk: optional project param for multi-repo routing
+6. index --force: detect running serve and delegate via POST /repos/{alias}/reindex
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.24"
+version = "1.0.25"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.22"
+version = "1.0.23"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.12"
+version = "1.0.14"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.20"
+version = "1.0.22"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.28"
+version = "1.0.29"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.26"
+version = "1.0.28"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.14"
+version = "1.0.16"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.23"
+version = "1.0.24"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.28"
+version = "1.0.29"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.11"
+version = "1.0.12"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.12"
+version = "1.0.14"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.16"
+version = "1.0.17"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.22"
+version = "1.0.23"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.20"
+version = "1.0.22"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.26"
+version = "1.0.28"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.24"
+version = "1.0.25"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.14"
+version = "1.0.16"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.29"
+version = "1.0.30"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.9"
+version = "1.0.10"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.18"
+version = "1.0.19"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.19"
+version = "1.0.20"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.23"
+version = "1.0.24"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.25"
+version = "1.0.26"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.17"
+version = "1.0.18"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ The solution: run `codesearch serve` as a persistent background process that hol
 
 This also unlocks **multi-repo search**: a single serve instance manages multiple projects, and agents can search across all of them in one call using groups.
 
+### Auto-reconnect (Claude Desktop proxy)
+
+When `codesearch serve` is restarted (update, config change, crash), the MCP proxy does **not** exit. Instead:
+
+```
+  serve stops  ──▶  proxy detects disconnect
+                    ├── clears peer (tool calls return "reconnecting")
+                    ├── retries every 3 seconds
+                    ├── serve comes back ──▶  hot-swap peer ──▶ tools work instantly
+                    └── no serve after 5 min ──▶ clean exit (Claude Desktop detects EOF)
+```
+
+Claude Desktop's stdio connection stays alive throughout. Tool calls during the reconnect window return a descriptive error that Claude will retry automatically. No manual intervention needed for a simple serve restart.
+
 ### MCP Mode Selection
 
 `codesearch mcp` accepts a `--mode` flag:
@@ -364,6 +378,7 @@ codesearch setup --model jina-code
 |---|---|
 | "No database found" | Run `codesearch index` in your project directory |
 | Claude Desktop times out on connect | Make sure `codesearch serve` is running before starting Claude Desktop |
+| "codesearch serve is reconnecting" error | Transient — serve was restarted and the proxy is reconnecting (up to 5 min). No action needed. |
 | serve not finding a repo | Check `repos.json` with `codesearch index list`; re-register with `codesearch index add` |
 | Search results stale after branch switch | File watcher handles this automatically; check serve logs if it doesn't |
 | Port conflict | `codesearch serve --port 8080` or set `CODESEARCH_SERVE_PORT=8080` |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -453,15 +453,15 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
             quiet,
             verbose,
         } => {
-            // Initialize logger for serve mode
-            // NOTE: For Serve, tracing is NOT initialized in main.rs — init_logger
-            // is the first and only call to set the global subscriber
-            if let Ok(Some(db_info)) =
-                crate::db_discovery::find_best_database(None as Option<&std::path::Path>)
+            // Initialize serve logger — always logs to ~/.codesearch/logs/serve.log.YYYY-MM-DD
+            // regardless of whether a database exists in the current directory.
+            // This is a central log for the multi-repo serve process, separate from
+            // per-database logs written by the MCP client (codesearch.log.YYYY-MM-DD).
+            let effective_quiet = (cli.quiet || quiet) && !verbose;
+            if let Err(e) =
+                crate::logger::init_serve_logger(log_level, effective_quiet)
             {
-                // Combine global --quiet with serve-specific --quiet, and allow --verbose to override
-                let effective_quiet = (cli.quiet || quiet) && !verbose;
-                let _ = crate::logger::init_logger(&db_info.db_path, log_level, effective_quiet);
+                eprintln!("Warning: failed to initialize serve logger: {}", e);
             }
             crate::serve::run_serve(port, register, cancel_token.clone()).await
         }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -50,6 +50,9 @@ pub const LOG_DIR_NAME: &str = "logs";
 /// Default log file name
 pub const LOG_FILE_NAME: &str = "codesearch.log";
 
+/// Serve-specific log file name (written to ~/.codesearch/logs/)
+pub const SERVE_LOG_FILE_NAME: &str = "serve.log";
+
 /// Default number of log files to retain
 pub const DEFAULT_LOG_MAX_FILES: usize = 5;
 

--- a/src/db_discovery/repos.rs
+++ b/src/db_discovery/repos.rs
@@ -136,6 +136,28 @@ impl ReposConfig {
         true
     }
 
+    /// Auto-discover repos when the config is empty.
+    ///
+    /// Scans the current working directory for a `.codesearch.db` database.
+    /// If found and the repo list is empty, registers the CWD as a repo.
+    /// Returns the number of newly discovered repos (0 or 1).
+    pub fn auto_discover_from_cwd(&mut self) -> usize {
+        if !self.repos.is_empty() {
+            return 0;
+        }
+
+        let cwd = std::env::current_dir().unwrap_or_default();
+        let db_path = cwd.join(crate::constants::DB_DIR_NAME);
+
+        if crate::db_discovery::is_valid_database(&db_path) {
+            let alias = self.register(cwd);
+            tracing::info!("🔍 Auto-discovered repo '{}' from CWD", alias);
+            return 1;
+        }
+
+        0
+    }
+
     pub fn unregister_path(&mut self, path: &Path) -> bool {
         let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
         let to_remove = self

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -624,51 +624,78 @@ impl IndexManager {
         stores: &SharedStores,
     ) -> Result<()> {
         use crate::cache::FileMetaStore;
+        use anyhow::Context;
 
         info!("🔄 Force reindex: clearing all store data in-place...");
 
-        // 1. Clear vector store (LMDB databases)
+        // ── Step 0: Read and preserve metadata BEFORE clearing anything ──
+        // This is defensive: the DB may be incomplete (no metadata.json at all),
+        // or clear() may indirectly remove it. We preserve model info so we can
+        // write it back before the reindex starts.
+        let metadata_path = db_path.join("metadata.json");
+        let preserved_metadata: serde_json::Value = if metadata_path.exists() {
+            let content = std::fs::read_to_string(&metadata_path)
+                .with_context(|| format!("Failed to read {}", metadata_path.display()))?;
+            serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {}", metadata_path.display()))?
+        } else {
+            warn!(
+                "⚠️  No metadata.json found in {} — using defaults for force reindex",
+                db_path.display()
+            );
+            serde_json::json!({
+                "model_short_name": "minilm-l6-q",
+                "model_name": "all-MiniLM-L6-v2-q",
+                "dimensions": 384,
+            })
+        };
+        let model_name = preserved_metadata
+            .get("model_short_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("minilm-l6-q")
+            .to_string();
+        let dimensions = preserved_metadata
+            .get("dimensions")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(384) as usize;
+
+        // ── Step 1: Clear vector store (LMDB databases) ──
         {
             let mut vstore = stores.vector_store.write().await;
             vstore.clear()?;
         }
 
-        // 2. Clear full-text search store (Tantivy index)
+        // ── Step 2: Clear full-text search store (Tantivy index) ──
         {
             let mut fts = stores.fts_store.write().await;
             fts.clear()?;
         }
 
-        // 3. Clear file metadata so every file is treated as new
+        // ── Step 3: Clear file metadata so every file is treated as new ──
         {
-            let metadata_path = db_path.join("metadata.json");
-            let model_name = if metadata_path.exists() {
-                let content = std::fs::read_to_string(&metadata_path)?;
-                let json: serde_json::Value = serde_json::from_str(&content)?;
-                json.get("model_short_name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("minilm-l6-q")
-                    .to_string()
-            } else {
-                "minilm-l6-q".to_string()
-            };
-            let dimensions = if metadata_path.exists() {
-                let content = std::fs::read_to_string(&metadata_path)?;
-                let json: serde_json::Value = serde_json::from_str(&content)?;
-                json.get("dimensions")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(384) as usize
-            } else {
-                384
-            };
             let mut file_meta = FileMetaStore::load_or_create(db_path, &model_name, dimensions)?;
             file_meta.clear();
             file_meta.save(db_path)?;
         }
 
-        info!("✅ Stores cleared. Starting full reindex...");
+        // ── Step 4: Ensure metadata.json exists before reindex ──
+        // perform_incremental_refresh_with_stores() hard-fails without it.
+        // Write back the preserved metadata (with updated timestamp).
+        {
+            let mut metadata_to_write = preserved_metadata.clone();
+            metadata_to_write["indexed_at"] = serde_json::Value::String(
+                chrono::Utc::now().to_rfc3339(),
+            );
+            std::fs::write(
+                &metadata_path,
+                serde_json::to_string_pretty(&metadata_to_write)?,
+            )
+            .with_context(|| format!("Failed to write {}", metadata_path.display()))?;
+        }
 
-        // 4. Reindex — all files will be treated as "changed" since metadata is empty
+        info!("✅ Stores cleared, metadata preserved. Starting full reindex...");
+
+        // ── Step 5: Reindex — all files treated as "changed" since metadata is empty ──
         Self::perform_incremental_refresh_with_stores(codebase_path, db_path, stores).await
     }
 

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -610,6 +610,68 @@ impl IndexManager {
         Ok(())
     }
 
+    /// Force a full reindex using the already-open stores.
+    ///
+    /// Instead of closing and deleting the LMDB database (which fails on Windows
+    /// when another process holds the memory-mapped file), this:
+    /// 1. Clears all data from VectorStore, FtsStore, and FileMetaStore in-place
+    /// 2. Reindexes every file from scratch using the existing store handles
+    ///
+    /// No files are deleted, so there is no OS error 32 (file in use).
+    pub async fn force_reindex_with_stores(
+        codebase_path: &Path,
+        db_path: &Path,
+        stores: &SharedStores,
+    ) -> Result<()> {
+        use crate::cache::FileMetaStore;
+
+        info!("🔄 Force reindex: clearing all store data in-place...");
+
+        // 1. Clear vector store (LMDB databases)
+        {
+            let mut vstore = stores.vector_store.write().await;
+            vstore.clear()?;
+        }
+
+        // 2. Clear full-text search store (Tantivy index)
+        {
+            let mut fts = stores.fts_store.write().await;
+            fts.clear()?;
+        }
+
+        // 3. Clear file metadata so every file is treated as new
+        {
+            let metadata_path = db_path.join("metadata.json");
+            let model_name = if metadata_path.exists() {
+                let content = std::fs::read_to_string(&metadata_path)?;
+                let json: serde_json::Value = serde_json::from_str(&content)?;
+                json.get("model_short_name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("minilm-l6-q")
+                    .to_string()
+            } else {
+                "minilm-l6-q".to_string()
+            };
+            let dimensions = if metadata_path.exists() {
+                let content = std::fs::read_to_string(&metadata_path)?;
+                let json: serde_json::Value = serde_json::from_str(&content)?;
+                json.get("dimensions")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(384) as usize
+            } else {
+                384
+            };
+            let mut file_meta = FileMetaStore::load_or_create(db_path, &model_name, dimensions)?;
+            file_meta.clear();
+            file_meta.save(db_path)?;
+        }
+
+        info!("✅ Stores cleared. Starting full reindex...");
+
+        // 4. Reindex — all files will be treated as "changed" since metadata is empty
+        Self::perform_incremental_refresh_with_stores(codebase_path, db_path, stores).await
+    }
+
     /// Start the file system watcher (begin collecting events) without starting the processing loop.
     ///
     /// Call this BEFORE a long-running operation (like incremental refresh) to capture

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -348,6 +348,24 @@ pub async fn index(
     model: Option<ModelType>,
     cancel_token: CancellationToken,
 ) -> Result<()> {
+    // When force=true, try to delegate to a running serve instance via HTTP.
+    // This avoids file-lock conflicts between CLI and serve holding the same LMDB.
+    if force && !dry_run {
+        if let Ok(alias_and_path) = try_delegate_reindex_to_serve(&path).await {
+            let (alias, project_path) = alias_and_path;
+            println!(
+                "{}",
+                format!(
+                    "🔄 Delegated reindex to running serve instance (alias: '{}', path: {})",
+                    alias,
+                    project_path.display()
+                )
+                .bright_cyan()
+            );
+            return Ok(());
+        }
+        // If delegation failed (serve not running), fall through to local indexing
+    }
     index_with_options(path, dry_run, force, global, model, false, cancel_token).await
 }
 
@@ -1394,4 +1412,76 @@ struct DbStats {
     chunk_count: usize,
     size_mb: f64,
     bloat_ratio: Option<f64>,
+}
+
+/// Try to delegate a reindex to a running serve instance.
+///
+/// Returns `Ok((alias, project_path))` if the serve accepted the reindex request.
+/// Returns `Err` if serve is not running or the alias could not be resolved.
+async fn try_delegate_reindex_to_serve(
+    path: &Option<PathBuf>,
+) -> std::result::Result<(String, PathBuf), ()> {
+    use crate::constants::{DEFAULT_SERVE_PORT, SERVE_PORT_ENV};
+
+    let port: u16 = std::env::var(SERVE_PORT_ENV)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_SERVE_PORT);
+
+    let base_url = format!("http://127.0.0.1:{}", port);
+
+    // 1. Health check — is serve running?
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+        .map_err(|_| ())?;
+
+    let health_resp = client
+        .get(format!("{}/health", base_url))
+        .send()
+        .await
+        .map_err(|_| ())?;
+
+    if !health_resp.status().is_success() {
+        return Err(());
+    }
+
+    // 2. Resolve the project path to an alias by loading repos config
+    let project_path = path
+        .as_ref()
+        .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+
+    let config = crate::db_discovery::repos::ReposConfig::load().map_err(|_| ())?;
+
+    // Find the alias for this path
+    let alias = config
+        .repos
+        .iter()
+        .find(|(_, p)| {
+            let canonical = p.canonicalize().unwrap_or_else(|_| (*p).clone());
+            canonical == project_path
+        })
+        .map(|(a, _)| a.clone())
+        .unwrap_or_else(|| {
+            // Fallback: use the directory name as alias
+            project_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("unknown")
+                .to_string()
+        });
+
+    // 3. POST /repos/{alias}/reindex
+    let reindex_resp = client
+        .post(format!("{}/repos/{}/reindex", base_url, alias))
+        .send()
+        .await
+        .map_err(|_| ())?;
+
+    if reindex_resp.status().is_success() {
+        Ok((alias, project_path))
+    } else {
+        Err(())
+    }
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -410,7 +410,7 @@ pub async fn index(
     // When force=true, try to delegate to a running serve instance via HTTP.
     // This avoids file-lock conflicts between CLI and serve holding the same LMDB.
     if force && !dry_run {
-        match try_delegate_reindex_to_serve(&path).await {
+        match try_delegate_reindex_to_serve(&path, force).await {
             Ok((alias, project_path)) => {
                 println!(
                     "{}",
@@ -1485,6 +1485,7 @@ struct DbStats {
 /// Returns `Err(reason)` with a human-readable reason if delegation failed.
 async fn try_delegate_reindex_to_serve(
     path: &Option<PathBuf>,
+    force: bool,
 ) -> std::result::Result<(String, PathBuf), String> {
     use crate::constants::{DEFAULT_SERVE_PORT, SERVE_PORT_ENV};
 
@@ -1554,9 +1555,14 @@ async fn try_delegate_reindex_to_serve(
                 .to_string()
         });
 
-    // 3. POST /repos/{alias}/reindex
+    // 3. POST /repos/{alias}/reindex[?force=true]
+    let url = if force {
+        format!("{}/repos/{}/reindex?force=true", base_url, alias)
+    } else {
+        format!("{}/repos/{}/reindex", base_url, alias)
+    };
     let reindex_resp = client
-        .post(format!("{}/repos/{}/reindex", base_url, alias))
+        .post(&url)
         .send()
         .await
         .map_err(|e| format!("reindex POST failed: {}", e))?;

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -66,7 +66,24 @@ fn get_db_path_smart(
                 )
                 .yellow()
             );
-            std::fs::remove_dir_all(&local_db)?;
+            std::fs::remove_dir_all(&local_db).map_err(|e| {
+                // On Windows, OS error 32 = "file in use by another process".
+                // This typically means 'codesearch serve' has the LMDB memory-mapped.
+                // The serve's /repos/{alias}/reindex endpoint should have been used instead.
+                #[cfg(target_os = "windows")]
+                if e.raw_os_error() == Some(32) {
+                    return anyhow::anyhow!(
+                        "Cannot delete database at {} — it is held open by another process \
+                        (likely 'codesearch serve').\n\
+                        Hint: 'codesearch index -f' automatically delegates to serve when it is \
+                        running. The delegation may have failed because this repo is not registered \
+                        in repos.json or the alias could not be resolved.\n\
+                        Run 'codesearch serve --register .' to register this repo, then retry.",
+                        local_db.display()
+                    );
+                }
+                anyhow::anyhow!("Failed to delete database at {}: {}", local_db.display(), e)
+            })?;
             // Wait for Windows to fully release file handles (memory-mapped files
             // from LMDB/tantivy may not be immediately released after deletion)
             std::thread::sleep(std::time::Duration::from_millis(1000));
@@ -1495,25 +1512,41 @@ async fn try_delegate_reindex_to_serve(
     }
 
     // 2. Resolve the project path to an alias by loading repos config
-    let project_path = path
-        .as_ref()
-        .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
+    let raw_project_path = path
+        .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+    // Canonicalize to resolve symlinks and normalize separators (incl. UNC on Windows)
+    let project_path = raw_project_path
+        .canonicalize()
+        .unwrap_or_else(|_| raw_project_path.clone());
 
     let config = crate::db_discovery::repos::ReposConfig::load()
         .map_err(|e| format!("cannot load repos.json: {}", e))?;
+
+    /// Normalize a path for comparison: canonicalize, then strip Windows UNC prefix
+    /// (`\\?\`) so that `\\?\C:\foo` and `C:\foo` compare equal.
+    fn normalize_for_cmp(p: &std::path::Path) -> String {
+        let canonical = p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+        let s = canonical.to_string_lossy().to_string();
+        // Strip Windows extended-length UNC prefix
+        let s = s.strip_prefix(r"\\?\").unwrap_or(&s).to_string();
+        s.to_lowercase()
+    }
+
+    let project_norm = normalize_for_cmp(&project_path);
 
     // Find the alias for this path
     let alias = config
         .repos
         .iter()
-        .find(|(_, p)| {
-            let canonical = p.canonicalize().unwrap_or_else(|_| (*p).clone());
-            canonical == project_path
-        })
+        .find(|(_, p)| normalize_for_cmp(p) == project_norm)
         .map(|(a, _)| a.clone())
         .unwrap_or_else(|| {
             // Fallback: use the directory name as alias
+            tracing::debug!(
+                "try_delegate_reindex: path '{}' not found in repos.json, using dir name as alias",
+                project_norm
+            );
             project_path
                 .file_name()
                 .and_then(|n| n.to_str())

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -50,50 +50,72 @@ fn get_db_path_smart(
             .unwrap_or_else(|_| PathBuf::from(project_path)),
     ));
 
-    // Step 1: Check if there's an existing database (local or global)
-    let existing_db = find_best_database(target)?;
-
-    // Step 2: Handle --force flag
+    // Step 1: Handle --force flag — delete databases
     if force {
-        if let Some(ref db_info) = existing_db {
-            // Safety check: only delete a database that is inside the project path.
-            // If find_best_database found a database in a parent directory or a
-            // globally-registered repo that is NOT the current project, refuse to
-            // delete it — that would destroy another project's index.
-            let db_project_normalized = normalize_path(&db_info.project_path);
-            let canonical_path_str = normalize_path(&canonical_path);
-            let db_is_for_this_project = db_project_normalized == canonical_path_str
-                || canonical_path.as_path().starts_with(Path::new(&*db_project_normalized));
-
-            if !db_is_for_this_project {
-                anyhow::bail!(
-                    "Found database at {} for project '{}', but you are indexing '{}'. \
-                     Cowardly refusing to delete another project's database. \
-                     If the database is stale, delete it manually or run from the correct directory.",
-                    db_info.db_path.display(),
-                    db_project_normalized,
-                    canonical_path_str
-                );
-            }
-
-            // Delete existing database (local or global)
+        // 1a. First, check for a database directly in the project directory.
+        //     This catches incomplete/corrupt databases that find_best_database
+        //     would skip (it only returns valid databases).
+        //     We always delete the local DB when --force is used from its own directory.
+        let local_db = canonical_path.join(crate::constants::DB_DIR_NAME);
+        if local_db.is_dir() {
             println!(
                 "{}",
                 format!(
                     "🗑️  Force rebuild: deleting existing database at {}",
-                    db_info.db_path.display()
+                    local_db.display()
                 )
                 .yellow()
             );
-            std::fs::remove_dir_all(&db_info.db_path)?;
+            std::fs::remove_dir_all(&local_db)?;
             // Wait for Windows to fully release file handles (memory-mapped files
             // from LMDB/tantivy may not be immediately released after deletion)
-            // Increased to 1000ms to handle slow file handle release on Windows
             std::thread::sleep(std::time::Duration::from_millis(1000));
             println!("✅ Existing database deleted");
+        } else {
+            // 1b. No local DB — check if find_best_database found one elsewhere.
+            //     This handles --global or cases where the DB is in a parent dir.
+            let existing_db = find_best_database(target)?;
+            if let Some(ref db_info) = existing_db {
+                // Safety check: only delete a database that belongs to this project.
+                let db_project_normalized = normalize_path(&db_info.project_path);
+                let canonical_path_str = normalize_path(&canonical_path);
+                let db_is_for_this_project = db_project_normalized == canonical_path_str
+                    || canonical_path.as_path().starts_with(Path::new(&*db_project_normalized));
+
+                if !db_is_for_this_project {
+                    anyhow::bail!(
+                        "Found database at {} for project '{}', but you are indexing '{}'. \
+                         Cowardly refusing to delete another project's database. \
+                         If the database is stale, delete it manually or run from the correct directory.",
+                        db_info.db_path.display(),
+                        db_project_normalized,
+                        canonical_path_str
+                    );
+                }
+
+                println!(
+                    "{}",
+                    format!(
+                        "🗑️  Force rebuild: deleting existing database at {}",
+                        db_info.db_path.display()
+                    )
+                    .yellow()
+                );
+                std::fs::remove_dir_all(&db_info.db_path)?;
+                std::thread::sleep(std::time::Duration::from_millis(1000));
+                println!("✅ Existing database deleted");
+            }
         }
         // After deletion, continue to create new database
     }
+
+    // Step 2: Check if there's an existing database (for non-force paths)
+    let existing_db = if force {
+        // Already handled above — DB was deleted, no existing DB to find
+        None
+    } else {
+        find_best_database(target)?
+    };
 
     // Step 3: Handle --global flag
     if global {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -56,6 +56,26 @@ fn get_db_path_smart(
     // Step 2: Handle --force flag
     if force {
         if let Some(ref db_info) = existing_db {
+            // Safety check: only delete a database that is inside the project path.
+            // If find_best_database found a database in a parent directory or a
+            // globally-registered repo that is NOT the current project, refuse to
+            // delete it — that would destroy another project's index.
+            let db_project_normalized = normalize_path(&db_info.project_path);
+            let canonical_path_str = normalize_path(&canonical_path);
+            let db_is_for_this_project = db_project_normalized == canonical_path_str
+                || canonical_path.as_path().starts_with(Path::new(&*db_project_normalized));
+
+            if !db_is_for_this_project {
+                anyhow::bail!(
+                    "Found database at {} for project '{}', but you are indexing '{}'. \
+                     Cowardly refusing to delete another project's database. \
+                     If the database is stale, delete it manually or run from the correct directory.",
+                    db_info.db_path.display(),
+                    db_project_normalized,
+                    canonical_path_str
+                );
+            }
+
             // Delete existing database (local or global)
             println!(
                 "{}",
@@ -351,20 +371,26 @@ pub async fn index(
     // When force=true, try to delegate to a running serve instance via HTTP.
     // This avoids file-lock conflicts between CLI and serve holding the same LMDB.
     if force && !dry_run {
-        if let Ok(alias_and_path) = try_delegate_reindex_to_serve(&path).await {
-            let (alias, project_path) = alias_and_path;
-            println!(
-                "{}",
-                format!(
-                    "🔄 Delegated reindex to running serve instance (alias: '{}', path: {})",
-                    alias,
-                    project_path.display()
-                )
-                .bright_cyan()
-            );
-            return Ok(());
+        match try_delegate_reindex_to_serve(&path).await {
+            Ok((alias, project_path)) => {
+                println!(
+                    "{}",
+                    format!(
+                        "🔄 Delegated reindex to running serve instance (alias: '{}', path: {})",
+                        alias,
+                        project_path.display()
+                    )
+                    .bright_cyan()
+                );
+                return Ok(());
+            }
+            Err(reason) => {
+                debug!(
+                    "Could not delegate reindex to serve (falling back to local): {}",
+                    reason
+                );
+            }
         }
-        // If delegation failed (serve not running), fall through to local indexing
     }
     index_with_options(path, dry_run, force, global, model, false, cancel_token).await
 }
@@ -1417,10 +1443,10 @@ struct DbStats {
 /// Try to delegate a reindex to a running serve instance.
 ///
 /// Returns `Ok((alias, project_path))` if the serve accepted the reindex request.
-/// Returns `Err` if serve is not running or the alias could not be resolved.
+/// Returns `Err(reason)` with a human-readable reason if delegation failed.
 async fn try_delegate_reindex_to_serve(
     path: &Option<PathBuf>,
-) -> std::result::Result<(String, PathBuf), ()> {
+) -> std::result::Result<(String, PathBuf), String> {
     use crate::constants::{DEFAULT_SERVE_PORT, SERVE_PORT_ENV};
 
     let port: u16 = std::env::var(SERVE_PORT_ENV)
@@ -1434,16 +1460,16 @@ async fn try_delegate_reindex_to_serve(
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
         .build()
-        .map_err(|_| ())?;
+        .map_err(|e| format!("failed to build HTTP client: {}", e))?;
 
     let health_resp = client
         .get(format!("{}/health", base_url))
         .send()
         .await
-        .map_err(|_| ())?;
+        .map_err(|e| format!("serve not reachable at {} ({}). Is 'codesearch serve' running?", base_url, e))?;
 
     if !health_resp.status().is_success() {
-        return Err(());
+        return Err(format!("serve health check returned {}", health_resp.status()));
     }
 
     // 2. Resolve the project path to an alias by loading repos config
@@ -1452,7 +1478,8 @@ async fn try_delegate_reindex_to_serve(
         .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
-    let config = crate::db_discovery::repos::ReposConfig::load().map_err(|_| ())?;
+    let config = crate::db_discovery::repos::ReposConfig::load()
+        .map_err(|e| format!("cannot load repos.json: {}", e))?;
 
     // Find the alias for this path
     let alias = config
@@ -1477,11 +1504,13 @@ async fn try_delegate_reindex_to_serve(
         .post(format!("{}/repos/{}/reindex", base_url, alias))
         .send()
         .await
-        .map_err(|_| ())?;
+        .map_err(|e| format!("reindex POST failed: {}", e))?;
 
     if reindex_resp.status().is_success() {
         Ok((alias, project_path))
     } else {
-        Err(())
+        let status = reindex_resp.status();
+        let body = reindex_resp.text().await.unwrap_or_default();
+        Err(format!("serve returned {} for alias '{}': {}", status, alias, body))
     }
 }

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -19,6 +19,7 @@ use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, Env
 
 use crate::constants::{
     DEFAULT_LOG_MAX_FILES, DEFAULT_LOG_RETENTION_DAYS, LOG_DIR_NAME, LOG_FILE_NAME,
+    SERVE_LOG_FILE_NAME,
 };
 
 /// Result of logger initialization, indicating whether file logging is active
@@ -274,6 +275,92 @@ pub fn init_logger(db_path: &Path, log_level: LogLevel, quiet: bool) -> Result<L
 
     tracing::info!(
         "Logger initialized: level={}, log_dir={:?}, max_files={}, retention_days={}",
+        log_level.as_str(),
+        log_dir,
+        config.max_files,
+        config.retention_days,
+    );
+
+    Ok(LoggerInitResult::FileLogging)
+}
+
+/// Initialize the serve logger, writing to `~/.codesearch/logs/serve.log.YYYY-MM-DD`.
+///
+/// This is separate from the per-database logger used by `init_logger()`.
+/// The serve process manages multiple repos and has no single "home" database,
+/// so it logs to the global config directory instead.
+///
+/// When `quiet` is false, logs are written to both stderr and the rotating file.
+/// When `quiet` is true, logs go to the file only (useful when serve is daemonized).
+///
+/// # Returns
+/// Returns `LoggerInitResult` indicating whether file logging is active.
+pub fn init_serve_logger(log_level: LogLevel, quiet: bool) -> Result<LoggerInitResult> {
+    let log_dir = crate::constants::get_global_cache_dir().join(LOG_DIR_NAME);
+    ensure_log_dir(&log_dir)?;
+
+    let config = LogRotationConfig::from_env();
+
+    // Separate file name so serve logs don't mix with per-repo MCP client logs.
+    let file_appender =
+        RollingFileAppender::new(Rotation::DAILY, &log_dir, SERVE_LOG_FILE_NAME);
+
+    let filter_str = format!(
+        "{level},tantivy=warn,arroy=warn,ort=warn,h2=warn,hyper=warn,tower=warn",
+        level = log_level.as_str()
+    );
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&filter_str));
+
+    let subscriber = tracing_subscriber::registry().with(env_filter);
+
+    if quiet {
+        let result = subscriber
+            .with(
+                fmt::layer()
+                    .with_writer(file_appender)
+                    .with_ansi(false)
+                    .with_target(true)
+                    .with_thread_ids(false),
+            )
+            .try_init();
+
+        if let Err(e) = result {
+            eprintln!(
+                "Serve logger: subscriber already set ({}), file logging not active",
+                e
+            );
+            return Ok(LoggerInitResult::ConsoleOnly);
+        }
+    } else {
+        let result = subscriber
+            .with(
+                fmt::layer()
+                    .with_writer(std::io::stderr)
+                    .with_ansi(true)
+                    .with_target(true)
+                    .with_thread_ids(false),
+            )
+            .with(
+                fmt::layer()
+                    .with_writer(file_appender)
+                    .with_ansi(false)
+                    .with_target(true)
+                    .with_thread_ids(false),
+            )
+            .try_init();
+
+        if let Err(e) = result {
+            eprintln!(
+                "Serve logger: subscriber already set ({}), file logging not active",
+                e
+            );
+            return Ok(LoggerInitResult::ConsoleOnly);
+        }
+    }
+
+    tracing::info!(
+        "Serve logger initialized: level={}, log_dir={:?}, max_files={}, retention_days={}",
         log_level.as_str(),
         log_dir,
         config.max_files,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2079,7 +2079,7 @@ use rmcp::{
         CallToolRequestParams, CallToolResult, Content, Implementation, ListToolsResult, PaginatedRequestParams,
         ServerCapabilities, ServerInfo,
     },
-    service::{RequestContext, RunningService},
+    service::RequestContext,
     tool, tool_handler, tool_router, ErrorData as McpError, RoleClient, RoleServer, ServerHandler,
 };
 use std::collections::HashSet;
@@ -2094,7 +2094,7 @@ pub use types::*;
 // MCP Proxy Service  (--mode client / --mode auto with serve detected)
 // ═══════════════════════════════════════════════════════════════════
 
-/// Transparent stdio↔HTTP proxy.
+/// Transparent stdio↔HTTP proxy with automatic reconnect.
 ///
 /// When `codesearch mcp --mode client` is started by Claude Desktop:
 /// - Claude Desktop sends MCP requests over stdio
@@ -2107,16 +2107,33 @@ pub use types::*;
 ///
 /// Only tool operations (`list_tools`, `call_tool`) are forwarded. Prompts, resources,
 /// and completion are not proxied — the serve hub does not expose them.
+///
+/// ## Reconnect
+///
+/// The peer is wrapped in `Arc<RwLock<Option<Peer>>>` so it can be hot-swapped when the
+/// serve connection drops and reconnects. During reconnection, tool calls return a
+/// descriptive "reconnecting" error so Claude Desktop can retry.
 struct McpProxyService {
-    /// Clonable peer handle to the serve hub. `Peer` supports `list_tools` / `call_tool`
-    /// directly via the rmcp `method!` macro.
-    peer: rmcp::service::Peer<RoleClient>,
+    /// Shared peer handle — hot-swapped on reconnect.
+    /// `None` means we're reconnecting to serve; tool calls return a retry-able error.
+    peer: std::sync::Arc<tokio::sync::RwLock<Option<rmcp::service::Peer<RoleClient>>>>,
 }
 
 impl McpProxyService {
+    #[allow(dead_code)]
     fn new(peer: rmcp::service::Peer<RoleClient>) -> Self {
-        Self { peer }
+        Self {
+            peer: std::sync::Arc::new(tokio::sync::RwLock::new(Some(peer))),
+        }
     }
+}
+
+/// Reconnect-related constants for the MCP proxy.
+mod reconnect {
+    /// How long to wait between reconnect attempts.
+    pub const INTERVAL_SECS: u64 = 3;
+    /// Maximum total time to spend trying to reconnect before giving up.
+    pub const MAX_DURATION_SECS: u64 = 300; // 5 minutes
 }
 
 impl ServerHandler for McpProxyService {
@@ -2134,10 +2151,17 @@ impl ServerHandler for McpProxyService {
         request: Option<PaginatedRequestParams>,
         _cx: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
-        self.peer
-            .list_tools(request)
-            .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))
+        let peer = self.peer.read().await.clone();
+        match peer {
+            Some(p) => p
+                .list_tools(request)
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None)),
+            None => Err(McpError::internal_error(
+                "codesearch serve is reconnecting — please retry in a moment".to_string(),
+                None,
+            )),
+        }
     }
 
     async fn call_tool(
@@ -2145,10 +2169,17 @@ impl ServerHandler for McpProxyService {
         request: CallToolRequestParams,
         _cx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        self.peer
-            .call_tool(request)
-            .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))
+        let peer = self.peer.read().await.clone();
+        match peer {
+            Some(p) => p
+                .call_tool(request)
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None)),
+            None => Err(McpError::internal_error(
+                "codesearch serve is reconnecting — please retry in a moment".to_string(),
+                None,
+            )),
+        }
     }
 }
 
@@ -6079,64 +6110,167 @@ async fn probe_serve_health(serve_url: &str) -> bool {
 /// Every MCP request from Claude Desktop is forwarded verbatim to the serve hub and the
 /// response is returned unchanged. This allows Claude Desktop — which has no repo context
 /// of its own — to reach all repos managed by `codesearch serve`.
+///
+/// ## Reconnect behaviour
+///
+/// When `codesearch serve` goes away (restart, crash, network blip), the proxy does NOT
+/// exit. Instead it:
+/// 1. Keeps the stdio connection to Claude Desktop alive
+/// 2. Returns "reconnecting" errors for any incoming tool calls
+/// 3. Retries the HTTP connection every 3 seconds for up to 5 minutes
+/// 4. On success, hot-swaps the peer — tool calls resume immediately
+/// 5. After 5 minutes of failure, exits cleanly (Claude Desktop detects the disconnect)
 async fn run_mcp_client(serve_url: &str, cancel_token: CancellationToken) -> Result<()> {
     use rmcp::{ServiceExt, transport::stdio};
 
     let mcp_url = format!("{}{}", serve_url, crate::constants::MCP_ENDPOINT_PATH);
     tracing::info!("🔗 Connecting to codesearch serve at {}", mcp_url);
 
-    // Step 1: Establish HTTP MCP client connection to the serve hub.
-    // () implements ClientHandler with no-op responses to server→client requests (ping, etc.).
-    let transport = {
-        use rmcp::transport::streamable_http_client::{StreamableHttpClientTransportConfig, StreamableHttpClientWorker};
-        let config = StreamableHttpClientTransportConfig::with_uri(mcp_url.as_str());
-        StreamableHttpClientWorker::new(reqwest::Client::new(), config)
+    // Channels: spawned monitor tasks notify us when their connection drops.
+    let (disconnect_tx, mut disconnect_rx) = tokio::sync::mpsc::channel::<()>(1);
+    let (stdio_close_tx, mut stdio_close_rx) = tokio::sync::mpsc::channel::<()>(1);
+
+    // Shared peer state — hot-swapped on reconnect.
+    let peer_state: std::sync::Arc<tokio::sync::RwLock<Option<rmcp::service::Peer<RoleClient>>>> =
+        std::sync::Arc::new(tokio::sync::RwLock::new(None));
+
+    // Step 1: Start stdio proxy for Claude Desktop.
+    // This must happen first so Claude Desktop has something to talk to,
+    // even before the serve connection is established.
+    let proxy = McpProxyService {
+        peer: peer_state.clone(),
     };
-
-    let http_client: RunningService<RoleClient, ()> = match ().serve(transport).await {
-        Ok(c) => c,
-        Err(e) => {
-            return Err(anyhow::anyhow!(
-                "Failed to connect to codesearch serve at {}.\n\
-                 Error: {}\n\
-                 Is `codesearch serve` running?",
-                mcp_url, e
-            ));
-        }
-    };
-
-    tracing::info!("✅ Connected to codesearch serve hub");
-
-    // Step 2: Clone the Peer (cheap handle — Clonable) for the proxy.
-    // Keep the owned RunningService for .waiting() to detect serve disconnect.
-    let peer = http_client.peer().clone();
-    let proxy = McpProxyService::new(peer);
     let server = proxy
         .serve(stdio())
         .await
         .context("Failed to start proxy stdio server")?;
 
+    // Spawn a task that watches the stdio connection (takes ownership of server).
+    tokio::spawn(async move {
+        let _ = server.waiting().await;
+        let _ = stdio_close_tx.send(()).await;
+    });
+
+    // Step 2: Initial connection to serve (must succeed).
+    connect_to_serve(&mcp_url, &peer_state, disconnect_tx.clone()).await?;
     tracing::info!("🚀 MCP proxy ready — forwarding Claude Desktop ↔ codesearch serve");
 
-    // Step 3: Wait for any of: stdio close, serve disconnect, or cancel signal.
-    tokio::select! {
-        result = server.waiting() => {
-            tracing::info!("MCP proxy transport closed");
-            result?;
-        }
-        result = http_client.waiting() => {
-            // Do NOT propagate the error: returning Ok(()) causes codesearch to exit
-            // with code 0 (clean EOF on stdio) rather than crashing, so Claude Desktop
-            // gets a graceful server-closed signal instead of an unexpected disconnect
-            // that wipes the current chat context ("een stuk vd chat verdwijnt").
-            tracing::warn!("codesearch serve disconnected — exiting cleanly: {:?}", result);
-        }
-        _ = cancel_token.cancelled() => {
-            tracing::info!("🛑 Shutdown signal received, stopping MCP proxy...");
+    // Step 3: Main loop — wait for stdio close, serve disconnect, or cancel.
+    let mut serve_down_since: Option<std::time::Instant> = None;
+
+    loop {
+        tokio::select! {
+            biased; // Prefer clean shutdown paths over reconnect
+
+            // Claude Desktop closed stdio — we're done.
+            _ = stdio_close_rx.recv() => {
+                tracing::info!("MCP proxy transport closed");
+                return Ok(());
+            }
+
+            // External cancel signal (e.g. process termination).
+            _ = cancel_token.cancelled() => {
+                tracing::info!("🛑 Shutdown signal received, stopping MCP proxy...");
+                return Ok(());
+            }
+
+            // Serve disconnected — enter reconnect loop.
+            _ = disconnect_rx.recv() => {
+                // Clear peer so tool calls get "reconnecting" error.
+                {
+                    let mut p = peer_state.write().await;
+                    *p = None;
+                }
+
+                if serve_down_since.is_none() {
+                    serve_down_since = Some(std::time::Instant::now());
+                    tracing::warn!(
+                        "codesearch serve disconnected — will attempt reconnect every {}s for up to {}s",
+                        reconnect::INTERVAL_SECS,
+                        reconnect::MAX_DURATION_SECS,
+                    );
+                }
+
+                let elapsed = serve_down_since.unwrap().elapsed();
+                if elapsed.as_secs() > reconnect::MAX_DURATION_SECS {
+                    tracing::error!(
+                        "❌ Could not reconnect to serve after {}s — giving up",
+                        reconnect::MAX_DURATION_SECS
+                    );
+                    return Ok(()); // Clean exit so Claude Desktop gets graceful EOF
+                }
+
+                // Wait before retrying.
+                tokio::time::sleep(std::time::Duration::from_secs(reconnect::INTERVAL_SECS)).await;
+
+                match connect_to_serve(&mcp_url, &peer_state, disconnect_tx.clone()).await {
+                    Ok(()) => {
+                        tracing::info!(
+                            "✅ Reconnected to codesearch serve (was down for {:.0}s)",
+                            serve_down_since.unwrap().elapsed().as_secs()
+                        );
+                        serve_down_since = None;
+                    }
+                    Err(e) => {
+                        tracing::debug!("Reconnect attempt failed: {}", e);
+                        // Re-trigger ourselves: the disconnect_tx from the failed
+                        // connect_to_serve was never used, so we send a synthetic
+                        // disconnect to keep the loop going.
+                        let tx = disconnect_tx.clone();
+                        tokio::spawn(async move {
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                            let _ = tx.send(()).await;
+                        });
+                    }
+                }
+            }
         }
     }
+}
 
-    tracing::info!("✅ MCP proxy shut down cleanly");
+/// Establish (or re-establish) an HTTP MCP client connection to the serve hub.
+///
+/// On success, updates `peer_state` with the new peer and spawns a background task
+/// that monitors the connection and sends a message on `disconnect_tx` when it drops.
+async fn connect_to_serve(
+    mcp_url: &str,
+    peer_state: &std::sync::Arc<tokio::sync::RwLock<Option<rmcp::service::Peer<RoleClient>>>>,
+    disconnect_tx: tokio::sync::mpsc::Sender<()>,
+) -> Result<()> {
+    use rmcp::ServiceExt;
+
+    let transport = {
+        use rmcp::transport::streamable_http_client::{
+            StreamableHttpClientTransportConfig, StreamableHttpClientWorker,
+        };
+        let config = StreamableHttpClientTransportConfig::with_uri(mcp_url);
+        StreamableHttpClientWorker::new(reqwest::Client::new(), config)
+    };
+
+    let http_client: rmcp::service::RunningService<RoleClient, ()> =
+        ().serve(transport).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to connect to codesearch serve at {}.\n\
+                 Error: {}\n\
+                 Is `codesearch serve` running?",
+                mcp_url, e
+            )
+        })?;
+
+    // Update the shared peer.
+    let peer = http_client.peer().clone();
+    {
+        let mut p = peer_state.write().await;
+        *p = Some(peer);
+    }
+
+    // Spawn a monitor task that detects when the connection drops.
+    tokio::spawn(async move {
+        let _ = http_client.waiting().await;
+        // Connection lost — notify main loop.
+        let _ = disconnect_tx.send(()).await;
+    });
+
     Ok(())
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -4475,7 +4475,18 @@ impl CodesearchService {
         } else {
             self.project_path.clone()
         };
-        let normalized = normalize_tool_path(&request.path, &project_root);
+        // Strip project-alias prefix from target path if present.
+        // E.g. "HUSQ.Aprimo/src/foo.cs" with project="HUSQ.Aprimo" → "src/foo.cs"
+        let stripped_path = if let Some(ref alias) = ctx.project_alias {
+            let prefix = format!("{}/", alias);
+            match request.path.strip_prefix(&prefix) {
+                Some(rest) => rest.to_string(),
+                None => request.path.clone(),
+            }
+        } else {
+            request.path.clone()
+        };
+        let normalized = normalize_tool_path(&stripped_path, &project_root);
 
         let items = if let Some(ref sv) = ctx.stores_vec {
             // Multi-store group fan-out: collect outline items from all stores
@@ -4691,7 +4702,17 @@ impl CodesearchService {
         } else {
             self.project_path.clone()
         };
-        let normalized = normalize_tool_path(&request.path, &project_root);
+        // Strip project-alias prefix from target path if present.
+        let stripped_path = if let Some(ref alias) = ctx.project_alias {
+            let prefix = format!("{}/", alias);
+            match request.path.strip_prefix(&prefix) {
+                Some(rest) => rest.to_string(),
+                None => request.path.clone(),
+            }
+        } else {
+            request.path.clone()
+        };
+        let normalized = normalize_tool_path(&stripped_path, &project_root);
 
         let mut items = if let Some(ref sv) = ctx.stores_vec {
             // Multi-store group fan-out: collect import items from all stores

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2464,6 +2464,23 @@ fn normalize_tool_path(path: &str, project_root: &Path) -> String {
     crate::cache::normalize_path_str(resolved.to_string_lossy().as_ref())
 }
 
+/// Strip a project-alias prefix from a tool path.
+///
+/// In serve mode, tools like explore receive `target = "ALIAS/src/foo.rs"` with
+/// `project = "ALIAS"`.  The alias prefix must be stripped before calling
+/// `chunks_for_file`, which expects a path relative to the project root.
+fn strip_alias_prefix(path: &str, alias: Option<&String>) -> String {
+    if let Some(a) = alias {
+        let prefix = format!("{}/", a);
+        match path.strip_prefix(&prefix) {
+            Some(rest) => rest.to_string(),
+            None => path.to_string(),
+        }
+    } else {
+        path.to_string()
+    }
+}
+
 /// Prefix a result path with its repo alias for group queries, normalizing
 /// Windows backslashes to forward slashes in the process. When `alias` is
 /// None or empty, the path is still normalized (useful for stdio mode).
@@ -4477,15 +4494,7 @@ impl CodesearchService {
         };
         // Strip project-alias prefix from target path if present.
         // E.g. "HUSQ.Aprimo/src/foo.cs" with project="HUSQ.Aprimo" → "src/foo.cs"
-        let stripped_path = if let Some(ref alias) = ctx.project_alias {
-            let prefix = format!("{}/", alias);
-            match request.path.strip_prefix(&prefix) {
-                Some(rest) => rest.to_string(),
-                None => request.path.clone(),
-            }
-        } else {
-            request.path.clone()
-        };
+        let stripped_path = strip_alias_prefix(&request.path, ctx.project_alias.as_ref());
         let normalized = normalize_tool_path(&stripped_path, &project_root);
 
         let items = if let Some(ref sv) = ctx.stores_vec {
@@ -4703,15 +4712,7 @@ impl CodesearchService {
             self.project_path.clone()
         };
         // Strip project-alias prefix from target path if present.
-        let stripped_path = if let Some(ref alias) = ctx.project_alias {
-            let prefix = format!("{}/", alias);
-            match request.path.strip_prefix(&prefix) {
-                Some(rest) => rest.to_string(),
-                None => request.path.clone(),
-            }
-        } else {
-            request.path.clone()
-        };
+        let stripped_path = strip_alias_prefix(&request.path, ctx.project_alias.as_ref());
         let normalized = normalize_tool_path(&stripped_path, &project_root);
 
         let mut items = if let Some(ref sv) = ctx.stores_vec {

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -865,7 +865,26 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
         });
     }
 
-    // Truncate to max_results after reranking and filtering
+    // Deduplicate by (path, start_line, end_line) — eliminates historical
+    // index snapshots that share the same location but have different chunk_ids.
+    // Strategy: sort by chunk_id descending (newest first), retain first match.
+    results.sort_by(|a, b| b.id.cmp(&a.id));
+    {
+        let mut seen_locations: std::collections::HashSet<(String, usize, usize)> =
+            std::collections::HashSet::new();
+        results.retain(|r| {
+            let key = (r.path.clone(), r.start_line, r.end_line);
+            seen_locations.insert(key)
+        });
+    }
+    // Re-sort by score descending for output
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // Truncate to max_results after reranking, dedup, and filtering
     results.truncate(options.max_results);
 
     // Output results

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -164,6 +164,20 @@ impl ServeState {
         Ok(())
     }
 
+    /// Close and remove a repo from the open-stores map.
+    ///
+    /// Fires the cancel token (stops FSW/git-HEAD watcher) and drops the
+    /// RepoState, which releases the LMDB write lock and closes all file handles.
+    /// On Windows this is required before deleting the DB directory.
+    fn close_repo(&self, alias: &str) {
+        if let Some((_, state)) = self.repos.remove(alias) {
+            if let RepoState::Write { cancel_token, .. } = state {
+                cancel_token.cancel();
+            }
+            tracing::info!("Closed repo '{}' (released LMDB handles)", alias);
+        }
+    }
+
     /// Try to open a repo by alias. Returns a clone of the Arc<SharedStores>
     /// if successful, or an error string if conflicted/unknown.
     pub(crate) async fn get_or_open_stores(
@@ -406,13 +420,20 @@ async fn health_handler() -> AxumJson<serde_json::Value> {
 
 /// Reindex handler: POST /repos/{alias}/reindex
 ///
-/// Triggers an incremental refresh for the given repo alias.
+/// Query params:
+/// - `force=true` — close the repo, delete the DB, full reindex, reopen.
+///   Required when the caller wants a clean rebuild (e.g. `codesearch index -f`).
+///   Without force, performs an incremental refresh only.
+///
 /// Returns 202 Accepted immediately; the reindex runs in the background.
 async fn reindex_handler(
     axum::extract::Path(alias): axum::extract::Path<String>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
     axum::extract::State(state): axum::extract::State<Arc<ServeState>>,
 ) -> (axum::http::StatusCode, axum::response::Json<serde_json::Value>) {
     use axum::http::StatusCode;
+
+    let force = params.get("force").map(|v| v == "true" || v == "1").unwrap_or(false);
 
     // Resolve the project path for this alias
     let project_path = {
@@ -442,42 +463,77 @@ async fn reindex_handler(
         }
     };
 
-    // Ensure the repo is opened (lazy-open if needed)
-    let stores = match state.get_or_open_stores(&alias).await {
-        Ok(s) => s,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                axum::response::Json(json!({
-                    "error": e,
-                    "status": "error"
-                })),
-            );
-        }
-    };
-
     let db_path = project_path.join(DB_DIR_NAME);
-
-    // Clone alias for the background task before we use it in the response
     let alias_bg = alias.clone();
-    // Spawn the reindex in the background
-    tokio::spawn(async move {
-        tracing::info!("🔄 Reindex triggered for '{}' via HTTP API", alias_bg);
-        match IndexManager::perform_incremental_refresh_with_stores(
-            &project_path,
-            &db_path,
-            &stores,
-        )
-        .await
-        {
-            Ok(()) => {
-                tracing::info!("✅ Reindex complete for '{}'", alias_bg);
+
+    if force {
+        // Force rebuild: close → delete → full reindex → reopen
+        // Step 1: close the repo to release LMDB file handles
+        state.close_repo(&alias);
+
+        tokio::spawn(async move {
+            tracing::info!("🗑️  Force reindex for '{}': closing and deleting DB", alias_bg);
+
+            // Step 2: wait for Windows to release memory-mapped file handles
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+            // Step 3: delete the DB directory
+            if db_path.exists() {
+                if let Err(e) = std::fs::remove_dir_all(&db_path) {
+                    tracing::error!(
+                        "❌ Force reindex for '{}': failed to delete DB at {}: {}",
+                        alias_bg, db_path.display(), e
+                    );
+                    return;
+                }
+                tracing::info!("🗑️  Deleted DB at {} for '{}'", db_path.display(), alias_bg);
             }
+
+            // Step 4: full reindex from scratch
+            tracing::info!("🔄 Full reindex starting for '{}'", alias_bg);
+            match crate::index::index_quiet(Some(project_path), true, CancellationToken::new()).await {
+                Ok(()) => {
+                    tracing::info!("✅ Force reindex complete for '{}'", alias_bg);
+                }
+                Err(e) => {
+                    tracing::error!("❌ Force reindex failed for '{}': {}", alias_bg, e);
+                }
+            }
+            // Step 5: serve will lazy-reopen on next query (get_or_open_stores)
+        });
+    } else {
+        // Incremental refresh: ensure the repo is opened, then refresh
+        let stores = match state.get_or_open_stores(&alias).await {
+            Ok(s) => s,
             Err(e) => {
-                tracing::error!("❌ Reindex failed for '{}': {}", alias_bg, e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    axum::response::Json(json!({
+                        "error": e,
+                        "status": "error"
+                    })),
+                );
             }
-        }
-    });
+        };
+
+        tokio::spawn(async move {
+            tracing::info!("🔄 Incremental reindex triggered for '{}' via HTTP API", alias_bg);
+            match IndexManager::perform_incremental_refresh_with_stores(
+                &project_path,
+                &db_path,
+                &stores,
+            )
+            .await
+            {
+                Ok(()) => {
+                    tracing::info!("✅ Reindex complete for '{}'", alias_bg);
+                }
+                Err(e) => {
+                    tracing::error!("❌ Reindex failed for '{}': {}", alias_bg, e);
+                }
+            }
+        });
+    }
 
     (
         StatusCode::ACCEPTED,

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -459,6 +459,26 @@ pub async fn run_serve(
     );
     info!("📋 Registered repos: {:?}", serve_state.aliases());
 
+    // ── Sequential pre-warming ──
+    // Open all registered repos sequentially before accepting connections.
+    // This avoids burst I/O and LMDB "already opened with different options"
+    // errors when multiple repos are first queried concurrently.
+    {
+        let aliases = serve_state.aliases();
+        if !aliases.is_empty() {
+            info!("🔥 Pre-warming {} repos sequentially...", aliases.len());
+            for alias in &aliases {
+                match serve_state.get_or_open_stores(alias).await {
+                    Ok(_) => info!("  ✅ {} ready", alias),
+                    Err(e) => warn!("  ⚠️  {} failed: {}", alias, e),
+                }
+                // Small delay between repos to avoid I/O burst
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            }
+            info!("🔥 Pre-warming complete");
+        }
+    }
+
     // Create the MCP service factory — each session gets a fresh CodesearchService
     // that uses serve_state for repo routing.
     let state_for_factory = serve_state.clone();

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -448,6 +448,14 @@ pub async fn run_serve(
         config.save().context("Failed to save repos config")?;
     }
 
+    // Auto-discover: if config is empty, scan CWD for a database
+    let discovered = config.auto_discover_from_cwd();
+    if discovered > 0 {
+        if let Err(e) = config.save() {
+            warn!("Failed to save auto-discovered repos: {}", e);
+        }
+    }
+
     let serve_state = Arc::new(ServeState::new(config, None));
 
     // Log startup

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -404,6 +404,77 @@ async fn health_handler() -> AxumJson<serde_json::Value> {
     }))
 }
 
+/// Reindex handler: POST /repos/{alias}/reindex
+///
+/// Triggers an incremental refresh for the given repo alias.
+/// Returns 202 Accepted immediately; the reindex runs in the background.
+async fn reindex_handler(
+    axum::extract::Path(alias): axum::extract::Path<String>,
+    axum::extract::State(state): axum::extract::State<Arc<ServeState>>,
+) -> axum::response::Json<serde_json::Value> {
+    // Resolve the project path for this alias
+    let project_path = {
+        let config = match state.config.read() {
+            Ok(c) => c,
+            Err(e) => {
+                return axum::response::Json(json!({
+                    "error": format!("Config lock poisoned: {}", e),
+                    "status": "error"
+                }));
+            }
+        };
+        match config.resolve(&alias) {
+            Some(p) => p,
+            None => {
+                return axum::response::Json(json!({
+                    "error": format!("Unknown alias '{}'", alias),
+                    "status": "not_found"
+                }));
+            }
+        }
+    };
+
+    // Ensure the repo is opened (lazy-open if needed)
+    let stores = match state.get_or_open_stores(&alias).await {
+        Ok(s) => s,
+        Err(e) => {
+            return axum::response::Json(json!({
+                "error": e,
+                "status": "error"
+            }));
+        }
+    };
+
+    let db_path = project_path.join(DB_DIR_NAME);
+
+    // Clone alias for the background task before we use it in the response
+    let alias_bg = alias.clone();
+    // Spawn the reindex in the background
+    tokio::spawn(async move {
+        tracing::info!("🔄 Reindex triggered for '{}' via HTTP API", alias_bg);
+        match IndexManager::perform_incremental_refresh_with_stores(
+            &project_path,
+            &db_path,
+            &stores,
+        )
+        .await
+        {
+            Ok(()) => {
+                tracing::info!("✅ Reindex complete for '{}'", alias_bg);
+            }
+            Err(e) => {
+                tracing::error!("❌ Reindex failed for '{}': {}", alias_bg, e);
+            }
+        }
+    });
+
+    axum::response::Json(json!({
+        "status": "accepted",
+        "alias": alias,
+        "message": "Reindex started in background"
+    }))
+}
+
 /// Axum middleware: log MCP requests (method + path, skips /health spam).
 async fn log_mcp_requests(
     req: axum::extract::Request,
@@ -512,8 +583,10 @@ pub async fn run_serve(
     // Build axum router with request logging
     let app = axum::Router::new()
         .route(HEALTH_PATH, axum::routing::get(health_handler))
+        .route("/repos/{alias}/reindex", axum::routing::post(reindex_handler))
         .nest_service(MCP_ENDPOINT_PATH, mcp_service)
-        .layer(axum::middleware::from_fn(log_mcp_requests));
+        .layer(axum::middleware::from_fn(log_mcp_requests))
+        .with_state(serve_state.clone());
 
     // Graceful shutdown
     //

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -471,22 +471,62 @@ async fn reindex_handler(
         // Step 1: close the repo to release LMDB file handles
         state.close_repo(&alias);
 
+        // state was used above for close_repo; consume it here to prevent
+        // the async move closure from capturing (and unnecessarily holding) it.
+        // The ServeState must not stay alive in the spawned task because it
+        // keeps LMDB handles open for all OTHER repos.
+        drop(state);
+
         tokio::spawn(async move {
             tracing::info!("🗑️  Force reindex for '{}': closing and deleting DB", alias_bg);
 
-            // Step 2: wait for Windows to release memory-mapped file handles
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            // Step 2: give Windows time to release memory-mapped file handles.
+            //
+            // close_repo() removed the RepoState from the map, which drops
+            // SharedStores (and the LMDB Env). On Windows, the OS may hold
+            // the file handle open for a short but unpredictable period after
+            // the Rust drop completes. We retry with exponential backoff.
 
-            // Step 3: delete the DB directory
+            // Step 3: delete the DB directory (with retries for Windows)
             if db_path.exists() {
-                if let Err(e) = std::fs::remove_dir_all(&db_path) {
-                    tracing::error!(
-                        "❌ Force reindex for '{}': failed to delete DB at {}: {}",
-                        alias_bg, db_path.display(), e
-                    );
+                let mut retry_delay = std::time::Duration::from_millis(300);
+                let mut deleted = false;
+                for attempt in 0..6 {
+                    if attempt > 0 {
+                        tracing::info!(
+                            "⏳ Force reindex for '{}': retry {} delete after {}ms",
+                            alias_bg, attempt, retry_delay.as_millis()
+                        );
+                        tokio::time::sleep(retry_delay).await;
+                    }
+                    match std::fs::remove_dir_all(&db_path) {
+                        Ok(()) => {
+                            tracing::info!("🗑️  Deleted DB at {} for '{}'", db_path.display(), alias_bg);
+                            deleted = true;
+                            break;
+                        }
+                        Err(e) if e.raw_os_error() == Some(32) => {
+                            // OS error 32: file in use — retry with longer delay
+                            retry_delay = retry_delay.saturating_mul(2);
+                            if attempt == 5 {
+                                tracing::error!(
+                                    "❌ Force reindex for '{}': failed to delete DB at {} after {} retries: {}",
+                                    alias_bg, db_path.display(), attempt + 1, e
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "❌ Force reindex for '{}': failed to delete DB at {}: {}",
+                                alias_bg, db_path.display(), e
+                            );
+                            break;
+                        }
+                    }
+                }
+                if !deleted {
                     return;
                 }
-                tracing::info!("🗑️  Deleted DB at {} for '{}'", db_path.display(), alias_bg);
             }
 
             // Step 4: full reindex from scratch

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -653,7 +653,7 @@ pub async fn run_serve(
     // Build axum router with request logging
     let app = axum::Router::new()
         .route(HEALTH_PATH, axum::routing::get(health_handler))
-        .route("/repos/{alias}/reindex", axum::routing::post(reindex_handler))
+            .route("/repos/:alias/reindex", axum::routing::post(reindex_handler))
         .nest_service(MCP_ENDPOINT_PATH, mcp_service)
         .layer(axum::middleware::from_fn(log_mcp_requests))
         .with_state(serve_state.clone());
@@ -890,6 +890,66 @@ mod tests {
         let _ = state.aliases();
         let after_second = state.reload_count.load(std::sync::atomic::Ordering::SeqCst);
         assert_eq!(after_second, after_first);
+    }
+
+    /// Verify that the /repos/:alias/reindex route is registered and reachable.
+    /// This test starts a real axum server on a random port and sends a POST request.
+    #[tokio::test]
+    async fn reindex_route_is_registered() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("myrepo");
+        std::fs::create_dir(&repo_path).unwrap();
+
+        let mut config = ReposConfig::default();
+        config.register_with_alias(repo_path.clone(), Some("testalias".to_string())).unwrap();
+
+        let config_file = tmp.path().join("repos.json");
+        config.save_to(&config_file).unwrap();
+
+        let state = Arc::new(ServeState::new(config, Some(config_file)));
+
+        let app = axum::Router::new()
+            .route(crate::constants::HEALTH_PATH, axum::routing::get(health_handler))
+            .route("/repos/:alias/reindex", axum::routing::post(reindex_handler))
+            .with_state(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        // Give the server a moment to start
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let client = reqwest::Client::new();
+
+        // POST to unknown alias → 404 from our handler (not axum's built-in 404)
+        let resp = client
+            .post(format!("http://{}/repos/unknown/reindex", addr))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND, "expected 404 from our handler");
+        let body: serde_json::Value = resp.json().await.expect("handler should return JSON body for 404");
+        assert!(body.get("error").is_some(), "expected JSON error body, got: {}", body);
+
+        // POST to known alias → 202 Accepted or 500 (DB missing), but NOT axum's built-in 404
+        // The key assertion is that the route IS registered (we get our handler's response, not axum's empty 404)
+        let resp = client
+            .post(format!("http://{}/repos/testalias/reindex", addr))
+            .send()
+            .await
+            .unwrap();
+        let status = resp.status();
+        let body: serde_json::Value = resp.json().await.expect("handler should return JSON body");
+        assert!(
+            status == reqwest::StatusCode::ACCEPTED || status == reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            "expected 202 or 500 from our handler (not axum's 404), got {}: {}",
+            status, body
+        );
+        assert!(body.get("status").is_some(), "expected JSON with 'status' field, got: {}", body);
     }
 
     #[test]

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -168,7 +168,12 @@ impl ServeState {
     ///
     /// Fires the cancel token (stops FSW/git-HEAD watcher) and drops the
     /// RepoState, which releases the LMDB write lock and closes all file handles.
-    /// On Windows this is required before deleting the DB directory.
+    /// Close a repo and release its LMDB file handles.
+    ///
+    /// Removes the repo from the live map, dropping SharedStores and stopping
+    /// the file watcher. On Windows this is required before deleting the DB
+    /// directory. Not used by force reindex (which clears data in-place instead).
+    #[allow(dead_code)]
     fn close_repo(&self, alias: &str) {
         if let Some((_, state)) = self.repos.remove(alias) {
             if let RepoState::Write { cancel_token, .. } = state {
@@ -467,71 +472,33 @@ async fn reindex_handler(
     let alias_bg = alias.clone();
 
     if force {
-        // Force rebuild: close → delete → full reindex → reopen
-        // Step 1: close the repo to release LMDB file handles
-        state.close_repo(&alias);
+        // Force rebuild: clear data in-place → full reindex.
+        // No files are deleted, so no OS error 32 on Windows.
+        // The repo stays open throughout — LMDB handles remain valid.
 
-        // state was used above for close_repo; consume it here to prevent
-        // the async move closure from capturing (and unnecessarily holding) it.
-        // The ServeState must not stay alive in the spawned task because it
-        // keeps LMDB handles open for all OTHER repos.
-        drop(state);
+        let stores = match state.get_or_open_stores(&alias).await {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    axum::response::Json(json!({
+                        "error": e,
+                        "status": "error"
+                    })),
+                );
+            }
+        };
 
         tokio::spawn(async move {
-            tracing::info!("🗑️  Force reindex for '{}': closing and deleting DB", alias_bg);
+            tracing::info!("🔄 Force reindex for '{}': clearing stores and reindexing", alias_bg);
 
-            // Step 2: give Windows time to release memory-mapped file handles.
-            //
-            // close_repo() removed the RepoState from the map, which drops
-            // SharedStores (and the LMDB Env). On Windows, the OS may hold
-            // the file handle open for a short but unpredictable period after
-            // the Rust drop completes. We retry with exponential backoff.
-
-            // Step 3: delete the DB directory (with retries for Windows)
-            if db_path.exists() {
-                let mut retry_delay = std::time::Duration::from_millis(300);
-                let mut deleted = false;
-                for attempt in 0..6 {
-                    if attempt > 0 {
-                        tracing::info!(
-                            "⏳ Force reindex for '{}': retry {} delete after {}ms",
-                            alias_bg, attempt, retry_delay.as_millis()
-                        );
-                        tokio::time::sleep(retry_delay).await;
-                    }
-                    match std::fs::remove_dir_all(&db_path) {
-                        Ok(()) => {
-                            tracing::info!("🗑️  Deleted DB at {} for '{}'", db_path.display(), alias_bg);
-                            deleted = true;
-                            break;
-                        }
-                        Err(e) if e.raw_os_error() == Some(32) => {
-                            // OS error 32: file in use — retry with longer delay
-                            retry_delay = retry_delay.saturating_mul(2);
-                            if attempt == 5 {
-                                tracing::error!(
-                                    "❌ Force reindex for '{}': failed to delete DB at {} after {} retries: {}",
-                                    alias_bg, db_path.display(), attempt + 1, e
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "❌ Force reindex for '{}': failed to delete DB at {}: {}",
-                                alias_bg, db_path.display(), e
-                            );
-                            break;
-                        }
-                    }
-                }
-                if !deleted {
-                    return;
-                }
-            }
-
-            // Step 4: full reindex from scratch
-            tracing::info!("🔄 Full reindex starting for '{}'", alias_bg);
-            match crate::index::index_quiet(Some(project_path), true, CancellationToken::new()).await {
+            match IndexManager::force_reindex_with_stores(
+                &project_path,
+                &db_path,
+                &stores,
+            )
+            .await
+            {
                 Ok(()) => {
                     tracing::info!("✅ Force reindex complete for '{}'", alias_bg);
                 }
@@ -539,7 +506,6 @@ async fn reindex_handler(
                     tracing::error!("❌ Force reindex failed for '{}': {}", alias_bg, e);
                 }
             }
-            // Step 5: serve will lazy-reopen on next query (get_or_open_stores)
         });
     } else {
         // Incremental refresh: ensure the repo is opened, then refresh

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -411,25 +411,33 @@ async fn health_handler() -> AxumJson<serde_json::Value> {
 async fn reindex_handler(
     axum::extract::Path(alias): axum::extract::Path<String>,
     axum::extract::State(state): axum::extract::State<Arc<ServeState>>,
-) -> axum::response::Json<serde_json::Value> {
+) -> (axum::http::StatusCode, axum::response::Json<serde_json::Value>) {
+    use axum::http::StatusCode;
+
     // Resolve the project path for this alias
     let project_path = {
         let config = match state.config.read() {
             Ok(c) => c,
             Err(e) => {
-                return axum::response::Json(json!({
-                    "error": format!("Config lock poisoned: {}", e),
-                    "status": "error"
-                }));
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    axum::response::Json(json!({
+                        "error": format!("Config lock poisoned: {}", e),
+                        "status": "error"
+                    })),
+                );
             }
         };
         match config.resolve(&alias) {
             Some(p) => p,
             None => {
-                return axum::response::Json(json!({
-                    "error": format!("Unknown alias '{}'", alias),
-                    "status": "not_found"
-                }));
+                return (
+                    StatusCode::NOT_FOUND,
+                    axum::response::Json(json!({
+                        "error": format!("Unknown alias '{}'", alias),
+                        "status": "not_found"
+                    })),
+                );
             }
         }
     };
@@ -438,10 +446,13 @@ async fn reindex_handler(
     let stores = match state.get_or_open_stores(&alias).await {
         Ok(s) => s,
         Err(e) => {
-            return axum::response::Json(json!({
-                "error": e,
-                "status": "error"
-            }));
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::response::Json(json!({
+                    "error": e,
+                    "status": "error"
+                })),
+            );
         }
     };
 
@@ -468,11 +479,14 @@ async fn reindex_handler(
         }
     });
 
-    axum::response::Json(json!({
-        "status": "accepted",
-        "alias": alias,
-        "message": "Reindex started in background"
-    }))
+    (
+        StatusCode::ACCEPTED,
+        axum::response::Json(json!({
+            "status": "accepted",
+            "alias": alias,
+            "message": "Reindex started in background"
+        })),
+    )
 }
 
 /// Axum middleware: log MCP requests (method + path, skips /health spam).

--- a/src/vectordb/store.rs
+++ b/src/vectordb/store.rs
@@ -315,8 +315,12 @@ impl VectorStore {
         error.to_string().contains("MDB_MAP_FULL") || error.to_string().contains("map full")
     }
 
-    /// Resize the LMDB environment to a new map size
-    /// This requires closing and reopening the environment
+    /// Resize the LMDB environment to a new map size.
+    ///
+    /// Uses `heed::Env::resize()` which calls `mdb_env_set_mapsize()` under the
+    /// hood.  This resizes in-place without closing and reopening the
+    /// environment, which avoids the "an environment is already opened with
+    /// different options" error when a live serve process needs to grow the map.
     fn resize_environment(&mut self, new_size_mb: usize) -> Result<()> {
         if new_size_mb > MAX_LMDB_MAP_SIZE_MB {
             return Err(anyhow::anyhow!(
@@ -326,54 +330,18 @@ impl VectorStore {
             ));
         }
 
+        let new_size_bytes = new_size_mb * 1024 * 1024;
+
         tracing::warn!("🔧 Resizing LMDB environment to {}MB", new_size_mb);
 
-        // Store the current database path
-        let db_path = self.env.path().to_path_buf();
+        // SAFETY: mdb_env_set_mapsize() is safe to call when no transaction is
+        // active.  Our caller holds &mut self and just got MDB_MAP_FULL on an
+        // insert — any write transaction that triggered the error has already
+        // been dropped by the caller before invoking the retry logic.
+        unsafe {
+            self.env.resize(new_size_bytes)?;
+        }
 
-        // Note: We don't need to explicitly drop the env/databases
-        // They will be dropped when we replace them below
-
-        // Open a new environment with the new map size
-        // Note: This is a simple implementation that just increases the map size
-        // In production, you might want to handle this more gracefully
-        let env = unsafe {
-            EnvOpenOptions::new()
-                .map_size(new_size_mb * 1024 * 1024)
-                .max_dbs(10)
-                .open(&db_path)?
-        };
-
-        // Reopen databases
-        let mut wtxn = env.write_txn()?;
-        let vectors: ArroyDatabase<Cosine> = env.create_database(&mut wtxn, Some("vectors"))?;
-        let chunks: Database<U32<BigEndian>, SerdeBincode<ChunkMetadata>> =
-            env.create_database(&mut wtxn, Some("chunks"))?;
-
-        // Get the next ID
-        let next_id = match chunks.last(&wtxn)? {
-            Some((max_key, _)) => max_key + 1,
-            None => 0,
-        };
-
-        wtxn.commit()?;
-
-        // Check if database is already indexed
-        let indexed = if next_id > 0 {
-            let rtxn = env.read_txn()?;
-            Reader::open(&rtxn, 0, vectors).is_ok()
-        } else {
-            false
-        };
-
-        // Replace the old environment with the new one
-        self.env = env;
-        self.vectors = vectors;
-        self.chunks = chunks;
-        self.next_id = next_id;
-        self.indexed = indexed;
-
-        // Update the map size tracking
         self.map_size_mb = new_size_mb;
 
         // Persist the new map size so subsequent opens in the same process
@@ -383,10 +351,8 @@ impl VectorStore {
         }
 
         tracing::info!(
-            "✅ LMDB environment resized to {}MB (next_id: {}, indexed: {})",
-            new_size_mb,
-            next_id,
-            indexed
+            "✅ LMDB environment resized to {}MB (in-place, no reopen)",
+            new_size_mb
         );
 
         Ok(())

--- a/src/vectordb/store.rs
+++ b/src/vectordb/store.rs
@@ -15,6 +15,43 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use tracing::warn;
 
+/// Read the persisted LMDB map size from metadata.json in the database directory.
+/// Returns DEFAULT_LMDB_MAP_SIZE_MB if no persisted value is found.
+fn read_persisted_map_size(db_path: &Path) -> usize {
+    let metadata_path = db_path.join("metadata.json");
+    if let Ok(content) = fs::read_to_string(&metadata_path) {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Some(mb) = json.get("lmdb_map_size_mb").and_then(|v| v.as_u64()) {
+                return mb as usize;
+            }
+        }
+    }
+    crate::constants::DEFAULT_LMDB_MAP_SIZE_MB
+}
+
+/// Persist the current LMDB map size into metadata.json so that subsequent
+/// opens in the same process use the same value (avoids "already opened with
+/// different options" errors from LMDB when multiple repos have been resized).
+fn persist_map_size(db_path: &Path, map_size_mb: usize) -> Result<()> {
+    let metadata_path = db_path.join("metadata.json");
+    let mut json: serde_json::Value = if metadata_path.exists() {
+        let content = fs::read_to_string(&metadata_path)?;
+        serde_json::from_str(&content).unwrap_or(serde_json::Value::Object(Default::default()))
+    } else {
+        serde_json::Value::Object(Default::default())
+    };
+
+    if let Some(obj) = json.as_object_mut() {
+        obj.insert(
+            "lmdb_map_size_mb".to_string(),
+            serde_json::Value::Number(map_size_mb.into()),
+        );
+    }
+
+    fs::write(&metadata_path, serde_json::to_string_pretty(&json)?)?;
+    Ok(())
+}
+
 /// Chunk metadata stored in the database
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChunkMetadata {
@@ -127,10 +164,18 @@ impl VectorStore {
         cleanup_stale_del_files(db_path)?;
 
         // Open LMDB environment
-        let map_size_mb = std::env::var("CODESEARCH_LMDB_MAP_SIZE_MB")
+        // Read persisted map_size from metadata.json if available, so that
+        // multiple repos in the same process use a consistent map size after
+        // one repo has been resized.  Use the max of persisted, env-var, and
+        // default to never shrink below what was previously allocated.
+        let persisted_map_size_mb = read_persisted_map_size(db_path);
+        let env_map_size_mb = std::env::var("CODESEARCH_LMDB_MAP_SIZE_MB")
             .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(crate::constants::DEFAULT_LMDB_MAP_SIZE_MB);
+            .and_then(|s| s.parse::<usize>().ok());
+        let map_size_mb = env_map_size_mb
+            .unwrap_or(persisted_map_size_mb)
+            .max(persisted_map_size_mb)
+            .max(crate::constants::DEFAULT_LMDB_MAP_SIZE_MB);
         let env = unsafe {
             EnvOpenOptions::new()
                 .map_size(map_size_mb * 1024 * 1024)
@@ -204,10 +249,15 @@ impl VectorStore {
         }
 
         // Open LMDB environment in read-only mode
-        let map_size_mb = std::env::var("CODESEARCH_LMDB_MAP_SIZE_MB")
+        // Use same map-size resolution as new() for consistency
+        let persisted_map_size_mb = read_persisted_map_size(db_path);
+        let env_map_size_mb = std::env::var("CODESEARCH_LMDB_MAP_SIZE_MB")
             .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(crate::constants::DEFAULT_LMDB_MAP_SIZE_MB);
+            .and_then(|s| s.parse::<usize>().ok());
+        let map_size_mb = env_map_size_mb
+            .unwrap_or(persisted_map_size_mb)
+            .max(persisted_map_size_mb)
+            .max(crate::constants::DEFAULT_LMDB_MAP_SIZE_MB);
         let env = unsafe {
             EnvOpenOptions::new()
                 .map_size(map_size_mb * 1024 * 1024)
@@ -326,6 +376,12 @@ impl VectorStore {
 
         // Update the map size tracking
         self.map_size_mb = new_size_mb;
+
+        // Persist the new map size so subsequent opens in the same process
+        // use the same value (avoids "already opened with different options").
+        if let Err(e) = persist_map_size(self.env.path(), new_size_mb) {
+            tracing::warn!("Failed to persist LMDB map size: {}", e);
+        }
 
         tracing::info!(
             "✅ LMDB environment resized to {}MB (next_id: {}, indexed: {})",

--- a/src/vectordb/store.rs
+++ b/src/vectordb/store.rs
@@ -29,6 +29,19 @@ fn read_persisted_map_size(db_path: &Path) -> usize {
     crate::constants::DEFAULT_LMDB_MAP_SIZE_MB
 }
 
+/// Resolve the effective LMDB map size using the max of persisted, env-var, and default.
+/// This ensures consistency across multiple repo opens in the same process.
+fn resolve_map_size(db_path: &Path) -> usize {
+    let persisted = read_persisted_map_size(db_path);
+    let from_env = std::env::var("CODESEARCH_LMDB_MAP_SIZE_MB")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok());
+    from_env
+        .unwrap_or(persisted)
+        .max(persisted)
+        .max(crate::constants::DEFAULT_LMDB_MAP_SIZE_MB)
+}
+
 /// Persist the current LMDB map size into metadata.json so that subsequent
 /// opens in the same process use the same value (avoids "already opened with
 /// different options" errors from LMDB when multiple repos have been resized).
@@ -168,14 +181,7 @@ impl VectorStore {
         // multiple repos in the same process use a consistent map size after
         // one repo has been resized.  Use the max of persisted, env-var, and
         // default to never shrink below what was previously allocated.
-        let persisted_map_size_mb = read_persisted_map_size(db_path);
-        let env_map_size_mb = std::env::var("CODESEARCH_LMDB_MAP_SIZE_MB")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok());
-        let map_size_mb = env_map_size_mb
-            .unwrap_or(persisted_map_size_mb)
-            .max(persisted_map_size_mb)
-            .max(crate::constants::DEFAULT_LMDB_MAP_SIZE_MB);
+        let map_size_mb = resolve_map_size(db_path);
         let env = unsafe {
             EnvOpenOptions::new()
                 .map_size(map_size_mb * 1024 * 1024)
@@ -250,14 +256,7 @@ impl VectorStore {
 
         // Open LMDB environment in read-only mode
         // Use same map-size resolution as new() for consistency
-        let persisted_map_size_mb = read_persisted_map_size(db_path);
-        let env_map_size_mb = std::env::var("CODESEARCH_LMDB_MAP_SIZE_MB")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok());
-        let map_size_mb = env_map_size_mb
-            .unwrap_or(persisted_map_size_mb)
-            .max(persisted_map_size_mb)
-            .max(crate::constants::DEFAULT_LMDB_MAP_SIZE_MB);
+        let map_size_mb = resolve_map_size(db_path);
         let env = unsafe {
             EnvOpenOptions::new()
                 .map_size(map_size_mb * 1024 * 1024)


### PR DESCRIPTION
## Summary

19 commits fixing multi-repo serve quality issues and adding robust production features for Claude Code / Claude Desktop integration.

### Core fixes (6 items from AGENTS plan)
1. **Search dedup** — eliminate historical snapshot duplicates on `(path, start_line, end_line)`
2. **Explore alias stripping** — strip project-alias prefix from target paths in `file_outline` and `find_imports`
3. **Sequential pre-warming + LMDB map-size persistence** — repos opened sequentially with 200ms delay; map_size persisted to `metadata.json` to prevent "already opened with different options"
4. **Auto-discovery** — scan CWD for `.codesearch.db` when `repos.json` is empty
5. **index --force via HTTP reindex** — delegates to running serve via `POST /repos/:alias/reindex?force=true`, falls back to local if serve not running
6. **get_chunk project routing** — already present, verified working

### Follow-up fixes discovered during testing
- **axum route syntax** — `:alias` not `{alias}` for axum 0.7 (was causing 404 on reindex endpoint)
- **Force reindex in-place** — clears LMDB + Tantivy data instead of deleting files (avoids OS error 32 entirely)
- **LMDB resize** — use `heed::Env::resize()` in-place instead of close+reopen (fixes "already opened with different options")
- **Windows UNC path normalization** — canonicalize returns `\?\C:\...` but repos.json stores `C:\...`
- **Defensive metadata preservation** — read metadata before clearing, write back before reindex
- **Wrong-DB deletion prevention** — `--force` won't delete another project's DB
- **Local incomplete DB deletion** — `--force` deletes local `.codesearch.db` even if incomplete/corrupt
- **Serve delegation diagnostics** — `try_delegate_reindex_to_serve` returns descriptive error reasons

### New features
- **Serve logging** — logs to `~/.codesearch/logs/serve.log.YYYY-MM-DD` with daily rotation
- **MCP proxy auto-reconnect** — when serve restarts, Claude Desktop proxy detects disconnect, reconnects with 3s interval (5min max), hot-swaps peer without dropping stdio session
- **README** — auto-reconnect architecture section + troubleshooting

### Validation
- `cargo check --all-targets` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` — 362 passed ✅
- `cargo build --release` ✅
- Live tested with 11 repos, 245K chunks on serve

## Not in scope (carried to next PR)
- C# `using` support in `find_imports` / `find_dependents`
- Duplicate chunk investigation (need user repro)
- Regex OR → BM25 confidence UX improvement