### PR TITLE
fix(serve): concurrent reindex guard + review remark cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.34"
+version = "1.0.35"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.34"
+version = "1.0.35"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1524,14 +1524,12 @@ async fn try_delegate_reindex_to_serve(
     let config = crate::db_discovery::repos::ReposConfig::load()
         .map_err(|e| format!("cannot load repos.json: {}", e))?;
 
-    /// Normalize a path for comparison: canonicalize, then strip Windows UNC prefix
-    /// (`\\?\`) so that `\\?\C:\foo` and `C:\foo` compare equal.
+    /// Normalize a path for alias comparison: canonicalize (resolves symlinks,
+    /// relative components), then normalize via `cache::normalize_path` (strips
+    /// Windows UNC prefix, converts backslashes) and lowercases for case-insensitive match.
     fn normalize_for_cmp(p: &std::path::Path) -> String {
         let canonical = p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
-        let s = canonical.to_string_lossy().to_string();
-        // Strip Windows extended-length UNC prefix
-        let s = s.strip_prefix(r"\\?\").unwrap_or(&s).to_string();
-        s.to_lowercase()
+        crate::cache::normalize_path(&canonical).to_lowercase()
     }
 
     let project_norm = normalize_for_cmp(&project_path);

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2554,6 +2554,10 @@ fn is_import_kind(kind: &str) -> bool {
     matches!(kind, "Import" | "Use" | "Require" | "Include" | "Imports")
 }
 
+/// Common import-keyword literals used by the FTS fallback when no import-kind
+/// chunks are found via vector-store lookup.
+const IMPORT_FTS_KEYWORDS: &[&str] = &["import", "use", "using", "from", "require", "include"];
+
 fn truncate_line_around_match(line: &str, match_start_byte: usize, max_chars: usize) -> String {
     let chars: Vec<char> = line.chars().collect();
     if chars.len() <= max_chars {
@@ -4818,7 +4822,7 @@ impl CodesearchService {
 
             if let Some(ref sv) = ctx.stores_vec {
                 // Multi-store FTS fallback
-                for keyword in &["import", "use", "using", "from", "require", "include"] {
+                for keyword in IMPORT_FTS_KEYWORDS {
                     let hits = self
                         .with_fts_store_read_multi(
                             |fts_store| {
@@ -4852,7 +4856,7 @@ impl CodesearchService {
                 items = resolved;
             } else {
                 // Single-store FTS fallback
-                for keyword in &["import", "use", "using", "from", "require", "include"] {
+                for keyword in IMPORT_FTS_KEYWORDS {
                     let hits = self
                         .with_fts_store_read_for(
                             |fts_store| {

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use axum::response::Json as AxumJson;
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use rmcp::transport::{
     StreamableHttpServerConfig, StreamableHttpService,
     streamable_http_server::session::local::LocalSessionManager,
@@ -66,6 +66,8 @@ pub(crate) struct ServeState {
     config_mtime: std::sync::RwLock<Option<std::time::SystemTime>>,
     /// Optional override for the repos config path (used in tests to avoid env vars).
     config_path_override: Option<PathBuf>,
+    /// Aliases currently being reindexed — prevents concurrent force reindex on the same repo.
+    active_reindexes: DashSet<String>,
     /// Test-only counter for reload invocations that actually swapped config.
     #[cfg(test)]
     reload_count: std::sync::atomic::AtomicUsize,
@@ -88,6 +90,7 @@ impl ServeState {
             config: std::sync::RwLock::new(config),
             config_mtime: std::sync::RwLock::new(None),
             config_path_override,
+            active_reindexes: DashSet::new(),
             #[cfg(test)]
             reload_count: std::sync::atomic::AtomicUsize::new(0),
         }
@@ -168,11 +171,8 @@ impl ServeState {
     ///
     /// Fires the cancel token (stops FSW/git-HEAD watcher) and drops the
     /// RepoState, which releases the LMDB write lock and closes all file handles.
-    /// Close a repo and release its LMDB file handles.
-    ///
-    /// Removes the repo from the live map, dropping SharedStores and stopping
-    /// the file watcher. On Windows this is required before deleting the DB
-    /// directory. Not used by force reindex (which clears data in-place instead).
+    /// On Windows this is required before deleting the DB directory.
+    /// Not used by force reindex (which clears data in-place instead).
     #[allow(dead_code)]
     fn close_repo(&self, alias: &str) {
         if let Some((_, state)) = self.repos.remove(alias) {
@@ -471,6 +471,21 @@ async fn reindex_handler(
     let db_path = project_path.join(DB_DIR_NAME);
     let alias_bg = alias.clone();
 
+    // Concurrent reindex guard — reject if this alias is already being reindexed
+    if !state.active_reindexes.insert(alias_bg.clone()) {
+        return (
+            StatusCode::CONFLICT,
+            axum::response::Json(json!({
+                "error": format!("Reindex already in progress for '{}'", alias),
+                "status": "conflict"
+            })),
+        );
+    }
+
+    // Ensure the guard is removed when we return early or the background task finishes.
+    let guard_alias = alias_bg.clone();
+    let guard_state = state.clone();
+
     if force {
         // Force rebuild: clear data in-place → full reindex.
         // No files are deleted, so no OS error 32 on Windows.
@@ -479,6 +494,7 @@ async fn reindex_handler(
         let stores = match state.get_or_open_stores(&alias).await {
             Ok(s) => s,
             Err(e) => {
+                state.active_reindexes.remove(&guard_alias);
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     axum::response::Json(json!({
@@ -489,6 +505,8 @@ async fn reindex_handler(
             }
         };
 
+        let g_alias = guard_alias.clone();
+        let g_state = guard_state.clone();
         tokio::spawn(async move {
             tracing::info!("🔄 Force reindex for '{}': clearing stores and reindexing", alias_bg);
 
@@ -506,12 +524,14 @@ async fn reindex_handler(
                     tracing::error!("❌ Force reindex failed for '{}': {}", alias_bg, e);
                 }
             }
+            g_state.active_reindexes.remove(&g_alias);
         });
     } else {
         // Incremental refresh: ensure the repo is opened, then refresh
         let stores = match state.get_or_open_stores(&alias).await {
             Ok(s) => s,
             Err(e) => {
+                state.active_reindexes.remove(&guard_alias);
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     axum::response::Json(json!({
@@ -522,6 +542,8 @@ async fn reindex_handler(
             }
         };
 
+        let g_alias = guard_alias.clone();
+        let g_state = guard_state.clone();
         tokio::spawn(async move {
             tracing::info!("🔄 Incremental reindex triggered for '{}' via HTTP API", alias_bg);
             match IndexManager::perform_incremental_refresh_with_stores(
@@ -538,6 +560,7 @@ async fn reindex_handler(
                     tracing::error!("❌ Reindex failed for '{}': {}", alias_bg, e);
                 }
             }
+            g_state.active_reindexes.remove(&g_alias);
         });
     }
 
@@ -659,7 +682,7 @@ pub async fn run_serve(
     // Build axum router with request logging
     let app = axum::Router::new()
         .route(HEALTH_PATH, axum::routing::get(health_handler))
-            .route("/repos/:alias/reindex", axum::routing::post(reindex_handler))
+        .route("/repos/:alias/reindex", axum::routing::post(reindex_handler))
         .nest_service(MCP_ENDPOINT_PATH, mcp_service)
         .layer(axum::middleware::from_fn(log_mcp_requests))
         .with_state(serve_state.clone());
@@ -979,5 +1002,65 @@ mod tests {
         // Should not panic; old config still usable
         let aliases = state.aliases();
         assert!(aliases.contains(&"a".to_string()));
+    }
+
+    /// Verify that concurrent reindex requests for the same alias return 409 Conflict.
+    #[tokio::test]
+    async fn concurrent_reindex_returns_conflict() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("myrepo");
+        std::fs::create_dir(&repo_path).unwrap();
+
+        let mut config = ReposConfig::default();
+        config.register_with_alias(repo_path.clone(), Some("testalias".to_string())).unwrap();
+
+        let config_file = tmp.path().join("repos.json");
+        config.save_to(&config_file).unwrap();
+
+        let state = Arc::new(ServeState::new(config, Some(config_file)));
+
+        let app = axum::Router::new()
+            .route("/repos/:alias/reindex", axum::routing::post(reindex_handler))
+            .with_state(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let client = reqwest::Client::new();
+
+        // First request: 202 Accepted (or 500 if DB missing) — but NOT 409
+        let resp1 = client
+            .post(format!("http://{}/repos/testalias/reindex", addr))
+            .send()
+            .await
+            .unwrap();
+        let status1 = resp1.status();
+        assert!(
+            status1 == reqwest::StatusCode::ACCEPTED || status1 == reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            "first request should be 202 or 500, got {}", status1
+        );
+
+        // If the first request was accepted (202), the reindex is running in background.
+        // Send a second request immediately — should get 409 Conflict.
+        if status1 == reqwest::StatusCode::ACCEPTED {
+            let resp2 = client
+                .post(format!("http://{}/repos/testalias/reindex", addr))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                resp2.status(),
+                reqwest::StatusCode::CONFLICT,
+                "second concurrent request should be 409 Conflict"
+            );
+            let body: serde_json::Value = resp2.json().await.unwrap();
+            assert_eq!(body["status"], "conflict");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Addresses review remarks from PR #25 and PR #26.

### Changes
- **Concurrent reindex guard**: `DashSet<String>` in `ServeState` tracks in-progress reindexes. Returns 409 Conflict for duplicate requests. Guard is cleaned up when the background task completes (success or failure).
- **Router indentation**: Fixed `.route()` alignment in the axum router chain.
- **Doc comment cleanup**: Consolidated double doc comment on `close_repo()`.
- **`normalize_for_cmp`**: Now uses `cache::normalize_path` internally instead of duplicating UNC-stripping logic.
- **FTS keywords DRY**: Extracted `IMPORT_FTS_KEYWORDS` constant, replacing two identical array literals.

### Validation
- `cargo check --all-targets` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` — 363 passed (1 new: `concurrent_reindex_returns_conflict`) ✅