### PR TITLE
feat(serve): standalone TUI + --no-tui flag + /status endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.81] - 2026-05-02
 
+### Added
+
+- **`codesearch serve tui`** — standalone sub-action that opens the ratatui TUI
+  connected to a running serve instance via HTTP polling. The TUI can be opened
+  and closed independently of the server.
+- **`codesearch serve --no-tui`** — start serve headless even when a TTY is
+  available. Typical workflow: `codesearch serve --no-tui` in one terminal,
+  `codesearch serve tui` in another.
+- **`GET /status` endpoint** on serve returns a JSON snapshot of all repo
+  states, sessions, and CPU usage — usable for external monitoring and the
+  standalone TUI.
+
 ### Fixed
 
 - **Idle eviction now covers warmed-but-never-queried repos**: `warmup_repo`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.89"
+version = "1.0.90"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.87"
+version = "1.0.89"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.89"
+version = "1.0.90"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.87"
+version = "1.0.89"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -110,6 +110,16 @@ pub struct Cli {
     pub model: Option<String>,
 }
 
+/// Action for the `serve` command.
+#[derive(clap::ValueEnum, Clone, Debug, Default)]
+pub enum ServeAction {
+    /// Start the serve process (default)
+    #[default]
+    Start,
+    /// Open a standalone TUI connected to a running serve instance
+    Tui,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Search the codebase using natural language
@@ -227,6 +237,10 @@ pub enum Commands {
 
     /// Run a background MCP server with live file watching and multi-repo support
     Serve {
+        /// Action: `start` (default) or `tui`
+        #[arg(default_value = "start")]
+        action: ServeAction,
+
         /// Port to listen on (default: 39725, override with CODESEARCH_SERVE_PORT)
         #[arg(short, long)]
         port: Option<u16>,
@@ -255,6 +269,14 @@ pub enum Commands {
             default_missing_value = "true"
         )]
         create_index: bool,
+
+        /// Disable the embedded TUI even when a TTY is available
+        #[arg(long)]
+        no_tui: bool,
+
+        /// For `tui` action: serve URL to connect to
+        #[arg(long, default_value = "http://127.0.0.1:39725")]
+        url: String,
     },
 
     /// Show statistics about the vector database
@@ -469,23 +491,33 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
         }
         Commands::Stats { path } => crate::index::stats(path).await,
         Commands::Serve {
+            action,
             port,
             register,
             quiet,
             verbose,
             create_index: _,
+            no_tui,
+            url,
         } => {
-            // Initialize serve logger — always logs to ~/.codesearch/logs/serve.log.YYYY-MM-DD
-            // regardless of whether a database exists in the current directory.
-            // This is a central log for the multi-repo serve process, separate from
-            // per-database logs written by the MCP client (codesearch.log.YYYY-MM-DD).
-            let effective_quiet = (cli.quiet || quiet) && !verbose;
-            if let Err(e) =
-                crate::logger::init_serve_logger(log_level, effective_quiet)
-            {
-                eprintln!("Warning: failed to initialize serve logger: {}", e);
+            match action {
+                crate::cli::ServeAction::Tui => {
+                    crate::serve::run_tui_standalone(url).await
+                }
+                crate::cli::ServeAction::Start => {
+                    // Initialize serve logger — always logs to ~/.codesearch/logs/serve.log.YYYY-MM-DD
+                    // regardless of whether a database exists in the current directory.
+                    // This is a central log for the multi-repo serve process, separate from
+                    // per-database logs written by the MCP client (codesearch.log.YYYY-MM-DD).
+                    let effective_quiet = (cli.quiet || quiet) && !verbose;
+                    if let Err(e) =
+                        crate::logger::init_serve_logger(log_level, effective_quiet)
+                    {
+                        eprintln!("Warning: failed to initialize serve logger: {}", e);
+                    }
+                    crate::serve::run_serve(port, register, no_tui, cancel_token.clone()).await
+                }
             }
-            crate::serve::run_serve(port, register, cancel_token.clone()).await
         }
         Commands::Clear { path, yes } => crate::index::clear(path, yes).await,
         Commands::Doctor { fix, json, all, repo } => crate::cli::doctor::run(fix, json, all, repo).await,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -155,6 +155,10 @@ pub const HEALTH_PATH: &str = "/health";
 /// MCP endpoint path served by `codesearch serve` (streamable HTTP).
 pub const MCP_ENDPOINT_PATH: &str = "/mcp";
 
+/// Status endpoint path served by `codesearch serve`.
+/// Returns JSON snapshot of all repo states, sessions, and CPU usage.
+pub const STATUS_PATH: &str = "/status";
+
 /// How long an open repo may remain idle (no queries) before it is evicted.
 /// Eviction closes the DB handles, stops the FSW, and releases memory.
 /// The repo is automatically re-opened on the next query.

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -11,6 +11,7 @@
 //! Lazy-opens stores on first query. Conflicted repos are isolated.
 
 mod tui;
+mod tui_remote;
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -31,7 +32,7 @@ use tracing::{info, warn};
 
 use crate::constants::{
     DB_DIR_NAME, DEFAULT_SERVE_PORT, HEALTH_PATH, MCP_ENDPOINT_PATH, REAPER_INTERVAL_SECS,
-    REPO_IDLE_TIMEOUT_ENV, REPO_IDLE_TIMEOUT_SECS, SERVE_PORT_ENV,
+    REPO_IDLE_TIMEOUT_ENV, REPO_IDLE_TIMEOUT_SECS, SERVE_PORT_ENV, STATUS_PATH,
 };
 use crate::db_discovery::repos::ReposConfig;
 use crate::index::{IndexManager, SharedStores};
@@ -1217,6 +1218,78 @@ async fn health_handler() -> AxumJson<serde_json::Value> {
     }))
 }
 
