### PR TITLE
fix: centralize DB open/create logic, fix force-reindex on missing DB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,27 @@ Debugging this required reading serve logs — no user-visible indication that D
 - Symbol resolution: exact match first, then fuzzy via `scip_simple_names`
 - Position lookup matches `start_line` only (not `[start_line, end_line]` range)
 
+### ⚠️ LMDB Access Rule — CRITICAL
+
+LMDB **does not allow** two `EnvOpenOptions::open()` handles on the same directory in the same process. Violating this causes runtime panics and corrupted indexes.
+
+**In serve context (`codesearch serve`):** ALL LMDB access MUST go through `get_or_open_stores()` (serve/mod.rs) which returns `Arc<SharedStores>`. This is the single entry point that ensures one LMDB handle per `.codesearch.db`.
+
+**Forbidden in serve/MCP code:**
+- `VectorStore::new()` — opens its own LMDB environment
+- `VectorStore::open_readonly()` — same issue
+- Any direct `heed::EnvOpenOptions::open()` on a `.codesearch.db` path
+
+**Allowed in CLI/stdio context:** `VectorStore::new()` is fine when codesearch runs as a standalone CLI tool (own process, no conflicting handles).
+
+**The 4 LMDB environments in this codebase:**
+1. Vector DB — `.codesearch.db/` via `VectorStore` (serve: through `SharedStores` only)
+2. SCIP symbols — `.codesearch.db/scip/` via `open_scip_env()` (separate dir, separate handle, safe)
+3. Embed cache — `~/.codesearch/embed_cache/` via `EmbeddingCache` (global path, separate dir, safe)
+4. FTS — `.codesearch.db/fts/` — Tantivy, NOT LMDB (no constraint)
+
+**If you add a new feature that needs LMDB in serve context:** Use `get_or_open_stores()` to get the shared handle. Never open a second handle on the same path.
+
 ### Runtime vs build locations
 
 - **Runtime**: `C:\Users\develterf\.local\bin\` — contains `codesearch.exe` and `helpers/csharp/scip-csharp.exe`. This is where `codesearch serve` runs from.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.109"
+version = "1.0.110"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.107"
+version = "1.0.109"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.104"
+version = "1.0.105"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.100"
+version = "1.0.101"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.103"
+version = "1.0.104"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.105"
+version = "1.0.107"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.101"
+version = "1.0.102"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.102"
+version = "1.0.103"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.104"
+version = "1.0.105"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.105"
+version = "1.0.107"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.100"
+version = "1.0.101"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.103"
+version = "1.0.104"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.109"
+version = "1.0.110"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.107"
+version = "1.0.109"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.101"
+version = "1.0.102"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.102"
+version = "1.0.103"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/embed/cache.rs
+++ b/src/embed/cache.rs
@@ -1,9 +1,10 @@
 use super::batch::EmbeddedChunk;
 use crate::chunker::Chunk;
+use crate::lmdb_registry::TrackedEnv;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use heed::types::*;
-use heed::{Database, Env, EnvOpenOptions};
+use heed::{Database, EnvOpenOptions};
 use moka::sync::Cache;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -281,7 +282,7 @@ impl QueryCacheStats {
 /// This is separate from the in-memory EmbeddingCache which uses Moka for
 /// automatic memory management. The persistent cache provides long-term storage.
 pub struct PersistentEmbeddingCache {
-    env: Env,
+    env: TrackedEnv,
     db: Database<Str, SerdeBincode<Vec<f32>>>,
     cache_dir: PathBuf,
 }
@@ -313,11 +314,15 @@ impl PersistentEmbeddingCache {
         // (different map_size or flags) at the same time. The cache directory is
         // process-private under the user's codesearch state directory, and we open it
         // exactly once per process via this constructor.
+        // TrackedEnv additionally prevents double-open within the same process.
+        let mut opts = EnvOpenOptions::new();
+        opts.map_size(512 * 1024 * 1024).max_dbs(1); // 512MB — plenty for cache
         let env = unsafe {
-            EnvOpenOptions::new()
-                .map_size(512 * 1024 * 1024) // 512MB — plenty for cache
-                .max_dbs(1)
-                .open(&cache_dir)?
+            TrackedEnv::open(
+                &opts,
+                &cache_dir,
+                &format!("PersistentEmbeddingCache({})", model_name),
+            )?
         };
 
         let mut wtxn = env.write_txn()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod file;
 pub mod fts;
 pub mod index;
+pub mod lmdb_registry;
 pub mod logger;
 pub mod mcp;
 pub mod output;

--- a/src/lmdb_registry.rs
+++ b/src/lmdb_registry.rs
@@ -51,22 +51,25 @@ fn register(path: &Path, description: &str) -> Result<PathBuf> {
         .canonicalize()
         .with_context(|| format!("Cannot canonicalize LMDB path: {}", path.display()))?;
 
-    if let Some(existing) = registry.get(&canonical) {
-        anyhow::bail!(
-            "LMDB double-open prevented: {} is already open ({}, opened {:.1}s ago)",
-            canonical.display(),
-            existing.description,
-            existing.opened_at.elapsed().as_secs_f64()
-        );
+    // Use DashMap's atomic entry API to prevent TOCTOU race between check+insert.
+    use dashmap::mapref::entry::Entry;
+    match registry.entry(canonical.clone()) {
+        Entry::Occupied(existing) => {
+            let entry = existing.get();
+            anyhow::bail!(
+                "LMDB double-open prevented: {} is already open ({}, opened {:.1}s ago)",
+                canonical.display(),
+                entry.description,
+                entry.opened_at.elapsed().as_secs_f64()
+            );
+        }
+        Entry::Vacant(slot) => {
+            slot.insert(LmdbEntry {
+                description: description.to_string(),
+                opened_at: Instant::now(),
+            });
+        }
     }
-
-    registry.insert(
-        canonical.clone(),
-        LmdbEntry {
-            description: description.to_string(),
-            opened_at: Instant::now(),
-        },
-    );
 
     Ok(canonical)
 }
@@ -146,12 +149,17 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn make_opts() -> heed::EnvOpenOptions {
+        let mut opts = heed::EnvOpenOptions::new();
+        opts.map_size(1024 * 1024).max_dbs(1);
+        opts
+    }
+
     #[test]
     fn test_registry_prevents_double_open() {
         let dir = TempDir::new().unwrap();
         let path = dir.path();
-
-        let opts = heed::EnvOpenOptions::new().map_size(1024 * 1024).max_dbs(1);
+        let opts = make_opts();
 
         // First open should succeed
         let _env1 = unsafe { TrackedEnv::open(&opts, path, "test-1").unwrap() };
@@ -168,8 +176,7 @@ mod tests {
     fn test_registry_allows_reopen_after_drop() {
         let dir = TempDir::new().unwrap();
         let path = dir.path();
-
-        let opts = heed::EnvOpenOptions::new().map_size(1024 * 1024).max_dbs(1);
+        let opts = make_opts();
 
         {
             let _env1 = unsafe { TrackedEnv::open(&opts, path, "test-1").unwrap() };
@@ -184,8 +191,7 @@ mod tests {
     fn test_different_paths_both_allowed() {
         let dir1 = TempDir::new().unwrap();
         let dir2 = TempDir::new().unwrap();
-
-        let opts = heed::EnvOpenOptions::new().map_size(1024 * 1024).max_dbs(1);
+        let opts = make_opts();
 
         let _env1 = unsafe { TrackedEnv::open(&opts, dir1.path(), "test-1").unwrap() };
         let _env2 = unsafe { TrackedEnv::open(&opts, dir2.path(), "test-2").unwrap() };

--- a/src/lmdb_registry.rs
+++ b/src/lmdb_registry.rs
@@ -1,0 +1,193 @@
+//! LMDB environment tracking to prevent double-open panics.
+//!
+//! LMDB does not allow two `EnvOpenOptions::open()` handles on the same directory
+//! in the same process with different options. Violating this causes runtime panics
+//! and corrupted indexes.
+//!
+//! This module provides [`TrackedEnv`], a thin wrapper around `heed::Env` that
+//! registers every open in a global `DashMap` and unregisters on Drop. If a
+//! second open is attempted on the same canonical path, it returns a clear error
+//! instead of a cryptic LMDB panic.
+
+use anyhow::{Context, Result};
+use dashmap::DashMap;
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::Instant;
+
+// ── Global registry ─────────────────────────────────────────────
+
+static LMDB_REGISTRY: OnceLock<DashMap<PathBuf, LmdbEntry>> = OnceLock::new();
+
+#[derive(Debug)]
+struct LmdbEntry {
+    description: String,
+    opened_at: Instant,
+}
+
+/// Check whether `path` is already registered (for diagnostics).
+#[allow(dead_code)]
+pub fn is_registered(path: &Path) -> bool {
+    let registry = match LMDB_REGISTRY.get() {
+        Some(r) => r,
+        None => return false,
+    };
+    match path.canonicalize() {
+        Ok(canonical) => registry.contains_key(&canonical),
+        Err(_) => false,
+    }
+}
+
+/// Return the number of currently tracked LMDB environments (for diagnostics).
+#[allow(dead_code)]
+pub fn tracked_count() -> usize {
+    LMDB_REGISTRY.get().map(|r| r.len()).unwrap_or(0)
+}
+
+fn register(path: &Path, description: &str) -> Result<PathBuf> {
+    let registry = LMDB_REGISTRY.get_or_init(DashMap::new);
+    let canonical = path
+        .canonicalize()
+        .with_context(|| format!("Cannot canonicalize LMDB path: {}", path.display()))?;
+
+    if let Some(existing) = registry.get(&canonical) {
+        anyhow::bail!(
+            "LMDB double-open prevented: {} is already open ({}, opened {:.1}s ago)",
+            canonical.display(),
+            existing.description,
+            existing.opened_at.elapsed().as_secs_f64()
+        );
+    }
+
+    registry.insert(
+        canonical.clone(),
+        LmdbEntry {
+            description: description.to_string(),
+            opened_at: Instant::now(),
+        },
+    );
+
+    Ok(canonical)
+}
+
+fn unregister(canonical: &Path) {
+    if let Some(registry) = LMDB_REGISTRY.get() {
+        registry.remove(canonical);
+    }
+}
+
+// ── TrackedEnv wrapper ──────────────────────────────────────────
+
+/// Wrapper around [`heed::Env`] that prevents double-open panics.
+///
+/// On creation, registers the LMDB path in a global registry. If another
+/// `TrackedEnv` is already open on the same canonical path, returns an error
+/// with context about who opened it and when. On drop, unregisters automatically.
+///
+/// Implements `Deref<Target = heed::Env>` so all existing `env.method()` calls
+/// work without changes.
+pub struct TrackedEnv {
+    inner: heed::Env,
+    canonical: PathBuf,
+}
+
+impl TrackedEnv {
+    /// Open a new LMDB environment, registered in the global tracker.
+    ///
+    /// # Safety
+    /// Same as `heed::EnvOpenOptions::open` — caller must ensure no other process
+    /// opens the same path with incompatible options (different map_size or flags).
+    pub unsafe fn open(
+        opts: &heed::EnvOpenOptions,
+        path: &Path,
+        description: &str,
+    ) -> Result<Self> {
+        let canonical = register(path, description)?;
+
+        match opts.open(path) {
+            Ok(env) => Ok(Self {
+                inner: env,
+                canonical,
+            }),
+            Err(e) => {
+                unregister(&canonical);
+                Err(e.into())
+            }
+        }
+    }
+}
+
+impl Drop for TrackedEnv {
+    fn drop(&mut self) {
+        unregister(&self.canonical);
+    }
+}
+
+impl Deref for TrackedEnv {
+    type Target = heed::Env;
+    fn deref(&self) -> &heed::Env {
+        &self.inner
+    }
+}
+
+impl std::fmt::Debug for TrackedEnv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrackedEnv")
+            .field("path", &self.canonical)
+            .finish()
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_registry_prevents_double_open() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        let opts = heed::EnvOpenOptions::new().map_size(1024 * 1024).max_dbs(1);
+
+        // First open should succeed
+        let _env1 = unsafe { TrackedEnv::open(&opts, path, "test-1").unwrap() };
+
+        // Second open on same path should fail
+        let result = unsafe { TrackedEnv::open(&opts, path, "test-2") };
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("double-open prevented"));
+        assert!(err.contains("test-1"));
+    }
+
+    #[test]
+    fn test_registry_allows_reopen_after_drop() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        let opts = heed::EnvOpenOptions::new().map_size(1024 * 1024).max_dbs(1);
+
+        {
+            let _env1 = unsafe { TrackedEnv::open(&opts, path, "test-1").unwrap() };
+            // env1 dropped here
+        }
+
+        // Should succeed after drop
+        let _env2 = unsafe { TrackedEnv::open(&opts, path, "test-2").unwrap() };
+    }
+
+    #[test]
+    fn test_different_paths_both_allowed() {
+        let dir1 = TempDir::new().unwrap();
+        let dir2 = TempDir::new().unwrap();
+
+        let opts = heed::EnvOpenOptions::new().map_size(1024 * 1024).max_dbs(1);
+
+        let _env1 = unsafe { TrackedEnv::open(&opts, dir1.path(), "test-1").unwrap() };
+        let _env2 = unsafe { TrackedEnv::open(&opts, dir2.path(), "test-2").unwrap() };
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod embed;
 mod file;
 mod fts;
 mod index;
+mod lmdb_registry;
 mod logger;
 mod mcp;
 mod output;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -3711,14 +3711,22 @@ impl CodesearchService {
             match action(&store) {
                 Ok(result) => return Ok(result),
                 Err(shared_err) => {
-                    tracing::error!(
-                        "Shared vector store read failed, falling back to standalone open: {:?}",
-                        shared_err
-                    );
+                    tracing::error!("Shared vector store read failed: {:?}", shared_err);
+
+                    // In serve mode, do NOT fall back to a standalone VectorStore —
+                    // it would open a second LMDB handle on the same .codesearch.db,
+                    // which LMDB rejects ("environment already opened with different options").
+                    if self.serve_state.is_some() {
+                        return Err(shared_err.context(
+                            "Shared vector store read failed in serve mode; \
+                             standalone fallback disabled to prevent LMDB double-open",
+                        ));
+                    }
                 }
             }
 
-            // If MCP is in readonly mode, fallback must also use readonly open.
+            // Standalone readonly fallback (non-serve mode only).
+            // In serve mode the guard above already returned.
             if stores.readonly {
                 let ro_store = VectorStore::open_readonly(&self.db_path, self.dimensions)
                     .context("Error opening readonly database for read fallback")?;
@@ -3727,9 +3735,8 @@ impl CodesearchService {
             }
         }
 
-        // Fallback path:
-        // - when shared stores are not available, OR
-        // - when shared read fails (e.g., transient readonly/shared handle issues)
+        // Standalone fallback (non-serve mode only — CLI / stdio MCP).
+        // In serve mode, either Priority 1/2 succeeded or the guard above returned Err.
         let store = VectorStore::new(&self.db_path, self.dimensions)
             .context("Error opening database for read fallback")?;
         action(&store).context("Error reading from vector store")

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -140,6 +140,15 @@ impl std::fmt::Debug for RepoState {
     }
 }
 
+/// Result of [].
+///
+/// - : opened in write mode; NOT yet registered in . Caller decides state.
+/// - : opened in readonly mode; ALREADY registered as .
+pub(crate) enum OpenedStores {
+    Write(Arc<SharedStores>),
+    Readonly(Arc<SharedStores>),
+}
+
 /// Shared state for the serve mode.
 pub(crate) struct ServeState {
     /// Repo alias → opened stores (or conflicted marker).
@@ -970,42 +979,10 @@ impl ServeState {
 
         let db_path = path.join(DB_DIR_NAME);
 
-        // Database existence precheck — don't cache missing DB as Conflicted
-        if !db_path.exists() {
-            return Err(format!(
-                "Database not found at {}. This usually means the repo was removed externally. \
-                 Run `codesearch index add {}` to recreate, or `codesearch index rm {}` to clean up the config entry.",
-                db_path.display(), path.display(), path.display()
-            ));
-        }
-
-        // Read dimensions from metadata
-        let dims = self.get_dimensions_for_path(&db_path);
-
-        // Try write-mode first, then readonly
-        let stores = match SharedStores::new(&db_path, dims) {
-            Ok(s) => {
-                info!("Warmup '{}': opened in write mode", alias);
-                s
-            }
-            Err(_) => match SharedStores::new_readonly(&db_path, dims) {
-                Ok(s) => {
-                    info!("Warmup '{}': opened in readonly mode", alias);
-                    let stores_arc = Arc::new(s);
-                    self.repos.insert(
-                        alias.to_string(),
-                        RepoState::Readonly {
-                            stores: stores_arc.clone(),
-                        },
-                    );
-                    return Ok(());
-                }
-                Err(e) => {
-                    warn!("Warmup '{}': failed to open: {}", alias, e);
-                    self.repos.insert(alias.to_string(), RepoState::Conflicted);
-                    return Err(Self::conflicted_msg(alias));
-                }
-            },
+        // Open stores: existence check + write/readonly/conflicted logic.
+        let stores = match self.try_open_stores(alias, &db_path, false)? {
+            OpenedStores::Readonly(_) => return Ok(()), // already registered
+            OpenedStores::Write(s) => s,
         };
 
         // Build vector index from existing data
@@ -1026,7 +1003,7 @@ impl ServeState {
             }
         }
 
-        let stores_arc = Arc::new(stores);
+        let stores_arc = stores;
 
         if let Err(e) =
             IndexManager::perform_incremental_refresh_with_stores(&path, &db_path, &stores_arc)
@@ -1128,47 +1105,14 @@ impl ServeState {
 
         let db_path = path.join(DB_DIR_NAME);
 
-        // Database existence precheck — don't cache missing DB as Conflicted
-        if !db_path.exists() {
-            return Err(format!(
-                "Database not found at {}. This usually means the repo was removed externally. \
-                 Run `codesearch index add {}` to recreate, or `codesearch index rm {}` to clean up the config entry.",
-                db_path.display(), path.display(), path.display()
-            ));
-        }
-
-        // Read dimensions from metadata
-        let dims = self.get_dimensions_for_path(&db_path);
-
-        // Try write-mode first, then readonly
-        let stores = match SharedStores::new(&db_path, dims) {
-            Ok(s) => {
-                info!("Opened repo '{}' in write mode", alias);
-                s
+        // Open stores: existence check + write/readonly/conflicted logic.
+        let stores = match self.try_open_stores(alias, &db_path, false)? {
+            OpenedStores::Readonly(s) => {
+                // Already registered as Readonly; touch and return.
+                self.touch_access(alias);
+                return Ok(s);
             }
-            Err(_) => {
-                // Try readonly
-                match SharedStores::new_readonly(&db_path, dims) {
-                    Ok(s) => {
-                        info!("Opened repo '{}' in readonly mode", alias);
-                        let stores_arc = Arc::new(s);
-                        self.repos.insert(
-                            alias.to_string(),
-                            RepoState::Readonly {
-                                stores: stores_arc.clone(),
-                            },
-                        );
-                        // Always update last_access so the reaper can evict.
-                        self.touch_access(alias);
-                        return Ok(stores_arc);
-                    }
-                    Err(e) => {
-                        warn!("Failed to open repo '{}': {}", alias, e);
-                        self.repos.insert(alias.to_string(), RepoState::Conflicted);
-                        return Err(Self::conflicted_msg(alias));
-                    }
-                }
-            }
+            OpenedStores::Write(s) => s,
         };
 
         // Ensure the HNSW vector index is built from existing data.
@@ -1192,7 +1136,7 @@ impl ServeState {
             }
         }
 
-        let stores_arc = Arc::new(stores);
+        let stores_arc = stores;
 
         // Fan-out / candidate-detection callers pass touch=false.
         // Open as Warm only — no FSW, no IndexManager overhead.
@@ -1366,6 +1310,65 @@ impl ServeState {
             }
         }
         crate::constants::DEFAULT_EMBEDDING_DIMENSIONS // default
+    }
+
+    /// Opens (or creates) LMDB/Tantivy stores for the repo at db_path.
+    ///
+    /// create_if_missing=false: warmup / incremental reindex path.
+    /// create_if_missing=true:  force-reindex / add-repo path, creates fresh DB.
+    fn try_open_stores(
+        &self,
+        alias: &str,
+        db_path: &Path,
+        create_if_missing: bool,
+    ) -> std::result::Result<OpenedStores, String> {
+        if !db_path.exists() && !create_if_missing {
+            let parent = db_path
+                .parent()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default();
+            return Err(format!(
+                "Database not found at {}. This usually means the repo was removed externally.                  Run codesearch index add {} to recreate, or codesearch index rm {} to clean up the config entry.",
+                db_path.display(),
+                parent,
+                parent
+            ));
+        }
+
+        let dims = self.get_dimensions_for_path(db_path);
+
+        match SharedStores::new(db_path, dims) {
+            Ok(s) => {
+                info!("Opened repo in write mode: {}", alias);
+                Ok(OpenedStores::Write(Arc::new(s)))
+            }
+            Err(write_err) => {
+                if create_if_missing {
+                    return Err(format!(
+                        "Failed to open/create database for {}: {}",
+                        alias, write_err
+                    ));
+                }
+                match SharedStores::new_readonly(db_path, dims) {
+                    Ok(s) => {
+                        info!("Opened repo in readonly mode: {}", alias);
+                        let stores_arc = Arc::new(s);
+                        self.repos.insert(
+                            alias.to_string(),
+                            RepoState::Readonly {
+                                stores: stores_arc.clone(),
+                            },
+                        );
+                        Ok(OpenedStores::Readonly(stores_arc))
+                    }
+                    Err(e) => {
+                        warn!("Failed to open repo {}: {}", alias, e);
+                        self.repos.insert(alias.to_string(), RepoState::Conflicted);
+                        Err(Self::conflicted_msg(alias))
+                    }
+                }
+            }
+        }
     }
 
     /// Get all registered aliases.
@@ -2119,9 +2122,37 @@ async fn reindex_handler(
         let stores = match state.stop_fsw(&alias) {
             Some(s) => s,
             None => {
-                // FSW not running -- try opening normally
-                match state.get_or_open_stores(&alias, true).await {
-                    Ok(s) => s,
+                // FSW not running -- open existing or create fresh DB.
+                // create_if_missing=true so a force-reindex can recover a deleted DB.
+                let cancel = CancellationToken::new();
+                match state.try_open_stores(&alias, &db_path, true) {
+                    Ok(OpenedStores::Write(s)) => {
+                        // Register as Write to block double-open races while we reindex.
+                        state.repos.insert(
+                            alias.clone(),
+                            RepoState::Write {
+                                stores: s.clone(),
+                                index_manager: None,
+                                cancel_token: cancel,
+                            },
+                        );
+                        state.touch_access(&alias);
+                        s
+                    }
+                    Ok(OpenedStores::Readonly(_)) => {
+                        // Cannot force-reindex against a readonly store.
+                        state.active_reindexes.remove(&guard_alias);
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            axum::response::Json(json!({
+                                "error": format!(
+                                    "Repo {} could only be opened read-only; cannot force-reindex",
+                                    alias
+                                ),
+                                "status": "error"
+                            })),
+                        );
+                    }
                     Err(e) => {
                         state.active_reindexes.remove(&guard_alias);
                         return (
@@ -2316,14 +2347,16 @@ async fn add_repo_handler(
         alias
     };
 
-    // Open stores INLINE (fast — just creates dirs + opens LMDB/Tantivy handles).
+    // Open stores INLINE (fast -- just creates dirs + opens LMDB/Tantivy handles).
     // This eliminates the LMDB double-open race that occurred when the old
-    // `index_quiet()` path opened its own LMDB handle, conflicting with
-    // `get_or_open_stores()` calls from the serve's request handlers.
+    //  path opened its own LMDB handle, conflicting with
+    //  calls from the serve's request handlers.
     let db_path = canonical_path.join(DB_DIR_NAME);
-    let dims = state.get_dimensions_for_path(&db_path);
-    let stores = match SharedStores::new(&db_path, dims) {
-        Ok(s) => Arc::new(s),
+    let stores = match state.try_open_stores(&alias, &db_path, true) {
+        Ok(OpenedStores::Write(s)) => s,
+        Ok(OpenedStores::Readonly(_)) => {
+            unreachable!("try_open_stores(create_if_missing=true) never returns Readonly")
+        }
         Err(e) => {
             // Clean up the config entry we just added
             if let Ok(mut config) = state.config.write() {
@@ -2333,7 +2366,7 @@ async fn add_repo_handler(
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 axum::response::Json(json!({
-                    "error": format!("Failed to open database for '{}': {}", alias, e),
+                    "error": format!("Failed to open database for {}: {}", alias, e),
                     "status": "error"
                 })),
             );

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -850,8 +850,12 @@ impl ServeState {
                 RepoState::Warm { stores } => {
                     return Some(stores.clone());
                 }
-                RepoState::Readonly { stores } => {
-                    return Some(stores.clone());
+                RepoState::Readonly { .. } => {
+                    // Cannot force-reindex a readonly store; let the caller
+                    // fall through to try_open_stores(create_if_missing=true)
+                    // which will attempt a write-mode open (and fail with a
+                    // clear error if the write lock is still held).
+                    return None;
                 }
                 RepoState::Conflicted => return None,
             }
@@ -1444,8 +1448,8 @@ impl ServeState {
     }
 
     /// Record that a repo was just accessed (query or reindex).
-    /// Called from `get_or_open_stores(touch=true)`, and `reindex_handler`.
-    /// NOT called from `warmup_repo` — background warmup is not a real query.
+    /// Called from `get_or_open_stores(touch=true)`, `reindex_handler`,
+    /// `add_repo_handler`, and `warmup_repo` (after successful warmup).
     pub(crate) fn touch_access(&self, alias: &str) {
         self.last_access
             .insert(alias.to_string(), std::time::Instant::now());

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -2230,14 +2230,16 @@ struct AddRepoRequest {
     alias: Option<String>,
     /// Create a global index instead of local.
     #[serde(default)]
+    #[allow(dead_code)]
     global: bool,
 }
 
 /// Add-repo handler: POST /repos
 ///
-/// Registers a new repo in repos.json, spawns index creation + warmup in the
-/// background, and returns 202 Accepted immediately.  Indexing must not run
-/// inline because the serve's own startup may still hold the LMDB lock.
+/// Registers a new repo in repos.json, opens the LMDB/Tantivy stores inline
+/// (fast — prevents the double-open race from the old `index_quiet` path),
+/// then spawns a full reindex + vector index build + FSW start in the
+/// background. Returns 202 Accepted immediately.
 async fn add_repo_handler(
     axum::extract::State(state): axum::extract::State<Arc<ServeState>>,
     axum::extract::Json(body): axum::extract::Json<AddRepoRequest>,
@@ -2314,29 +2316,79 @@ async fn add_repo_handler(
         alias
     };
 
-    // Spawn index creation + warmup in the background to avoid blocking the
-    // HTTP handler.  Previously this ran inline, which caused a deadlock when
-    // the serve's own startup still held the LMDB lock (Phase 1).  Returning
-    // 202 Accepted immediately matches the pattern used by reindex_handler.
+    // Open stores INLINE (fast — just creates dirs + opens LMDB/Tantivy handles).
+    // This eliminates the LMDB double-open race that occurred when the old
+    // `index_quiet()` path opened its own LMDB handle, conflicting with
+    // `get_or_open_stores()` calls from the serve's request handlers.
+    let db_path = canonical_path.join(DB_DIR_NAME);
+    let dims = state.get_dimensions_for_path(&db_path);
+    let stores = match SharedStores::new(&db_path, dims) {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            // Clean up the config entry we just added
+            if let Ok(mut config) = state.config.write() {
+                config.unregister_alias(&alias);
+                let _ = config.save();
+            }
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::response::Json(json!({
+                    "error": format!("Failed to open database for '{}': {}", alias, e),
+                    "status": "error"
+                })),
+            );
+        }
+    };
+
+    // Store as Write immediately so get_or_open_stores() finds the repo in the
+    // fast-path and does NOT try to open a second LMDB handle on the same path.
     let cancel_token = CancellationToken::new();
-    let index_path = canonical_path.clone();
+    state.repos.insert(
+        alias.clone(),
+        RepoState::Write {
+            stores: stores.clone(),
+            index_manager: None,
+            cancel_token: cancel_token.clone(),
+        },
+    );
+    state.touch_access(&alias);
+
+    // Guard against concurrent reindex for the same alias.
+    if !state.active_reindexes.insert(alias.clone()) {
+        return (
+            StatusCode::CONFLICT,
+            axum::response::Json(json!({
+                "error": format!("Reindex already in progress for '{}'", alias),
+                "status": "conflict"
+            })),
+        );
+    }
+
+    // Spawn the heavy indexing work in the background.  Returns 202 immediately.
     let alias_bg = alias.clone();
     let state_bg = state.clone();
+    let project_path = canonical_path.clone();
 
     tokio::spawn(async move {
-        match crate::index::index_quiet(Some(index_path.clone()), false, body.global, cancel_token)
-            .await
-        {
+        tracing::info!(
+            "Indexing newly added repo '{}' ({}) in background",
+            alias_bg,
+            project_path.display()
+        );
+
+        match IndexManager::force_reindex_with_stores(&project_path, &db_path, &stores).await {
             Ok(()) => {
                 tracing::info!(
                     "Index created for '{}' ({})",
                     alias_bg,
-                    index_path.display()
+                    project_path.display()
                 );
             }
             Err(e) => {
-                // Index failed — remove the config entry we just added
                 tracing::error!("Index creation failed for '{}': {}", alias_bg, e);
+                // Clean up: remove from repos and config
+                state_bg.repos.remove(&alias_bg);
+                state_bg.active_reindexes.remove(&alias_bg);
                 if let Ok(mut config) = state_bg.config.write() {
                     config.unregister_alias(&alias_bg);
                     let _ = config.save();
@@ -2345,10 +2397,19 @@ async fn add_repo_handler(
             }
         }
 
-        // Warmup the repo (opens DB, builds vector index, stores as Warm)
-        if let Err(e) = state_bg.warmup_repo(&alias_bg).await {
-            tracing::warn!("Warmup failed for newly added repo '{}': {}", alias_bg, e);
+        // Build vector index from freshly indexed data
+        {
+            let mut vstore = stores.vector_store.write().await;
+            if let Err(e) = vstore.build_index() {
+                tracing::warn!("Failed to build vector index for '{}': {}", alias_bg, e);
+            }
         }
+
+        // Start FSW and transition to proper Write state with IndexManager
+        state_bg.restart_fsw(&alias_bg, stores).await;
+
+        state_bg.active_reindexes.remove(&alias_bg);
+        tracing::info!("Repo '{}' fully indexed and ready", alias_bg);
     });
 
     (

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -1,4 +1,4 @@
-//! `codesearch serve` — MCP streamable HTTP server mode.
+﻿//! `codesearch serve` — MCP streamable HTTP server mode.
 //!
 //! Binds on `127.0.0.1:{port}` and serves:
 //! - `GET /health` → JSON health check
@@ -140,10 +140,10 @@ impl std::fmt::Debug for RepoState {
     }
 }
 
-/// Result of [].
+/// Result of [`ServeState::try_open_stores`].
 ///
-/// - : opened in write mode; NOT yet registered in . Caller decides state.
-/// - : opened in readonly mode; ALREADY registered as .
+/// - [`OpenedStores::Write`]: opened in write mode; NOT yet registered in `repos`. Caller decides state.
+/// - [`OpenedStores::Readonly`]: opened in readonly mode; ALREADY registered as [`RepoState::Readonly`].
 pub(crate) enum OpenedStores {
     Write(Arc<SharedStores>),
     Readonly(Arc<SharedStores>),
@@ -981,7 +981,12 @@ impl ServeState {
 
         // Open stores: existence check + write/readonly/conflicted logic.
         let stores = match self.try_open_stores(alias, &db_path, false)? {
-            OpenedStores::Readonly(_) => return Ok(()), // already registered
+            OpenedStores::Readonly(_) => {
+                // Already registered as Readonly by try_open_stores.
+                // Touch so the idle reaper can evict this handle.
+                self.touch_access(alias);
+                return Ok(());
+            }
             OpenedStores::Write(s) => s,
         };
 
@@ -1328,7 +1333,8 @@ impl ServeState {
                 .map(|p| p.display().to_string())
                 .unwrap_or_default();
             return Err(format!(
-                "Database not found at {}. This usually means the repo was removed externally.                  Run codesearch index add {} to recreate, or codesearch index rm {} to clean up the config entry.",
+                "Database not found at {}. This usually means the repo was removed externally. \
+                 Run `codesearch index add {}` to recreate, or `codesearch index rm {}` to clean up the config entry.",
                 db_path.display(),
                 parent,
                 parent
@@ -2388,6 +2394,10 @@ async fn add_repo_handler(
 
     // Guard against concurrent reindex for the same alias.
     if !state.active_reindexes.insert(alias.clone()) {
+        // Clean up the Write registration + cancel the token we just created,
+        // so the leaked LMDB handle is released and the alias reverts to Conflicted.
+        cancel_token.cancel();
+        state.repos.remove(&alias);
         return (
             StatusCode::CONFLICT,
             axum::response::Json(json!({

--- a/src/symbols/csharp.rs
+++ b/src/symbols/csharp.rs
@@ -39,9 +39,10 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::lmdb_registry::TrackedEnv;
 use anyhow::{bail, Context, Result};
 use heed::types::{Bytes, Str};
-use heed::{Database, Env, EnvOpenOptions};
+use heed::{Database, EnvOpenOptions};
 use serde::{Deserialize, Serialize};
 
 use super::scip_parse;
@@ -346,18 +347,17 @@ impl CSharpSymbolIndexer {
     /// Pre-opens ALL named databases so they exist before first use.
     /// LMDB requires named DBs to be created (or opened) in a write txn
     /// before they can be read in later read txns within the same env session.
-    fn open_scip_env(&self, db_path: &Path) -> Result<Env> {
+    fn open_scip_env(&self, db_path: &Path) -> Result<TrackedEnv> {
         let scip_dir = db_path.join("scip");
         std::fs::create_dir_all(&scip_dir)
             .with_context(|| format!("Failed to create SCIP directory: {}", scip_dir.display()))?;
 
         // SAFETY: same pattern as vectordb/store.rs — LMDB mmap contract.
-        let env = unsafe {
-            EnvOpenOptions::new()
-                .map_size(64 * 1024 * 1024) // 64MB — symbol indexes are small
-                .max_dbs(10) // 5 named DBs + headroom
-                .open(&scip_dir)?
-        };
+        // TrackedEnv additionally prevents double-open within the same process.
+        let mut opts = EnvOpenOptions::new();
+        opts.map_size(64 * 1024 * 1024).max_dbs(10); // 64MB, 5 named DBs + headroom
+        let env =
+            unsafe { TrackedEnv::open(&opts, &scip_dir, &format!("SCIP({})", db_path.display()))? };
 
         // Eagerly create / re-open all named databases.
         let mut wtxn = env.write_txn()?;
@@ -572,7 +572,7 @@ impl CSharpSymbolIndexer {
 
     /// Resolve a (possibly fuzzy) symbol name to the canonical SCIP key stored
     /// in `scip_symbols`. Returns `None` if no matching symbol is found.
-    fn resolve_canonical_key(&self, env: &Env, symbol: &str) -> Result<Option<String>> {
+    fn resolve_canonical_key(&self, env: &TrackedEnv, symbol: &str) -> Result<Option<String>> {
         let rtxn = env.read_txn()?;
 
         let symbols_db: Database<Str, Bytes> = match env.open_database(&rtxn, Some(SCIP_DB_NAME))? {

--- a/src/vectordb/store.rs
+++ b/src/vectordb/store.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, Result};
 /// format change). The open path checks this and reports mismatches so the
 /// caller can trigger a rebuild.
 const SCHEMA_VERSION: u32 = 1;
+use crate::lmdb_registry::TrackedEnv;
 use arroy::distances::Cosine;
 use arroy::{Database as ArroyDatabase, ItemId, Reader, Writer};
 use heed::byteorder::BigEndian;
@@ -236,7 +237,7 @@ impl ChunkMetadata {
 /// - ACID transactions
 /// - Memory-mapped for performance
 pub struct VectorStore {
-    env: heed::Env,
+    env: TrackedEnv,
     vectors: ArroyDatabase<Cosine>,
     chunks: Database<U32<BigEndian>, SerdeBincode<ChunkMetadata>>,
     next_id: u32,
@@ -286,11 +287,15 @@ impl VectorStore {
         // level (one `serve` process per machine, and the CLI rejects concurrent
         // reindex). The map_size is reconciled across opens via `resolve_map_size`
         // above, so we never reopen with a smaller map than was previously persisted.
+        // TrackedEnv additionally prevents double-open within the same process.
+        let mut opts = EnvOpenOptions::new();
+        opts.map_size(map_size_mb * 1024 * 1024).max_dbs(10);
         let env = unsafe {
-            EnvOpenOptions::new()
-                .map_size(map_size_mb * 1024 * 1024)
-                .max_dbs(10)
-                .open(db_path)?
+            TrackedEnv::open(
+                &opts,
+                db_path,
+                &format!("VectorStore({})", db_path.display()),
+            )?
         };
 
         // Open or create databases
@@ -371,12 +376,17 @@ impl VectorStore {
         // which is acceptable because the writer's resize logic explicitly
         // rebuilds the env (see `resize_map` below) before any reader is invited
         // to reopen.
+        // TrackedEnv additionally prevents double-open within the same process.
+        let mut opts = EnvOpenOptions::new();
+        opts.map_size(map_size_mb * 1024 * 1024).max_dbs(10);
+        // SAFETY: READ_ONLY flag is safe for concurrent read access.
+        unsafe { opts.flags(EnvFlags::READ_ONLY) };
         let env = unsafe {
-            EnvOpenOptions::new()
-                .map_size(map_size_mb * 1024 * 1024)
-                .max_dbs(10)
-                .flags(EnvFlags::READ_ONLY)
-                .open(db_path)?
+            TrackedEnv::open(
+                &opts,
+                db_path,
+                &format!("VectorStore(readonly, {})", db_path.display()),
+            )?
         };
 
         // Open databases (read-only, no create)


### PR DESCRIPTION
## Summary

Centralize all LMDB database open/create logic into a single `try_open_stores` helper on `ServeState`, eliminating 4 duplicate code paths. Fix the bug where `POST /repos/{alias}/reindex?force=true` returned HTTP 500 when the `.codesearch.db` directory had been externally deleted.

## Changes

### New: `try_open_stores` helper (`src/serve/mod.rs:1319`)
- Single entry point for all open LMDB stores operations
- `create_if_missing=false`: fails fast if DB missing; tries write -> readonly -> Conflicted fallback
- `create_if_missing=true`: creates fresh DB if absent; no readonly fallback
- Returns `OpenedStores::Write` (caller registers) or `OpenedStores::Readonly` (already registered)

### Bug fix: force-reindex on deleted DB
- `reindex_handler` force branch now calls `try_open_stores(.., true)` when FSW is not running
- Previously called `get_or_open_stores` which blocked on missing DB -> HTTP 500

### 4 call sites unified
- `warmup_repo` slow path: create_if_missing=false
- `get_or_open_stores` slow path: create_if_missing=false
- `reindex_handler` force branch: create_if_missing=true (bug fix)
- `add_repo_handler`: create_if_missing=true

### Bonus fixes
- `stop_fsw` returns None for Readonly repos (prevents force-reindex against readonly-locked stores)
- `add_repo_handler` concurrent guard cancels token + removes repos entry on 409
- `touch_access` doc updated (warmup_repo now calls it)
- `TrackedEnv` runtime guard prevents LMDB double-open from MCP fallback paths

## Testing
- cargo check pass
- cargo clippy -- -D warnings pass
- cargo test --lib: 390 passed, 12 ignored, 0 failed
- QC gate (fmt + check + clippy + test) pass