### PR TITLE
feat: auto-register repos on index from unknown path, add TUI reload

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1626,10 +1626,62 @@ async fn try_delegate_reindex_to_serve(
         .map_err(|e| format!("reindex POST failed: {}", e))?;
 
     if reindex_resp.status().is_success() {
-        Ok((alias, project_path))
+        return Ok((alias, project_path));
+    }
+
+    let status = reindex_resp.status();
+    let body = reindex_resp.text().await.unwrap_or_default();
+
+    // If 404, the alias is unknown to serve — auto-register via POST /repos, then retry reindex.
+    if status == reqwest::StatusCode::NOT_FOUND {
+        tracing::info!(
+            "alias '{}' not known to serve (404), auto-registering via POST /repos",
+            alias
+        );
+
+        // Register the repo with serve
+        let mut add_body = serde_json::json!({
+            "path": project_path,
+            "global": false,
+        });
+        // Use the resolved alias so the reindex retry targets the same name
+        add_body["alias"] = serde_json::Value::String(alias.clone());
+
+        let add_resp = client
+            .post(format!("{}/repos", base_url))
+            .json(&add_body)
+            .send()
+            .await
+            .map_err(|e| format!("auto-register POST /repos failed: {}", e))?;
+
+        if !add_resp.status().is_success() {
+            let add_status = add_resp.status();
+            let add_text = add_resp.text().await.unwrap_or_default();
+            return Err(format!(
+                "auto-register returned {} for alias '{}': {}",
+                add_status, alias, add_text
+            ));
+        }
+
+        // Repo registered — retry the reindex POST
+        let retry_resp = client
+            .post(&url)
+            .send()
+            .await
+            .map_err(|e| format!("reindex retry POST failed: {}", e))?;
+
+        if retry_resp.status().is_success() {
+            tracing::info!("reindex retry succeeded for alias '{}'", alias);
+            return Ok((alias, project_path));
+        }
+
+        let retry_status = retry_resp.status();
+        let retry_body = retry_resp.text().await.unwrap_or_default();
+        Err(format!(
+            "reindex retry returned {} for alias '{}': {}",
+            retry_status, alias, retry_body
+        ))
     } else {
-        let status = reindex_resp.status();
-        let body = reindex_resp.text().await.unwrap_or_default();
         Err(format!(
             "serve returned {} for alias '{}': {}",
             status, alias, body

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -1985,6 +1985,35 @@ async fn trigger_symbol_rebuild(
     }
 }
 
+/// Reload repos config handler: POST /reload
+///
+/// Forces a reload of repos.json from disk, even if the mtime hasn't changed.
+/// Used by the TUI [s] key to pick up external changes (e.g. `codesearch index add`).
+async fn reload_handler(
+    axum::extract::State(state): axum::extract::State<Arc<ServeState>>,
+) -> (
+    axum::http::StatusCode,
+    axum::response::Json<serde_json::Value>,
+) {
+    use axum::http::StatusCode;
+
+    // Clear the stored mtime so reload_if_changed will actually reload.
+    if let Ok(mut mtime_guard) = state.config_mtime.write() {
+        *mtime_guard = None;
+    }
+
+    match state.reload_if_changed() {
+        Ok(()) => (
+            StatusCode::OK,
+            axum::response::Json(json!({"status": "reloaded"})),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::response::Json(json!({"error": format!("reload failed: {}", e)})),
+        ),
+    }
+}
+
 /// Reindex handler: POST /repos/{alias}/reindex
 ///
 /// Query params:
@@ -2584,6 +2613,7 @@ pub async fn run_serve(
         .route(STATUS_PATH, axum::routing::get(status_handler))
         .route("/repos", axum::routing::post(add_repo_handler))
         .route("/repos/:alias", axum::routing::delete(remove_repo_handler))
+        .route("/reload", axum::routing::post(reload_handler))
         .route(
             "/repos/:alias/reindex",
             axum::routing::post(reindex_handler),

--- a/src/serve/tui.rs
+++ b/src/serve/tui.rs
@@ -132,7 +132,14 @@ async fn run_tui_loop(
                     should_quit = true;
                     break;
                 }
-                handle_key(key, &mut table_state, repos.len());
+                if handle_key(key, &mut table_state, repos.len()) {
+                    // 's' pressed — force reload of repos config
+                    // Clear mtime so reload_if_changed actually reloads
+                    if let Ok(mut mtime_guard) = state.config_mtime.write() {
+                        *mtime_guard = None;
+                    }
+                    let _ = state.reload_if_changed();
+                }
             }
         }
 
@@ -176,9 +183,9 @@ fn is_quit_key(key: KeyEvent) -> bool {
     matches!(key.code, KeyCode::Char('q'))
 }
 
-fn handle_key(key: KeyEvent, table_state: &mut TableState, row_count: usize) {
+fn handle_key(key: KeyEvent, table_state: &mut TableState, row_count: usize) -> bool {
     if row_count == 0 {
-        return;
+        return false;
     }
     match key.code {
         KeyCode::Up | KeyCode::Char('k') => {
@@ -199,8 +206,12 @@ fn handle_key(key: KeyEvent, table_state: &mut TableState, row_count: usize) {
         KeyCode::End => {
             table_state.select(Some(row_count - 1));
         }
+        KeyCode::Char('s') => {
+            return true; // signal: reload requested
+        }
         _ => {}
     }
+    false
 }
 
 // ---------------------------------------------------------------------------
@@ -534,6 +545,7 @@ fn render_footer(
     let left_line = Line::from(vec![
         Span::styled("[q] quit  ", Style::default().fg(Color::DarkGray)),
         Span::styled("[↑↓] scroll  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("[s] reload  ", Style::default().fg(Color::DarkGray)),
         Span::styled(scroll_indicator, Style::default().fg(Color::Yellow)),
     ]);
 

--- a/src/serve/tui_remote.rs
+++ b/src/serve/tui_remote.rs
@@ -176,7 +176,17 @@ async fn run_remote_tui_loop(
                     .as_ref()
                     .map(|d| d.repos.len())
                     .unwrap_or(0);
-                handle_key(key, &mut table_state, repo_count);
+                if handle_key(key, &mut table_state, repo_count) {
+                    // 's' pressed — trigger reload via HTTP
+                    let reload_url =
+                        format!("{}/reload", serve_url.trim_end_matches('/'));
+                    // Fire-and-forget POST; don't block the TUI loop
+                    let _ = reqwest::Client::new()
+                        .post(&reload_url)
+                        .timeout(std::time::Duration::from_secs(3))
+                        .send()
+                        .await;
+                }
             }
         }
 
@@ -209,9 +219,9 @@ fn is_quit_key(key: KeyEvent) -> bool {
     matches!(key.code, KeyCode::Char('q'))
 }
 
-fn handle_key(key: KeyEvent, table_state: &mut TableState, row_count: usize) {
+fn handle_key(key: KeyEvent, table_state: &mut TableState, row_count: usize) -> bool {
     if row_count == 0 {
-        return;
+        return false;
     }
     match key.code {
         KeyCode::Up | KeyCode::Char('k') => {
@@ -232,8 +242,12 @@ fn handle_key(key: KeyEvent, table_state: &mut TableState, row_count: usize) {
         KeyCode::End => {
             table_state.select(Some(row_count - 1));
         }
+        KeyCode::Char('s') => {
+            return true; // signal: reload requested
+        }
         _ => {}
     }
+    false
 }
 
 // ---------------------------------------------------------------------------
@@ -527,6 +541,7 @@ fn render_footer(
     let left_line = Line::from(vec![
         Span::styled("[q] quit  ", Style::default().fg(Color::DarkGray)),
         Span::styled("[↑↓] scroll  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("[s] reload  ", Style::default().fg(Color::DarkGray)),
         Span::styled(scroll_indicator, Style::default().fg(Color::Yellow)),
     ]);
 


### PR DESCRIPTION
## Summary
- **CLI auto-register on 404**: When `codesearch index -f` runs from a directory not yet in repos.json, the CLI now auto-registers the repo with serve (via `POST /repos`) instead of falling back to local indexing, which caused LMDB file-lock conflicts
- **POST /reload endpoint**: New endpoint that forces repos.json to be re-read from disk, even if mtime hasn't changed
- **TUI [s] key**: Both embedded and remote TUIs now support `[s]` to reload repos.json on demand — picks up externally added/removed repos without restarting serve

## Files changed
- `src/index/mod.rs` — `try_delegate_reindex_to_serve` auto-registers on 404, retries reindex
- `src/serve/mod.rs` — new `reload_handler` + `/reload` route
- `src/serve/tui.rs` — embedded TUI: `handle_key` returns bool, `[s]` triggers `reload_if_changed`
- `src/serve/tui_remote.rs` — remote TUI: `[s]` triggers `POST /reload`, same footer update

## Validation
- `cargo check --all-targets` ✅
- `cargo clippy --all-targets -- -D warnings` ✅