+/// Status handler: GET /status
+///
+/// Returns a JSON snapshot of all repo states, active sessions, and CPU usage.
+/// Used by the standalone TUI (`codesearch serve tui`) to poll server state.
+async fn status_handler(
+    axum::extract::State(state): axum::extract::State<Arc<ServeState>>,
+) -> AxumJson<serde_json::Value> {
+    let repos = state.repo_statuses_lightweight();
+    let active_sessions = state.active_session_count();
+
+    let repo_json: Vec<serde_json::Value> = repos
+        .iter()
+        .map(|(alias, info)| {
+            let status_str = match info.status {
+                RepoStateLabel::Open => "open",
+                RepoStateLabel::Warm => "warm",
+                RepoStateLabel::Readonly => "readonly",
+                RepoStateLabel::Closed => "closed",
+                RepoStateLabel::Indexing => "indexing",
+                RepoStateLabel::Error => "error",
+                RepoStateLabel::NoIndex => "no_index",
+            };
+            let lock_mode = match info.status {
+                RepoStateLabel::Open | RepoStateLabel::Indexing => "write",
+                RepoStateLabel::Warm | RepoStateLabel::Readonly => "read",
+                _ => "—",
+            };
+            json!({
+                "alias": alias,
+                "status": status_str,
+                "lock_mode": lock_mode,
+                "changes": info.changes,
+                "last_tool_call": info.last_tool_call,
+            })
+        })
+        .collect();
+
+    // CPU usage — lightweight single-sample read
+    let cpu = {
+        use sysinfo::{ProcessesToUpdate, System};
+        let pid = match sysinfo::get_current_pid() {
+            Ok(p) => p,
+            Err(_) => {
+                return AxumJson(json!({
+                    "version": env!("CARGO_PKG_VERSION"),
+                    "repos": repo_json,
+                    "active_sessions": active_sessions,
+                    "cpu_percent": "—",
+                }));
+            }
+        };
+        let mut sys = System::new();
+        sys.refresh_cpu_list(sysinfo::CpuRefreshKind::nothing());
+        sys.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+        match sys.process(pid) {
+            Some(proc) => {
+                let num_cpus = sys.cpus().len().max(1) as f32;
+                let pct = proc.cpu_usage() / num_cpus;
+                format!("{:.0}%", pct)
+            }
+            None => "—".to_string(),
+        }
+    };
+
+    AxumJson(json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "repos": repo_json,
+        "active_sessions": active_sessions,
+        "cpu_percent": cpu,
+    }))
+}
+
 /// Reindex handler: POST /repos/{alias}/reindex
 ///
 /// Query params:
