### PR TITLE
fix(serve): idle timer + TUI Ctrl-C; SAFETY comments on LMDB unsafe blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.77] - 2026-05-01
+
+### Removed
+
+- Stale planning documents (`.docs/`) and old benchmark results (`benchmarks/`)
+  removed from the repository. These were internal working documents with no
+  value for contributors.
+
 ## [1.0.74] - 2026-05-01
 
 ### Fixed
@@ -87,6 +95,7 @@ repositories.
 - `codesearch serve` keeps one writer per database (LMDB invariant). Concurrent
   reindex from a second process is rejected.
 
+[1.0.77]: https://github.com/flupkede/codesearch/compare/v1.0.75...v1.0.77
 [1.0.75]: https://github.com/flupkede/codesearch/compare/v1.0.74...v1.0.75
 [1.0.74]: https://github.com/flupkede/codesearch/compare/v1.0.72...v1.0.74
 [1.0.72]: https://github.com/flupkede/codesearch/releases/tag/v1.0.72

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.79"
+version = "1.0.80"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.76"
+version = "1.0.78"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.80"
+version = "1.0.81"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.78"
+version = "1.0.79"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.80"
+version = "1.0.81"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.76"
+version = "1.0.78"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.79"
+version = "1.0.80"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.78"
+version = "1.0.79"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/embed/cache.rs
+++ b/src/embed/cache.rs
@@ -308,6 +308,11 @@ impl PersistentEmbeddingCache {
             )
         })?;
 
+        // SAFETY: heed's `EnvOpenOptions::open` is unsafe because the caller must
+        // ensure no other process maps this LMDB environment with incompatible options
+        // (different map_size or flags) at the same time. The cache directory is
+        // process-private under the user's codesearch state directory, and we open it
+        // exactly once per process via this constructor.
         let env = unsafe {
             EnvOpenOptions::new()
                 .map_size(512 * 1024 * 1024) // 512MB — plenty for cache

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -492,10 +492,14 @@ impl ServeState {
         });
 
         // Store as Warm — FSW will be started lazily on first query.
-        // Do NOT touch_access: warmup is background activity, not a real query.
-        // The idle timer should only reset when a user/agent actually queries this repo.
         self.repos
             .insert(alias.to_string(), RepoState::Warm { stores: stores_arc });
+
+        // Start the idle timer at warmup. A real query will reset it via
+        // touch_access; without this, repos that are warmed but never queried
+        // would never appear in `last_access` and therefore never be evicted
+        // by `evict_idle_repos`, holding LMDB envs and embedder state forever.
+        self.touch_access(alias);
         Ok(())
     }
 

--- a/src/serve/tui.rs
+++ b/src/serve/tui.rs
@@ -14,7 +14,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Row, Table, TableState};
 use ratatui::Terminal;
 
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEvent};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 
 use tokio_util::sync::CancellationToken;
@@ -27,7 +27,7 @@ use super::ServeState;
 
 /// Run the fullscreen TUI.  Spawns as a tokio task from `run_serve`.
 ///
-/// Returns `Ok(())` when the user presses `q` / `Ctrl-C`, or when the
+/// Returns `Ok(())` when the user presses `q`, or when the
 /// `cancel_token` is cancelled externally (e.g. Ctrl-C from the main task).
 ///
 /// Terminal restoration is guaranteed on normal exit and on errors.
@@ -154,11 +154,12 @@ fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io
 // ---------------------------------------------------------------------------
 
 fn is_quit_key(key: KeyEvent) -> bool {
-    match key.code {
-        KeyCode::Char('q') => true,
-        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => true,
-        _ => false,
-    }
+    // Ctrl-C is intentionally NOT a quit key here. crossterm's raw mode delivers
+    // it as a key event (ENABLE_PROCESSED_INPUT off on Windows / ISIG off on Unix),
+    // so the OS-level ctrlc::set_handler in main.rs is bypassed while the TUI runs.
+    // Treating Ctrl-C as quit was a foot-gun: a stray Ctrl-C in the wrong terminal
+    // would tear down the whole serve process. Use `q` instead.
+    matches!(key.code, KeyCode::Char('q'))
 }
 
 fn handle_key(key: KeyEvent, table_state: &mut TableState, row_count: usize) {

--- a/src/vectordb/store.rs
+++ b/src/vectordb/store.rs
@@ -283,6 +283,12 @@ impl VectorStore {
         // one repo has been resized.  Use the max of persisted, env-var, and
         // default to never shrink below what was previously allocated.
         let map_size_mb = resolve_map_size(db_path);
+        // SAFETY: heed's `EnvOpenOptions::open` is unsafe because the caller must
+        // ensure no other process maps this LMDB environment with incompatible options
+        // at the same time. codesearch enforces single-writer-per-DB at the application
+        // level (one `serve` process per machine, and the CLI rejects concurrent
+        // reindex). The map_size is reconciled across opens via `resolve_map_size`
+        // above, so we never reopen with a smaller map than was previously persisted.
         let env = unsafe {
             EnvOpenOptions::new()
                 .map_size(map_size_mb * 1024 * 1024)
@@ -361,6 +367,13 @@ impl VectorStore {
         // Open LMDB environment in read-only mode
         // Use same map-size resolution as new() for consistency
         let map_size_mb = resolve_map_size(db_path);
+        // SAFETY: heed's `EnvOpenOptions::open` is unsafe because of LMDB's mmap
+        // contract; see the SAFETY comment on the read-write `new()` above. This
+        // open is read-only (`EnvFlags::READ_ONLY`), so it cannot conflict with a
+        // concurrent writer's map_size, only with stale handles after a resize —
+        // which is acceptable because the writer's resize logic explicitly
+        // rebuilds the env (see `resize_map` below) before any reader is invited
+        // to reopen.
         let env = unsafe {
             EnvOpenOptions::new()
                 .map_size(map_size_mb * 1024 * 1024)


### PR DESCRIPTION
Two serve fixes plus SAFETY-comment cleanup. Audited per instructions/AUDIT_2026-05-02.md: clippy and 740 tests green.