### PR TITLE
fix: add_repo_handler deadlock — spawn index_quiet in background

### DIFF
--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -2235,8 +2235,9 @@ struct AddRepoRequest {
 
 /// Add-repo handler: POST /repos
 ///
-/// Registers a new repo in repos.json, creates the index, and warms it up.
-/// Returns 201 on success.
+/// Registers a new repo in repos.json, spawns index creation + warmup in the
+/// background, and returns 202 Accepted immediately.  Indexing must not run
+/// inline because the serve's own startup may still hold the LMDB lock.
 async fn add_repo_handler(
     axum::extract::State(state): axum::extract::State<Arc<ServeState>>,
     axum::extract::Json(body): axum::extract::Json<AddRepoRequest>,

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -2313,51 +2313,46 @@ async fn add_repo_handler(
         alias
     };
 
-    // Create the index using index_quiet
+    // Spawn index creation + warmup in the background to avoid blocking the
+    // HTTP handler.  Previously this ran inline, which caused a deadlock when
+    // the serve's own startup still held the LMDB lock (Phase 1).  Returning
+    // 202 Accepted immediately matches the pattern used by reindex_handler.
     let cancel_token = CancellationToken::new();
     let index_path = canonical_path.clone();
     let alias_bg = alias.clone();
     let state_bg = state.clone();
 
-    match crate::index::index_quiet(Some(index_path.clone()), false, body.global, cancel_token)
-        .await
-    {
-        Ok(()) => {
-            tracing::info!("Index created for '{}' ({})", alias, index_path.display());
-        }
-        Err(e) => {
-            // Index failed — remove the config entry we just added
-            tracing::error!("Index creation failed for '{}': {}", alias, e);
-            {
-                if let Ok(mut config) = state.config.write() {
-                    config.unregister_alias(&alias);
+    tokio::spawn(async move {
+        match crate::index::index_quiet(Some(index_path.clone()), false, body.global, cancel_token)
+            .await
+        {
+            Ok(()) => {
+                tracing::info!("Index created for '{}' ({})", alias_bg, index_path.display());
+            }
+            Err(e) => {
+                // Index failed — remove the config entry we just added
+                tracing::error!("Index creation failed for '{}': {}", alias_bg, e);
+                if let Ok(mut config) = state_bg.config.write() {
+                    config.unregister_alias(&alias_bg);
                     let _ = config.save();
                 }
+                return;
             }
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                axum::response::Json(json!({
-                    "error": format!("Index creation failed: {}", e),
-                    "status": "error"
-                })),
-            );
         }
-    }
 
-    // Warmup the repo (opens DB, builds vector index, stores as Warm)
-    tokio::spawn(async move {
+        // Warmup the repo (opens DB, builds vector index, stores as Warm)
         if let Err(e) = state_bg.warmup_repo(&alias_bg).await {
             tracing::warn!("Warmup failed for newly added repo '{}': {}", alias_bg, e);
         }
     });
 
     (
-        StatusCode::CREATED,
+        StatusCode::ACCEPTED,
         axum::response::Json(json!({
-            "status": "created",
+            "status": "accepted",
             "alias": alias,
             "path": canonical_path,
-            "message": "Repo registered, indexed, and warming up"
+            "message": "Repo registered, indexing in background"
         })),
     )
 }


### PR DESCRIPTION
## Summary

- **Fix deadlock in `add_repo_handler` (POST `/repos`)**: `index_quiet()` was called inline, blocking the HTTP handler while trying to acquire LMDB locks that the serve's own startup (Phase 1) already held. This caused the serve to hang on fresh installs when a CLI `codesearch index` command triggered auto-registration.
- **Return 202 Accepted immediately**: Indexing + warmup now run in a `tokio::spawn` background task, matching the existing `reindex_handler` pattern.
- **Error cleanup preserved**: On indexing failure, the spawned task unregisters the alias from repos.json.

## Reproduction

1. Fresh install — `codesearch serve` (Phase 1 startup holds LMDB locks)
2. In another terminal: `codesearch index -f` (auto-registers via POST `/repos`)
3. Before fix: POST hangs → 3s timeout → CLI falls back to local → LMDB conflict → serve stuck
4. After fix: POST returns 202 immediately → indexing runs in background → no conflict

## Review

Reviewed by @reviewer — verdict: ✅ PASS