### PR TITLE
feat(chunker): C# using import support + tree-sitter bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.30"
+version = "1.0.32"
 dependencies = [
  "anyhow",
  "arroy",
@@ -3848,7 +3848,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4808,9 +4808,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.5"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12987371f54efc9b9306a20dc87ed5aaee9f320c8a8b115e28515c412b2efe39"
+checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
 dependencies = [
  "cc",
  "regex",
@@ -4822,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3aad8f0129083a59fe8596157552d2bb7148c492d44c21558d68ca1c722707"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4832,9 +4832,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c-sharp"
-version = "0.23.1"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67f06accca7b45351758663b8215089e643d53bd9a660ce0349314263737fcb0"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4898,9 +4898,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.24.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.32"
+version = "1.0.34"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.30"
+version = "1.0.32"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"
@@ -37,14 +37,14 @@ hf-hub = "0.3"
 # lancedb = "0.5"
 
 # Text processing & Parsing
-tree-sitter = "0.26"
-tree-sitter-rust = "0.24"
+tree-sitter = "0.26.8"
+tree-sitter-rust = "0.24.2"
 tree-sitter-python = "0.25"
 tree-sitter-javascript = "0.25"
 tree-sitter-typescript = "0.23.2"
-tree-sitter-c = "0.24.1"
+tree-sitter-c = "0.24.2"
 tree-sitter-cpp = "0.23.4"
-tree-sitter-c-sharp = "0.23.1"
+tree-sitter-c-sharp = "0.23.5"
 tree-sitter-go = "0.25"
 tree-sitter-java = "0.23.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.32"
+version = "1.0.34"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/chunker/semantic.rs
+++ b/src/chunker/semantic.rs
@@ -452,6 +452,7 @@ impl<'a> GapTracker<'a> {
                 line.starts_with("import ")
                     || line.starts_with("from ")
                     || line.starts_with("use ")
+                    || line.starts_with("using ")
                     || line.starts_with("#include")
             })
             .count();

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2835,6 +2835,13 @@ fn parse_import_lines(content: &str, start_line: usize) -> Vec<ImportItem> {
 
         let parsed = if let Some(rest) = trimmed.strip_prefix("use ") {
             Some(("use".to_string(), rest.trim().trim_end_matches(';').to_string()))
+        } else if let Some(rest) = trimmed.strip_prefix("using ") {
+            // C# using directive — skip `using (...)` statements and `using var` declarations
+            if rest.starts_with('(') || rest.starts_with("var ") {
+                None
+            } else {
+                Some(("using".to_string(), rest.trim().trim_end_matches(';').to_string()))
+            }
         } else if let Some(rest) = trimmed.strip_prefix("import ") {
             Some(("import".to_string(), rest.trim().trim_end_matches(';').to_string()))
         } else if let Some(rest) = trimmed.strip_prefix("from ") {
@@ -4811,7 +4818,7 @@ impl CodesearchService {
 
             if let Some(ref sv) = ctx.stores_vec {
                 // Multi-store FTS fallback
-                for keyword in &["import", "use", "from", "require", "include"] {
+                for keyword in &["import", "use", "using", "from", "require", "include"] {
                     let hits = self
                         .with_fts_store_read_multi(
                             |fts_store| {
@@ -4845,7 +4852,7 @@ impl CodesearchService {
                 items = resolved;
             } else {
                 // Single-store FTS fallback
-                for keyword in &["import", "use", "from", "require", "include"] {
+                for keyword in &["import", "use", "using", "from", "require", "include"] {
                     let hits = self
                         .with_fts_store_read_for(
                             |fts_store| {


### PR DESCRIPTION
## Summary

Two changes to improve C# import detection and keep tree-sitter dependencies current.

### 1. C# `using` import support
`classify_gap()` in `src/chunker/semantic.rs` now recognizes `using` statements as import patterns, alongside `import`, `from`, `use`, and `#include`. This means C# `using` blocks are classified as `ChunkKind::Imports` instead of `ChunkKind::Block`, enabling `find_imports` and `find_dependents` to work for C# projects.

### 2. Tree-sitter patch bumps
| Package | Old | New |
|---------|-----|-----|
| tree-sitter | 0.26 | 0.26.8 |
| tree-sitter-c | 0.24.1 | 0.24.2 |
| tree-sitter-c-sharp | 0.23.1 | 0.23.5 |
| tree-sitter-rust | 0.24 | 0.24.2 |

All patch bumps — no breaking changes.

### Validation
- `cargo check --all-targets` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` — 362 passed ✅

### After merge
Force reindex C# repos (e.g. BRU.Aprimo) so `using` blocks get re-classified as Imports in existing databases.