@@ -1673,12 +1746,45 @@ async fn log_mcp_requests(
 
 
 
+/// Run the standalone TUI that connects to a running serve instance via HTTP.
+///
+/// This is the entry point for `codesearch serve tui`.
+pub async fn run_tui_standalone(serve_url: String) -> Result<()> {
+    if !tui::is_tty() {
+        eprintln!("Error: No TTY detected. The standalone TUI requires an interactive terminal.");
+        std::process::exit(1);
+    }
+
+    // Check if serve is reachable
+    let health_url = format!("{}{}", serve_url, HEALTH_PATH);
+    match reqwest::get(&health_url).await {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(_) => {
+            eprintln!(
+                "Error: Serve at {} returned an error. Is it running?",
+                serve_url
+            );
+            std::process::exit(1);
+        }
+        Err(_) => {
+            eprintln!(
+                "Error: No serve running at {}. Start with: codesearch serve",
+                serve_url
+            );
+            std::process::exit(1);
+        }
+    }
+
+    tui_remote::run_remote_tui(serve_url).await
+}
+
 /// Run the MCP serve mode.
 ///
 /// This is the entry point called from CLI when `codesearch serve` is invoked.
 pub async fn run_serve(
     port: Option<u16>,
     register_paths: Vec<PathBuf>,
+    no_tui: bool,
     cancel_token: CancellationToken,
 ) -> Result<()> {
     let effective_port = port.unwrap_or_else(|| {
@@ -1763,6 +1869,7 @@ pub async fn run_serve(
     // before the request hits this middleware).
     let app = axum::Router::new()
         .route(HEALTH_PATH, axum::routing::get(health_handler))
+        .route(STATUS_PATH, axum::routing::get(status_handler))
         .route("/repos", axum::routing::post(add_repo_handler))
         .route("/repos/:alias", axum::routing::delete(remove_repo_handler))
         .route(
@@ -1788,7 +1895,11 @@ pub async fn run_serve(
     let tui_state = serve_state.clone();
     let tui_url = serve_url.clone();
 
-    let tui_handle = tui::maybe_spawn_tui(tui_state, tui_cancel, tui_url);
+    let tui_handle = if !no_tui {
+        tui::maybe_spawn_tui(tui_state, tui_cancel, tui_url)
+    } else {
+        None
+    };
 
     // ── Background pre-warming (NO FSW) ──
     // Open all registered repos sequentially: opens DB, builds vector index,

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -143,6 +143,9 @@ pub(crate) struct ServeState {
     active_sessions: AtomicU64,
     /// Total MCP sessions since serve started.
     total_sessions: AtomicU64,
+    /// Shared sysinfo instance for CPU measurement — must persist across calls
+    /// so cpu_usage() can compute a delta (first call always returns 0%).
+    sysinfo_system: std::sync::Mutex<sysinfo::System>,
     /// Test-only counter for reload invocations that actually swapped config.
     #[cfg(test)]
     reload_count: std::sync::atomic::AtomicUsize,
@@ -160,6 +163,8 @@ impl std::fmt::Debug for ServeState {
 
 impl ServeState {
     fn new(config: ReposConfig, config_path_override: Option<PathBuf>) -> Self {
+        let mut sys = sysinfo::System::new();
+        sys.refresh_cpu_list(sysinfo::CpuRefreshKind::nothing());
         Self {
             repos: DashMap::new(),
             last_access: DashMap::new(),
@@ -171,6 +176,7 @@ impl ServeState {
             last_tool_call: DashMap::new(),
             active_sessions: AtomicU64::new(0),
             total_sessions: AtomicU64::new(0),
+            sysinfo_system: std::sync::Mutex::new(sys),
             #[cfg(test)]
             reload_count: std::sync::atomic::AtomicUsize::new(0),
         }
@@ -918,7 +924,6 @@ impl ServeState {
     }
 
     /// Get the current number of active sessions.
-    #[allow(dead_code)]
     pub(crate) fn active_session_count(&self) -> u64 {
         self.active_sessions.load(Ordering::Relaxed)
     }
@@ -1255,9 +1260,9 @@ async fn status_handler(
         })
         .collect();
 
-    // CPU usage — lightweight single-sample read
+    // CPU usage — reuse shared System instance so cpu_usage() can compute delta
     let cpu = {
-        use sysinfo::{ProcessesToUpdate, System};
+        use sysinfo::ProcessesToUpdate;
         let pid = match sysinfo::get_current_pid() {
             Ok(p) => p,
             Err(_) => {
@@ -1269,8 +1274,17 @@ async fn status_handler(
                 }));
             }
         };
-        let mut sys = System::new();
-        sys.refresh_cpu_list(sysinfo::CpuRefreshKind::nothing());
+        let mut sys = match state.sysinfo_system.lock() {
+            Ok(s) => s,
+            Err(_) => {
+                return AxumJson(json!({
+                    "version": env!("CARGO_PKG_VERSION"),
+                    "repos": repo_json,
+                    "active_sessions": active_sessions,
+                    "cpu_percent": "—",
+                }));
+            }
+        };
         sys.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
         match sys.process(pid) {
             Some(proc) => {

--- a/src/serve/tui_remote.rs
+++ b/src/serve/tui_remote.rs
@@ -1,0 +1,509 @@
+//! Standalone TUI that connects to a running `codesearch serve` via HTTP.
+//!
+//! Polls `GET /status` every second and renders the same ratatui layout
+//! as the embedded TUI in `tui.rs`. This allows the TUI to be opened and
+//! closed independently of the server process.
+
+use std::io;
+use std::time::Duration;
+
+use anyhow::Result;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Layout, Margin, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Row, Table, TableState};
+use ratatui::Terminal;
+
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
+use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+
+use serde::Deserialize;
+
+// ---------------------------------------------------------------------------
+// Data model for the remote TUI
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Deserialize)]
+struct StatusResponse {
+    version: String,
+    repos: Vec<RepoInfo>,
+    active_sessions: u64,
+    cpu_percent: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RepoInfo {
+    alias: String,
+    status: String,
+    lock_mode: String,
+    changes: u64,
+    last_tool_call: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct RemoteTuiState {
+    data: Option<StatusResponse>,
+    connection_errors: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Run the standalone remote TUI. Polls `GET {serve_url}/status` every second.
+pub async fn run_remote_tui(serve_url: String) -> Result<()> {
+    // Setup terminal
+    crossterm::execute!(io::stdout(), EnterAlternateScreen)?;
+    terminal::enable_raw_mode()?;
+
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+
+    let result = run_remote_tui_loop(&mut terminal, &serve_url).await;
+
+    // Always restore terminal
+    restore_terminal(&mut terminal)?;
+
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Main loop
+// ---------------------------------------------------------------------------
+
+async fn run_remote_tui_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    serve_url: &str,
+) -> Result<()> {
+    let mut table_state = TableState::default();
+    table_state.select(Some(0));
+
+    let mut remote_state = RemoteTuiState::default();
+
+    let status_url = format!("{}/status", serve_url.trim_end_matches('/'));
+    let poll_interval = Duration::from_secs(1);
+    let key_poll_timeout = Duration::from_millis(100);
+
+    loop {
+        // Fetch status from serve
+        match reqwest::get(&status_url).await {
+            Ok(resp) if resp.status().is_success() => {
+                match resp.json::<StatusResponse>().await {
+                    Ok(data) => {
+                        remote_state.data = Some(data);
+                        remote_state.connection_errors = 0;
+                    }
+                    Err(_) => {
+                        remote_state.connection_errors += 1;
+                    }
+                }
+            }
+            _ => {
+                remote_state.connection_errors += 1;
+            }
+        }
+
+        // Clamp selection
+        if let Some(ref data) = remote_state.data {
+            if !data.repos.is_empty() {
+                let sel = table_state.selected().unwrap_or(0);
+                if sel >= data.repos.len() {
+                    table_state.select(Some(data.repos.len() - 1));
+                }
+            }
+        }
+
+        // Render
+        terminal.draw(|f| {
+            let size = f.area();
+            let chunks = Layout::vertical([
+                Constraint::Length(3), // header
+                Constraint::Min(4),    // body (table)
+                Constraint::Length(3), // detail panel
+                Constraint::Length(1), // footer
+            ])
+            .split(size);
+
+            match &remote_state.data {
+                Some(data) => {
+                    render_header(f, chunks[0], serve_url, &data.version);
+                    render_table(f, chunks[1], &data.repos, &mut table_state);
+                    render_detail(f, chunks[2], &data.repos, &table_state);
+                    render_footer(
+                        f,
+                        chunks[3],
+                        &data.repos,
+                        &table_state,
+                        data.active_sessions,
+                        &data.cpu_percent,
+                    );
+                }
+                None => {
+                    render_header(f, chunks[0], serve_url, "?");
+                    let msg = if remote_state.connection_errors >= 3 {
+                        "Connection lost — will retry..."
+                    } else {
+                        "Connecting..."
+                    };
+                    let connecting = ratatui::widgets::Paragraph::new(Line::from(vec![
+                        Span::styled(
+                            format!(" {} ", msg),
+                            Style::default().fg(Color::Yellow),
+                        ),
+                    ]));
+                    f.render_widget(connecting, chunks[1]);
+                    render_footer(f, chunks[3], &[], &table_state, 0, "—");
+                }
+            }
+        })?;
+
+        // Poll for key events
+        let mut should_quit = false;
+        while event::poll(key_poll_timeout)? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                if is_quit_key(key) {
+                    should_quit = true;
+                    break;
+                }
+                let repo_count = remote_state
+                    .data
+                    .as_ref()
+                    .map(|d| d.repos.len())
+                    .unwrap_or(0);
+                handle_key(key, &mut table_state, repo_count);
+            }
+        }
+
+        if should_quit {
+            break;
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Restore helpers
+// ---------------------------------------------------------------------------
+
+fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<()> {
+    terminal::disable_raw_mode()?;
+    crossterm::execute!(io::stdout(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Key handling
+// ---------------------------------------------------------------------------
+
+fn is_quit_key(key: KeyEvent) -> bool {
+    matches!(key.code, KeyCode::Char('q'))
+}
+
+fn handle_key(key: KeyEvent, table_state: &mut TableState, row_count: usize) {
+    if row_count == 0 {
+        return;
+    }
+    match key.code {
+        KeyCode::Up | KeyCode::Char('k') => {
+            let i = table_state.selected().unwrap_or(0);
+            if i > 0 {
+                table_state.select(Some(i - 1));
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            let i = table_state.selected().unwrap_or(0);
+            if i < row_count - 1 {
+                table_state.select(Some(i + 1));
+            }
+        }
+        KeyCode::Home => {
+            table_state.select(Some(0));
+        }
+        KeyCode::End => {
+            table_state.select(Some(row_count - 1));
+        }
+        _ => {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering — mirrors the embedded TUI in tui.rs
+// ---------------------------------------------------------------------------
+
+fn render_header(
+    f: &mut ratatui::Frame,
+    area: Rect,
+    serve_url: &str,
+    version: &str,
+) {
+    let now = chrono::Local::now().format("%H:%M:%S").to_string();
+
+    let title_line = Line::from(vec![
+        Span::styled(
+            format!(" codesearch serve v{} · ", version),
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            serve_url.to_string(),
+            Style::default().fg(Color::White),
+        ),
+        Span::styled(
+            format!("  {} ", now),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(
+            "[remote]".to_string(),
+            Style::default().fg(Color::Magenta),
+        ),
+    ]);
+
+    let block = Block::default()
+        .borders(Borders::TOP)
+        .border_style(Style::default().fg(Color::DarkGray));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let centered = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(0),
+    ])
+    .split(inner);
+    f.render_widget(
+        ratatui::widgets::Paragraph::new(title_line),
+        centered[0],
+    );
+}
+
+fn render_table(
+    f: &mut ratatui::Frame,
+    area: Rect,
+    repos: &[RepoInfo],
+    table_state: &mut TableState,
+) {
+    let header_cells = ["Alias", "Status", "Changes", "Last Tool Call", "Lock"];
+    let header = Row::new(
+        header_cells
+            .iter()
+            .map(|h| Cell::from(*h).style(Style::default().add_modifier(Modifier::BOLD))),
+    )
+    .style(Style::default().fg(Color::White))
+    .bottom_margin(1);
+
+    let max_alias_w = repos
+        .iter()
+        .map(|r| r.alias.len())
+        .max()
+        .unwrap_or(10)
+        .max(10);
+
+    let rows: Vec<Row> = repos
+        .iter()
+        .map(|repo| {
+            let status_cell = status_cell(&repo.status);
+            let changes_cell = Cell::from(format!("{}", repo.changes))
+                .style(Style::default().fg(Color::White));
+            let tool_cell = Cell::from(
+                repo.last_tool_call
+                    .as_deref()
+                    .unwrap_or("—")
+                    .to_string(),
+            )
+            .style(Style::default().fg(Color::DarkGray));
+            let lock_cell = lock_cell(&repo.lock_mode);
+
+            Row::new(vec![
+                Cell::from(repo.alias.clone()).style(Style::default().fg(Color::White)),
+                status_cell,
+                changes_cell,
+                tool_cell,
+                lock_cell,
+            ])
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Min(max_alias_w as u16 + 2),
+            Constraint::Length(12),
+            Constraint::Length(9),
+            Constraint::Min(24),
+            Constraint::Length(7),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .borders(Borders::NONE)
+            .style(Style::default().bg(Color::Reset)),
+    )
+    .row_highlight_style(
+        Style::default()
+            .bg(Color::Rgb(30, 30, 50))
+            .add_modifier(Modifier::BOLD),
+    )
+    .highlight_symbol("▶ ");
+
+    f.render_stateful_widget(table, area, table_state);
+}
+
+fn render_detail(
+    f: &mut ratatui::Frame,
+    area: Rect,
+    repos: &[RepoInfo],
+    table_state: &TableState,
+) {
+    if repos.is_empty() {
+        return;
+    }
+
+    let idx = table_state.selected().unwrap_or(0);
+    if idx >= repos.len() {
+        return;
+    }
+
+    let repo = &repos[idx];
+
+    let status_label = match repo.status.as_str() {
+        "open" => "Open",
+        "warm" => "Warm (no FSW)",
+        "readonly" => "Readonly",
+        "closed" => "Closed",
+        "indexing" => "Indexing…",
+        "error" => "Error",
+        "no_index" => "No Index",
+        _ => &repo.status,
+    };
+
+    let detail_line = Line::from(vec![
+        Span::styled(" ▶ ", Style::default().fg(Color::Yellow)),
+        Span::styled(
+            repo.alias.clone(),
+            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("  ", Style::default()),
+        Span::styled(status_label, Style::default().fg(Color::Cyan)),
+        Span::styled("  ", Style::default()),
+        Span::styled(
+            format!("lock: {}", repo.lock_mode),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]);
+
+    let tool_str = repo.last_tool_call.as_deref().unwrap_or("—");
+    let info_line = Line::from(vec![
+        Span::styled("   changes:", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!(" {}  ", repo.changes),
+            Style::default().fg(Color::White),
+        ),
+        Span::styled("last:", Style::default().fg(Color::DarkGray)),
+        Span::styled(format!(" {}", tool_str), Style::default().fg(Color::White)),
+    ]);
+
+    let block = Block::default()
+        .borders(Borders::TOP)
+        .border_style(Style::default().fg(Color::Rgb(40, 40, 60)));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let detail_chunks = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+
+    f.render_widget(ratatui::widgets::Paragraph::new(detail_line), detail_chunks[0]);
+    f.render_widget(ratatui::widgets::Paragraph::new(info_line), detail_chunks[1]);
+}
+
+fn render_footer(
+    f: &mut ratatui::Frame,
+    area: Rect,
+    repos: &[RepoInfo],
+    table_state: &TableState,
+    active: u64,
+    cpu: &str,
+) {
+    let selected = table_state.selected().unwrap_or(0);
+    let scroll_indicator = if repos.len() > 1 {
+        format!("[{}/{}]", selected + 1, repos.len())
+    } else {
+        String::new()
+    };
+
+    let sessions_str = format!("Sessions: {}", active);
+    let cpu_str = format!("CPU: {}", cpu);
+
+    let right_len = cpu_str.len() + sessions_str.len() + 3;
+
+    let footer_inner = area.inner(Margin {
+        vertical: 0,
+        horizontal: 1,
+    });
+    let [left, right] = Layout::horizontal([
+        Constraint::Min(0),
+        Constraint::Length(right_len as u16 + 2),
+    ])
+    .areas(footer_inner);
+
+    let left_line = Line::from(vec![
+        Span::styled("[q] quit  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("[↑↓] scroll  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(scroll_indicator, Style::default().fg(Color::Yellow)),
+    ]);
+
+    let right_line = Line::from(vec![
+        Span::styled(cpu_str, Style::default().fg(Color::Green)),
+        Span::styled(" │ ", Style::default().fg(Color::DarkGray)),
+        Span::styled(sessions_str, Style::default().fg(Color::Cyan)),
+    ]);
+
+    f.render_widget(ratatui::widgets::Paragraph::new(left_line), left);
+    f.render_widget(
+        ratatui::widgets::Paragraph::new(right_line).right_aligned(),
+        right,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cell styling helpers
+// ---------------------------------------------------------------------------
+
+fn status_cell(status: &str) -> Cell<'static> {
+    match status {
+        "open" => Cell::from("✓ ready".to_string())
+            .style(Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+        "warm" => Cell::from("◐ warm".to_string())
+            .style(Style::default().fg(Color::Yellow)),
+        "readonly" => Cell::from("◑ ro".to_string())
+            .style(Style::default().fg(Color::Cyan)),
+        "indexing" => Cell::from("⟳ idx…".to_string())
+            .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        "closed" => Cell::from("○ closed".to_string())
+            .style(Style::default().fg(Color::Gray)),
+        "error" => Cell::from("✗ error".to_string())
+            .style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+        "no_index" => Cell::from("— no idx".to_string())
+            .style(Style::default().fg(Color::Gray)),
+        _ => Cell::from(status.to_string())
+            .style(Style::default().fg(Color::White)),
+    }
+}
+
+fn lock_cell(lock_mode: &str) -> Cell<'static> {
+    match lock_mode {
+        "write" => Cell::from("write".to_string()).style(Style::default().fg(Color::Cyan)),
+        "read" => Cell::from("read".to_string()).style(Style::default().fg(Color::White)),
+        _ => Cell::from("—".to_string()).style(Style::default().fg(Color::Gray)),
+    }
+}


### PR DESCRIPTION
Decouples the ratatui TUI from serve so it can be opened and closed independently.

## New capabilities

- `codesearch serve --no-tui` start serve headless even when TTY present
- `codesearch serve tui` open standalone TUI connecting to running serve via HTTP polling
- `GET /status` endpoint for live repo state, sessions, CPU

## Tests

363 lib tests pass.