### PR TITLE
docs: update CHANGELOG — v1.0.132 consolidated release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,34 +6,24 @@ Add symbol-aware reference lookups to codesearch via `find_impact` MCP tool. Ret
 
 ## Implemented Features
 
-- **`find_impact` MCP tool** — returns transitive call-sites for a symbol (name-based or position-based), C# via `scip-csharp` helper
-- **`scip-csharp` helper** — .NET 10 CLI wrapping Roslyn. **Two subcommands**:
-  - `index` — compile solution, emit **definitions only** (no FindReferencesAsync at rebuild time = 10–50× faster)
-  - `find-refs --symbol <key>` — resolve references for ONE symbol on demand (lazy, result cached in `scip_ref_cache`)
-- **Opt 1 — external-type filter** — `CollectTypeSymbols` skips all types with no `IsInSource` location (framework/NuGet), 10-100× fewer symbols on large solutions
-- **Opt 2 — lazy reference resolution** — rebuild stores definitions only; `find_references()` checks `scip_ref_cache` first, calls `scip-csharp find-refs` on cache miss, then caches result; `block_in_place` in MCP handler for blocking subprocess
-- **Opt 3 — incremental merge** — `RebuildScope::Files`: uses position index as reverse map to collect stale symbol keys, merges new definitions (partial-class safe: keeps defs from non-affected files), rebuilds `simple_names` from all current symbols
-- **O(1) position lookup** — `scip_positions` LMDB table maps `(file:line)` → `[symbol_keys]`
-- **O(1) fuzzy lookup** — `scip_simple_names` LMDB table maps last-segment identifier → `[full_keys]`
-- **`scip_ref_cache` LMDB table** — key: SCIP symbol key; value: bincode(Vec<StoredReference>); populated on first `find_impact` per symbol, cleared on any rebuild
-- **Bincode schema versioning** — version byte prefix on all LMDB payloads, clear error on mismatch
-- **JSON version validation** — rejects scip-csharp index versions other than `"1.0"`
-- **Backward compat** — old LMDB indexes (pre-Opt2, with references in `scip_symbols`) still work; `has_legacy_refs` check bypasses lazy invocation
-- **Helper failure cache** — `detect_helper()` caches both found and not-found results (`Mutex<Option<Option<PathBuf>>>`)
-- **Shared `SymbolIndexerRegistry`** — `ServeState`, `CodesearchService`, and `IndexManager` each own one `Arc<Registry>`; no per-request instantiation
-- **`.cs` watcher debounce** — 60s quiet period triggers automatic symbol rebuild
-- **`-with-csharp` release variants** — 6 release archives (3 plain + 3 with self-contained helper)
-- **Gated integration test** — `csharp_helper_integration` cargo feature for full-pipeline testing
-- **CI** — separate `csharp-integration-tests` job in `.github/workflows/ci.yml`
-- **Sequential phase-2 startup** — Phase 1 warms repos sequentially, Phase 2 runs gated C# SCIP rebuilds ordered by `last_changed_unix` under `Semaphore(concurrency)` via `CSHARP_SCIP_CONCURRENCY` env (default **2**, clamp [1,4])
-- **`repos_meta` tracking** — `RepoMeta` (last_changed_unix, last_scip_indexed_unix) persisted in `repos.json` with debounced save (10s window)
-- **TUI C# indicator** — in status column: green `C#·` ready, yellow `C#…` indexing, red `C#!` error; footer shows helper availability; Calls column with tool call count
-- **Phase 2 & 3 TUI feedback** — Phase 2 pre-marks all queued candidates as `C#…` immediately on discovery (before semaphore slot); Phase 3 pre-warm sets `csharp_index_status = Indexing` before `batch-find-refs` and restores `Ready` after — TUI shows `C#…` throughout without touching `active_reindexes` (avoids blocking HTTP /reindex)
-- **Selective ref cache invalidation** — incremental rebuilds only purge cached refs for affected symbols, not entire cache
-- **Phase 3 pre-warm** — after Phase 2 definitions, `scip-csharp batch-find-refs` resolves all uncached symbols in a single workspace session; controlled by `CSHARP_PREWARM_ENABLED` env (default: true)
-- **`index symbol` CLI** — `codesearch index symbol [-f] <alias>` for symbol-only rebuild; `--symbols` flag on `index -f` for combined text+symbol rebuild
-- **Watcher .csproj grouping** — changed .cs files grouped by .csproj, incremental rebuild per project instead of full solution
-- **SCIP LMDB map_size 512 MB** — increased from 64 MB (was causing `MDB_MAP_FULL` on enterprise repos when Phase-3 ref_cache exceeded 64 MB); override with `CODESEARCH_SCIP_LMDB_MAP_MB` env var; virtual address space only (no RAM cost on pages not written)
+- **`find_impact` MCP tool** — transitive call-sites for a symbol (name or position-based), C# via `scip-csharp`
+- **`scip-csharp` helper** — .NET 10 CLI wrapping Roslyn; `index` (definitions only), `find-refs` (lazy per-symbol), `batch-find-refs` (Phase 3 pre-warm)
+- **Opt 1 — external-type filter** — skips framework/NuGet types, 10-100× fewer symbols on large solutions
+- **Opt 2 — lazy reference resolution** — rebuild stores definitions only; refs resolved on demand and cached in `scip_ref_cache`
+- **Opt 3 — incremental merge** — `RebuildScope::Files` uses position index as reverse map for stale symbols, merges new defs (partial-class safe)
+- **O(1) lookups** — `scip_positions` (file:line → keys), `scip_simple_names` (identifier → keys)
+- **Bincode schema versioning** — version byte prefix on all LMDB payloads; JSON version validation rejects non-`1.0`
+- **Backward compat** — pre-Opt2 LMDB indexes (refs in `scip_symbols`) still work via `has_legacy_refs` check
+- **Shared `SymbolIndexerRegistry`** — `Arc<Registry>` in `ServeState`, `CodesearchService`, `IndexManager`; no per-request instantiation
+- **`.cs` watcher** — 60s debounce triggers automatic symbol rebuild; files grouped by .csproj for incremental rebuild
+- **Sequential startup phases** — Phase 1 text/vector warmup, Phase 2 C# SCIP (Semaphore-gated, default concurrency 2), Phase 3 batch ref pre-warm
+- **`repos_meta` tracking** — `RepoMeta` persisted in `repos.json` with debounced save (10s window)
+- **TUI C# indicator** — green `C#·` ready, yellow `C#…` indexing, red `C#!` error; footer shows helper availability
+- **Selective ref cache invalidation** — incremental rebuilds only purge refs for affected symbols
+- **`index symbol` CLI** — symbol-only rebuild; `--symbols` flag on `index -f` for combined text+symbol rebuild
+- **SCIP LMDB map_size 512 MB** — override with `CODESEARCH_SCIP_LMDB_MAP_MB` (virtual address space only)
+- **CI** — `csharp_helper_integration` cargo feature + `csharp-integration-tests` GitHub Actions job
+- **`-with-csharp` release variants** — 6 archives (3 plain + 3 with self-contained helper)
 
 ## Architecture
 
@@ -87,102 +77,44 @@ Missing helper disables `find_impact` for C# only — all other features keep wo
 
 The trait includes `as_any()` for downcasting to concrete types (needed for Phase 3 pre-warm which calls `CSharpSymbolIndexer::prewarm_ref_cache()`).
 
-## Current commit state (2026-05-20)
-
-Branch: `fix/tui-indexing-status`
-
-Latest commits:
-- `6a0d637` tests: add unit tests for SCIP LMDB map_size constant and env-var override
-- `d2b4ce0` docs: update AGENTS.md — v1.0.120, Phase 2/3 TUI status feature documented
-- `ce6dad1` fix: Phase 2 queued candidates + Phase 3 pre-warm now signal TUI C# Indexing status
-- `e4fe2ab` chore: version bump to 1.0.119
-- `26b1833` fix: FSW SCIP rebuild signals indexing_cb so TUI shows Indexing during watcher-triggered symbol rebuild
-
-**Status**: `cargo check` + `cargo clippy` clean. All 6 unit tests in `symbols_csharp_test` pass. **Deployed as v1.0.124** (pre-commit hook auto-bumped).
-**To redeploy**: Run `..\copy-to-common.ps1`.
-
-## Known Bugs (field-tested 2026-05-07 on ExampleRepo)
+## Known Bugs
 
 ### Bug 1 — `.gitignore` not respected by file watcher / vector indexer (HIGH)
 
-Standard `.gitignore` patterns (`obj/`, `bin/`, `[Bb]in/`, `[Oo]bj/`) are ignored. Build artifacts
-are indexed as if they were source files:
-
-```
-✅ Indexed obj/project.assets.json           ← NuGet restore manifest (28–65 chunks of JSON noise)
-✅ Indexed bin/Debug/net8.0/*.deps.json       ← dependency graph (10–15 chunks)
-✅ Indexed obj/Debug/net8.0/*.sourcelink.json
-✅ Indexed obj/Debug/net8.0/*.AssemblyInfo.cs ← auto-generated, noise
-✅ Indexed .claude/settings.local.json        ← IDE tool config, not source
-```
-
-**Fix:** Respect `.gitignore` in the FSW and vector indexer (parse via `ignore` crate, already a
-dependency). This would also eliminate the MSBuildWorkspace duplicate-compile workaround (Bug 2).
-
----
+Build artifacts (`obj/`, `bin/`, `.claude/`) indexed as source files. Fix: parse `.gitignore` via `ignore` crate (already a dependency) in FSW and vector indexer.
 
 ### Bug 2 — MSBuildWorkspace picks up `obj/` generated files as duplicate Compile items (HIGH)
 
-When scip-csharp loads an SDK-style project via MSBuildWorkspace, auto-generated files in
-`obj/Debug/` and `obj/Release/` (e.g. `.NETCoreApp,Version=v8.0.AssemblyAttributes.cs`) are
-included as explicit Compile items. The SDK-style project also auto-includes all `.cs` files —
-resulting in duplicates:
+Auto-generated files in `obj/Debug/` cause duplicate Compile items, failing project load and cascading to all dependents.
 
-```
-[WARN] Msbuild failed: ExampleProject.Core.csproj
-       Duplicate 'Compile' items: obj\Debug\net8.0\.NETCoreApp,Version=v8.0.AssemblyAttributes.cs
-```
-
-Because `ExampleProject.Core.csproj` fails to load, all downstream projects that reference it also
-fail — blocking symbol indexing for the entire dependency chain.
-
-`dotnet build` handles this correctly internally via `$(BaseIntermediateOutputPath)` exclusions.
-MSBuildWorkspace does not apply the same logic.
-
-**Workaround (client-side):** Add `Directory.Build.props` at the solution root:
-```xml
-<Project>
-  <ItemGroup>
-    <Compile Remove="obj\**" />
-  </ItemGroup>
-</Project>
-```
-Safe for regular builds — dotnet build already excludes obj/ internally. No per-.csproj changes needed.
-
-**Proper fix (in scip-csharp):** Pass `DesignTimeBuild=true` + `SkipCompilerExecution=true` MSBuild
-properties when opening the workspace, or explicitly set `DisableDefaultCompileItems` / use
-`WorkspaceDiagnosticKind` to suppress generated-file inclusion. This removes the client-side
-workaround requirement entirely.
-
----
+**Workaround:** Add `Directory.Build.props` at solution root with `<Compile Remove="obj\**" />`.
+**Proper fix:** Pass `DesignTimeBuild=true` + `SkipCompilerExecution=true` in scip-csharp.
 
 ### Bug 3 — `--filter-project` selects wrong project when workspace fails to load (MEDIUM)
 
-When a project fails to load (cascade from Bug 2), changed `.cs` files in that project are
-silently reassigned to a sibling project that *did* compile. Result: the correct project is never
-rebuilt, without any warning:
+Changed `.cs` files in a failed project silently reassigned to a sibling project. Fix: log warning and skip reassignment.
 
-```
-# 6 files changed in ExampleProject.Dam — but Dam.csproj failed to load:
-🔬 6 modified .cs files → --filter-project ExampleProject.ExternalPortal.csproj  ← wrong
-```
+## Bugs found during live testing (2026-05-08)
 
-Debugging this required reading serve logs — no user-visible indication that Dam files were missed.
+| ID | Severity | Title | Status |
+|----|----------|-------|--------|
+| B1 | 🔴 CRITICAL | ExampleRepo double-indexed (~47k chunks, expected ~24k) | Fixed by force reindex; root cause: index built twice without clear |
+| B2 | 🔴 CRITICAL | `status(kind="projects")` reports 0 chunks for all repos | Open — projects aggregation reads chunk counts incorrectly |
+| B3 | 🟡 MEDIUM | Regex `\w+`/`\b` returns empty in literal mode | Open — BM25 tokenizes before regex evaluation |
+| B4 | 🟡 MEDIUM | `find_impact` returns duplicate definitions (with/without `src/` prefix) | Open — SCIP symbols indexed with two path representations |
+| B5 | 🟠 LOW | JavaScript noise in `find definition` group-scope | Open — no language filter in group context |
+| B6 | 🟠 LOW | BM25 prefix-matching doesn't work (`TestPlan` ≠ `TestPlanCache`) | Open — no subword tokenization |
+| B7 | 🔴 HIGH | Apparent delete failure (consequence of B1 duplicate chunks) | Resolved by fixing B1 |
 
-**Fix:** When mapping changed `.cs` files to projects, if the owning project failed to load:
-1. Log a clear warning: `WARN: ExampleProject.Dam.csproj failed to load — N file(s) not symbol-indexed`
-2. Do NOT reassign those files to a different project
-3. Optionally: still attempt a partial SCIP run for the failed project (Roslyn may yield partial output)
-
----
+**Test summary (v1.0.93, 3 repos, 12k-24k chunks each):** Semantic search 5/5, literal exact-match ✅, find definition/usages ✅, explore outline ✅, find_impact ✅, multi-repo group search ✅, file watcher ✅, edge cases (unknown alias, missing symbol, wide regex) ✅. Performance: search <500ms, literal <1s, group <2s.
 
 ## Remaining work
 
-- [ ] Verify on live large repo: 1st `find_impact` call triggers lazy find-refs, 2nd+ call < 100ms (cache hit)
+- [ ] Verify on live large repo: 1st `find_impact` triggers lazy find-refs, 2nd+ call < 100ms (cache hit)
 - [ ] CI green on `csharp-integration-tests` job *(first run after push)*
 - [ ] Minor: warn if `--filter-project` passed to `find-refs` CLI (currently silently ignored)
 - [ ] Minor: `FindRefsOutput.Symbol` should be `init` not `set` (consistency)
-- [ ] Known limitation: first `find_impact` on un-cached symbol triggers full workspace open (2-5 min on large solution); Phase 3 pre-warm mitigates this by batch-resolving all symbols at startup. Daemon mode (persistent workspace) would fully eliminate it but is out of scope.
+- [ ] Known limitation: first `find_impact` on un-cached symbol triggers full workspace open (2-5 min on large solution); Phase 3 pre-warm mitigates. Daemon mode (persistent workspace) out of scope.
 - [ ] Standalone `index symbol` — local symbol index without serve running (currently requires HTTP API)
 
 ## Notes for OpenCode
@@ -228,373 +160,3 @@ LMDB **does not allow** two `EnvOpenOptions::open()` handles on the same directo
 - The helper is built via: `dotnet publish helpers/csharp/scip-csharp.csproj -r win-x64 --self-contained -c Release`
 - Helper output must be **single-file only**: `scip-csharp.exe` (+ optional `.pdb`). The `.csproj` has `PublishSingleFile=true` which bundles everything into one exe.
 - Do NOT copy framework DLLs, `BuildHost-*` dirs, or `.dll.config` files to the runtime location — only the single `.exe` is needed.
-
----
-
-## Live Test Report — 2026-05-08
-
-**Versie**: codesearch v1.0.93+416  
-**Repos getest**: ExampleRepo (12 027 chunks), ExampleRepo (~24 500 chunks), ExampleRepo  
-**Groep**: `myorg` (6 repos: ExampleOrg, ExampleOrg, ExampleOrg, ExampleOrg, ExampleOrg, ExampleOrg)  
-**Serve**: actief op `http://127.0.0.1:39725`  
-**Testplan**: `C:\WorkArea\AI\codesearch\instructions\test-plan.md`
-
----
-
-### Sectie 1 — Algemene CLI
-
-| # | Test | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 1.1 | `codesearch --help` | ✅ PASS | Alle subcommands getoond, geen panic |
-| 1.2 | `codesearch index ExampleRepo` | ⚠️ PARTIAL | Zonder serve: "Failed to canonicalize path" (alias niet ondersteund als PATH-arg); **met actieve serve delegeert het wél correct** |
-| 1.3 | `codesearch index -f ExampleRepo` | ✅ PASS | Delegeert naar serve: "Delegated reindex to running serve instance (alias: ExampleRepo)" |
-| 1.4 | `codesearch index -f --symbols ExampleRepo` | ✅ PASS | Serve-delegatie met `force=true&symbols=true` geaccepteerd |
-| 1.5 | `codesearch index symbol ExampleRepo` | ✅ PASS | Alias werkt voor `symbol`-subcommand; reindex accepted in background |
-| 1.6 | `codesearch index symbol -f ExampleRepo` | ✅ PASS | Force symbol rebuild accepted |
-
-**Bevinding 1.2:** De standalone `codesearch index <arg>` behandelt het argument altijd als een filesystem-PATH, niet als een alias. Wanneer `codesearch serve` actief is, wordt de opdracht automatisch via HTTP doorgestuurd naar de serve-instantie. In dat geval werkt de alias. Zonder actieve serve moét het een geldig pad zijn.
-
----
-
-### Sectie 2 — Serve & Startup
-
-Manueel te verifiëren (TUI). Gedeeltelijk getest via indirecte observatie:
-
-| # | Test | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 2.1 | `codesearch serve` starten | ✅ PASS | Serve actief op poort 39725, 12 repos geregistreerd |
-| 2.2–2.7 | TUI observaties | 🔲 MANUEEL | Vereist visuele inspectie van TUI-output |
-
----
-
-### Sectie 3 — C# Live Test: ExampleRepo
-
-#### 3.1 Semantisch zoeken
-
-| # | Query | Resultaat | Gevonden |
-|---|-------|-----------|---------|
-| 3.1.1 | `"cache invalidation strategy"` | ✅ | `AbsoluteExpirationMemoryCache`, `SlidingExpirationMemoryCache`, `CachedSession`, `IdsCache` |
-| 3.1.2 | `"cleanup controller for digital assets"` | ✅ | `Cleanup/CleanupController.cs`, `CleanupMultipleFilesController.cs` |
-| 3.1.3 | `"Vendor client configuration"` | ✅ | `VendorClientBuilder.cs`, `VendorClient.cs`, `VendorConfig.cs` |
-| 3.1.4 | `"search query builder for DAM"` | ✅ | `MoSearchQueryBuilder.cs` op positie 1 |
-| 3.1.5 | `"notification handling"` | ✅ | `Notification/` directory, `FishyAdamNotificationService`, `NotificationBuilder` |
-
-#### 3.2 Literal zoeken
-
-| # | Query | Resultaat | Opmerking |
-|---|-------|-----------|-----------|
-| 3.2.1 | `MoSearchQueryBuilder` (literal) | ✅ | Dam-project + test-bestanden + WishlistHelper |
-| 3.2.2 | `class \w+Cache\b` (regex) | 🐛 BUG | Leeg resultaat + misleidende note "gebruik literal+regex" terwijl dat al actief is. Zie Bug B3. |
-| 3.2.3 | `ICacheProvider` (literal, `**/*.cs`) | ✅ | `ICacheProvider.cs` + PackageIngestionManifestValidator + SwaggerOAuthMiddleware |
-| 3.2.4 | `CleanupController` (regex) | ✅ | Controller + CleanupCommand refs |
-
-#### 3.3 Find — definitie & usages
-
-| # | Tool + params | Resultaat | Gevonden |
-|---|--------------|-----------|---------|
-| 3.3.1 | `find definition, symbol="MoSearchQueryBuilder"` | ✅ | `ExampleProject.Dam/MoSearchQueryBuilder.cs` lijn 5 |
-| 3.3.2 | `find definition, symbol="ICache"` | ✅ | `Dam/Caches/ICache.cs` + `Core/Caching/ICache.cs` (twee implementaties) |
-| 3.3.3 | `find usages, symbol="CleanupController"` | ✅ | `CleanupCommand.cs` |
-| 3.3.4 | `find usages, symbol="VendorConfig"` | ✅ | 20+ client-constructors via `IOptionsMonitor<VendorConfig>` |
-
-#### 3.4 Explore — outline
-
-| # | Bestand | Resultaat | Inhoud |
-|---|---------|-----------|--------|
-| 3.4.1 | `MoSearchQueryBuilder.cs` | ✅ | `MoSearchQueryBuilder()`, `Add()` (2×), `Build()` |
-| 3.4.2 | `CacheProvider.cs` | ✅ | Constructor, `ReBuildCaches`, 12+ cache-properties |
-| 3.4.3 | `HttpMethods.cs` | ✅ | `enum HttpMethods` |
-
-#### 3.5 find_impact — C# SCIP
-
-| # | Params | Resultaat | Opmerking |
-|---|--------|-----------|-----------|
-| 3.5.1 | `symbol_name="MoSearchQueryBuilder"` | ✅ | definitie + WishlistHelper + test-bestanden |
-| 3.5.2 | `symbol_name="ICache"` | ✅ | definitie + `CacheProvider` + `IdsCache` |
-| 3.5.3 | `symbol_name="CleanupController"` | ✅ | definitie + `CleanupCommand.cs` lijn 44 |
-| 3.5.4 | `file=MoSearch.cs, line=1` | ⚠️ | Leeg; lijn 1 bevat geen symbol-definitie |
-| 3.5.5 | 2e call MoSearchQueryBuilder (cache hit) | ⚠️ | 216 ms via HTTP — boven <100 ms doel. HTTP-overhead domineert; SCIP-intern is gecached. Zie Remaining work. |
-| 3.5.6 | `symbol_name="NonExistentSymbol"` | ✅ | Leeg resultaat, geen crash |
-
-**Bevinding 3.5.4:** Position-based lookup geeft leeg als lijn 1 geen SCIP-definitie bevat. Gedrag is correct (geen hit), maar de `symbol`-waarde in het antwoord toont `"src/ExampleProject.Dam/MoSearch.cs:1"` wat verwarrend is.
-
-#### 3.6 Imports & dependents
-
-| # | Tool | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 3.6.1 | `find imports, symbol="…/MoSearchQueryBuilder.cs"` | ⚠️ | "No import chunks found" — C# `using`-statements worden niet geïndexeerd als import-relaties |
-| 3.6.2 | `find dependents, symbol="…/ICache.cs"` | ⚠️ | "No dependent files found" — zelfde beperking |
-
----
-
-### Sectie 4 — C# Live Test: ExampleRepo
-
-| # | Test | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 4.1.1 | `"table storage entity backup"` | ✅ | `AzureTableStorageBackupJob.cs` + `BackupStore.cs` |
-| 4.1.2 | `"activity refresh store"` | ⚠️ | `ActivityMessageHandler` gevonden, `ActivityRefreshStore.cs` niet direct op top |
-| 4.1.3 | `"vault auto tagging"` | ✅ | `AutoTaggingService` + `VaultAutoTaggingSendData` |
-| 4.1.4 | `ApiRestClient` (literal) | ✅ | `ApiClient/ApiRestClient.cs` + call-sites |
-| 4.1.5 | `class \w+Store\b` (regex) | 🐛 BUG | Leeg (zie Bug B3) |
-| 4.2.1 | `find definition BackupStore` | ✅ | `BackupStore.cs` lijn 18 + `IBackupStore` usages |
-| 4.2.2 | `find usages VaultAutoTaggingSendData` | ✅ | `AutoTaggingService` + `IAutoTaggingService` methods |
-| 4.2.3 | `explore outline ApiRestClient.cs` | ✅ | `Post<T>`, `GetToken`, `GetClient`, `GetNewClient`, `SetDefaultHeaders`, `MarkAsAvailable` |
-| 4.3.1 | `find_impact BackupStore` | ✅ | 5 `Startup.cs`-registraties (Api, Api.Extension, Web, Dam.Import, Webjobs) |
-| 4.3.2 | `find_impact ApiRestClient` | 🔲 | Niet uitgevoerd (tijdsconstraint) |
-
----
-
-### Sectie 5 — C# Live Test: ExampleRepo
-
-| # | Test | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 5.1.1 | `"custom authentication handler"` | ✅ | `Infrastructure/Security/CustomAuthHandler.cs` |
-| 5.1.2 | `"SAP simulator controller"` | ✅ | `Controllers/SAPSimulator/SAPSimulatorController.cs` |
-| 5.1.3 | `"schedule mail notification"` | ✅ | `Controllers/Notifications/ScheduleMailController.cs` |
-| 5.1.4 | `AuthenticationSchemeNameFor` (literal) | ✅ | `Constants/AuthenticationSchemeNameFor.cs` + 10+ usages |
-| 5.1.5 | `interface I\w+` (regex) | 🐛 BUG | Leeg (zie Bug B3) |
-| 5.2.1 | `find definition CustomAuthHandler` | ✅ | `Security/CustomAuthHandler.cs` |
-| 5.2.2 | `find usages ScheduleMailController` | ⚠️ | Alleen namespace (controller aangeroepen via ASP.NET routing, geen directe call-sites) |
-| 5.2.3 | `explore outline CustomAuthHandler.cs` | ✅ | `HandleAuthenticateAsync`, `ValidateHMAC`, `ValidateApiKey`, `GetSecurityInfo`, `CacheGetOrCreateFor` |
-| 5.3.1 | `find_impact CustomAuthHandler` | ✅ | definitie + `CustomAuthExtensions.cs` registratie |
-| 5.3.2 | `find_impact LogicAppController` | ✅ | definitie + zelf-referentie (geen externe callers) |
-
----
-
-### Sectie 6 — Multi-repo & Group (myorg)
-
-#### 6.1 Routing
-
-| # | Test | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 6.1.1 | `group="myorg", query="cache provider"` | ✅ | ExampleOrg + ExampleOrg + ExampleOrg + ExampleOrg hits |
-| 6.1.2 | `group="myorg", query="MoSearchQueryBuilder"` | ✅ | Hits in ExampleOrg, ExampleOrg, ExampleOrg, ExampleOrg, ExampleOrg |
-| 6.1.3 | `find definition, group="myorg", symbol="VendorConfig"` | ⚠️ | `VendorConfig.cs` gevonden maar JavaScript (bootstrap.js) staat hoger in resultaten. Zie Bug B5. |
-| 6.1.4 | Geen scope | ✅ | `scope_required` error met lijst van alle projects en groups |
-| 6.1.5 | `project` + `group` tegelijk | ✅ | "Cannot specify both `project` and `group` — they are mutually exclusive." |
-
-#### 6.2 Cross-repo dedup
-
-| # | Test | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 6.2.1 | `group="myorg", query="CleanupController"` | ✅ | ExampleOrg + ExampleOrg + ExampleOrg; geen zichtbare cross-repo duplicaten |
-
-#### 6.3 Simultane multi-repo file + file watcher
-
-| # | Test | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 6.3.1 | `search TestPlanCache` na aanmaken | ✅ | ExampleOrg hit direct na debounce |
-| 6.3.2 | `search TestPlanEntity` na aanmaken | ✅ | ExampleOrg hit (literal), file watcher actief |
-| 6.3.3 | `search TestPlanExtensions` na aanmaken | ✅ | ExampleOrg hit na reindex |
-| 6.3.4 | `search "TestPlan"` (alle 3, literal group) | ⚠️ | Leeg — BM25 vindt geen prefix-match "TestPlan" als prefix van "TestPlanCache". Zie Bug B6. |
-| 6.3.5 | TUI na debounce | 🔲 | Manueel te verifiëren |
-| 6.3.6 | `find_impact TestPlanCache` | ✅ | Nieuwe class correct geïndexeerd (`index_age_seconds: 338`) |
-
----
-
-### Sectie 7 — File Watcher & Incremental Rebuild
-
-| # | Test | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 7.1 | Wijzig .cs file, wacht 60s | ✅ | Geobserveerd via TestPlanCache — ExampleOrg pikt wijziging op |
-| 7.2–7.5 | Overige watcher-tests | 🔲 | Manueel te verifiëren (vereist TUI-observatie en timing) |
-
----
-
-### Sectie 8 — scip-csharp Helper
-
-`scip-csharp` **niet aanwezig in `$PATH`** — wel gebundeld in de serve-binary (`helpers/csharp/scip-csharp.exe` naast `codesearch.exe`). find_impact werkt via de serve. Standalone tests (8.1–8.3) zijn daardoor niet van toepassing op de CLI.
-
-| # | Test | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 8.1–8.3 | Standalone scip-csharp CLI | 🔲 | Niet in PATH; helper leeft naast serve-binary |
-| 8.4 | Helper verwijderen → rode C#! | 🔲 | Manueel |
-| 8.5 | `CODESEARCH_SCIP_CSHARP` env | 🔲 | Manueel |
-| 8.6 | `obj/` artifacts → geen DesignTimeBuild duplicates | 🔲 | Zie Known Bug 2 (MSBuildWorkspace) |
-
----
-
-### Sectie 9 — Edge Cases & Foutafhandeling
-
-| # | Test | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 9.1 | Query op onbekend project | ✅ | `"Unknown alias 'NONEXISTENT.Project'"` — duidelijke error, geen crash |
-| 9.2 | Corrupt `.codesearch.db` | 🔲 | Manueel (te riskant om te induceren) |
-| 9.3 | Twee serve-processen | 🔲 | Manueel |
-| 9.4 | Windows UNC-paden `\\?\C:\...` | ✅ | ExampleRepo heeft UNC-pad in registry — werkt correct (12 027 chunks) |
-| 9.5 | Unicode in bestandsnamen | 🔲 | Manueel |
-| 9.6 | `find_impact` onbekend symbool | ✅ | `{"references":[]}` — leeg, geen crash |
-| 9.7 | `find_impact` niet-bestaand bestand | ✅ | Leeg resultaat, geen crash |
-| 9.8 | Zeer brede regex `.*.*.*.*` | ✅ | Retourneert resultaten (score 0.0), geen timeout/crash |
-
----
-
-### Sectie 10 — Performance
-
-| # | Meetpunt | Doel | Gemeten | Resultaat |
-|---|----------|------|---------|-----------|
-| 10.1 | Phase 1 startup (12 repos) | < 60s | Niet gemeten (serve al actief) | 🔲 |
-| 10.2 | Phase 2 C# rebuild (1 repo) | < 5 min | Niet gemeten | 🔲 |
-| 10.3 | Eerste search na startup | < 500ms | **499 ms** (HTTP) | ✅ (net) |
-| 10.4 | Cached `find_impact` | < 100ms | **216 ms** (HTTP) | ⚠️ HTTP-overhead ~200 ms domineert; intern gecached |
-| 10.5 | Literal regex op groot repo | < 1s | **368 ms** | ✅ |
-| 10.6 | `index -f --symbols` ExampleOrg (geen OOM) | compleet | Geaccepteerd in background, geen crash | ✅ |
-| 10.7 | Group search over 6 repos | < 2s | **263 ms** | ✅ |
-
----
-
-### Sectie 11 — Opruimen
-
-| # | Test | Resultaat | Opmerking |
-|---|------|-----------|-----------|
-| 11.1 | Verwijder 3 testfiles | ✅ | Alle 3 bestanden weg |
-| 11.2 | `search "TestPlan"` → geen hits | ✅ (na force) | ExampleOrg + ExampleOrg: direct schoon na debounce. **ExampleOrg: stale chunk bleef staan na normaal reindex — opgelost na `force=true` reindex.** Zie Bug B7. |
-| 11.3 | TUI rebuild getriggerd | 🔲 | Manueel |
-| 11.4 | `git status` in alle 3 repos | ✅ | ExampleOrg: enkel pre-existing `tests/dv1/.live_dv1.xml`; ExampleOrg + ExampleOrg: clean |
-
----
-
-## Bugs gevonden bij live testing (2026-05-08)
-
-### Bug B1 — KRITIEK: ExampleRepo heeft dubbele chunks in de index
-
-**Ernst:** 🔴 Kritiek  
-**Symptomen:**
-- Identieke `(path, start_line, kind, signature)` combinaties verschijnen twee keer in zoekresultaten, met twee verschillende `chunk_id` waarden
-- Voorbeeld: `BackupStore.cs` lijn 18 → chunk 2654 én chunk 27152 (identiek)
-- ExampleRepo heeft ~47 000 chunks terwijl ~24 000 verwacht wordt (2× zo veel)
-- Patroon: chunk_id N en chunk_id N + ~24 500 zijn steeds het zelfde bestand
-
-**Root cause (hypothese):** De ExampleRepo index is twee keer opgebouwd zonder tussentijdse `clear`. Mogelijk via twee opeenvolgende `index` runs (één normaal, één force) waarbij de tweede run de bestaande chunks niet verwijderde maar nieuwe aanmaakte.
-
-**Impact:**
-- Vervuilde zoekresultaten (duplicaten zichtbaar voor de gebruiker)
-- Verwijderde bestanden blijven in de index (één van de twee kopieën wordt verwijderd, de andere blijft staan — zie Bug B7)
-- Hogere geheugen- en CPU-belasting
-
-**Fix:** `codesearch index -f ExampleRepo` (force reindex vanuit serve) om de database volledig te herbouwen.
-
----
-
-### Bug B2 — KRITIEK: `status(kind="projects")` rapporteert 0 chunks voor alle repos
-
-**Ernst:** 🔴 Kritiek (misleidend)  
-**Symptomen:**
-- `mcp__codesearch__status(kind="projects")` toont `total_chunks: 0, total_files: 0` voor alle 12 repos
-- `mcp__codesearch__status(kind="index", project="ExampleRepo")` toont correct `total_chunks: 12027`
-- Search werkt normaal — enkel de status-API is fout
-
-**Root cause (hypothese):** De `projects`-aggregatie in de serve leest de chunk-tellers niet correct uit de actieve serve-context; de per-project `status`-route doet dit wel.
-
-**Impact:** Gebruikers en agents denken ten onrechte dat alle repos leeg zijn.
-
----
-
-### Bug B3 — MEDIUM: Regex met `\w`, `\b`, `\d` werkt niet in literal mode
-
-**Ernst:** 🟡 Medium  
-**Symptomen:**
-- `search(mode="literal", regex=true, query="class \\w+Cache\\b")` → leeg + note "consider using literal+regex" (al actief)
-- `search(mode="literal", regex=true, query="class \\w+Cache")` → ook leeg
-- `search(mode="literal", regex=true, query="interface I\\w+")` → leeg
-- `search(mode="literal", regex=true, query="class \\w+Store\\b")` → leeg
-- Eenvoudige regex **zonder** backslash-escapes werkt wél: `"CleanupController"` (regex=true) → correcte resultaten
-
-**Root cause (hypothese):** BM25 tokeniseert de query vóór regex-matching en splitst op `\w`/`\b` grenstekens, waardoor de regex niet als geheel wordt geëvalueerd.
-
-**Impact:** Gebruikers kunnen geen patroon-gebaseerde class/interface discovery doen.
-
----
-
-### Bug B4 — MEDIUM: `find_impact` retourneert dubbele definities (met/zonder `src/`-prefix)
-
-**Ernst:** 🟡 Medium  
-**Symptomen:**
-```json
-{"file": "src/ExampleProject.Dam/Caches/ICache.cs", "kind": "definition"},
-{"file": "Caches/ICache.cs", "kind": "definition"}
-```
-- Beide items verwijzen naar hetzelfde bestand, alleen het pad-prefix verschilt
-- Consistent zichtbaar voor ICache, CleanupController, MoSearchQueryBuilder, BackupStore
-
-**Root cause (hypothese):** SCIP-symbolen worden geïndexeerd met twee padrepresentaties (absoluut vs. relatief t.o.v. project root) in `scip_positions`.
-
-**Impact:** Verdubbelde definities verwarren agents die impact-analyses doen.
-
----
-
-### Bug B5 — LOW: Ruis in `find definition` bij group-scope
-
-**Ernst:** 🟠 Low  
-**Symptomen:**
-- `find(kind="definition", group="myorg", symbol="VendorConfig")` → top resultaten zijn JavaScript-functies uit `bootstrap.js`, niet de C# klasse
-- `VendorConfig.cs` staat wél in de resultaten, maar niet op positie 1
-
-**Root cause:** Group-search aggregeert resultaten van alle taaltypen; JavaScript-bestanden scoren hoog doordat BM25 toevallig hoge frequentie heeft voor de tokenized naam.
-
-**Fix:** Taalfilter toepassen bij `find definition` in group-context, of C#-klassen zwaarder wegen dan JS-functies.
-
----
-
-### Bug B6 — LOW: BM25 prefix-matching werkt niet in literal mode
-
-**Ernst:** 🟠 Low  
-**Symptomen:**
-- `search(mode="literal", query="TestPlan", group="myorg")` → leeg
-- `search(mode="literal", query="TestPlanCache", project="ExampleRepo")` → correct gevonden
-- BM25 vindt `TestPlan` niet als prefix van `TestPlanCache`
-
-**Root cause:** BM25 werkt op volledige tokens; `TestPlan` is een ander token dan `TestPlanCache`. Subword/prefix matching is niet ingebouwd.
-
-**Workaround:** Gebruik `regex=true` met `TestPlan.*` — maar dat is getroffen door Bug B3.
-
----
-
-### Bug B7 — GEVOLG van B1: Verwijderde bestanden lijken te blijven bij ExampleRepo
-
-**Ernst:** 🔴 High (maar oorzaak is Bug B1, niet de delete-logica zelf)  
-**Symptomen:**
-- `TestPlanEntity.cs` verwijderd → ExampleOrg en ExampleOrg cleanen correct na file-watcher debounce
-- ExampleRepo: `TestPlanEntity.cs` lijkt nog aanwezig na:
-  1. 90s wachttijd (file watcher debounce)
-  2. Expliciet `POST /repos/ExampleRepo/reindex` (normaal)
-  3. Pas na `POST /repos/ExampleRepo/reindex?force=true` verdwijnt het
-
-**Wat er werkelijk gebeurt — delete-tracking werkt WEL:**  
-De incrementele reindex **verwijderde correct één set chunks** voor `TestPlanEntity.cs`. Dat is het verwachte en correcte gedrag. Echter: door Bug B1 bestonden er **twee identieke sets chunks** voor datzelfde bestand in de ExampleOrg-index. De reindex verwijderde set 1 (correct), maar set 2 (de duplicaat uit Bug B1) bleef staan. Het leek daardoor alsof de delete niet werkte — maar de delete-logica zelf functioneerde juist.
-
-**Root cause:** Uitsluitend Bug B1. De delete-tracking in de indexer is correct geïmplementeerd. Zolang er geen dubbele chunks bestaan (zoals in ExampleOrg en ExampleOrg), werken deletes foutloos.
-
-**Impact:** Stale data persisteert in ExampleOrg zolang Bug B1 aanwezig is. Elke verwijderde file laat één duplicate-set achter.
-
-**Fix (tijdelijk):** `codesearch index -f ExampleRepo` (force reindex rebuild elimineert alle duplicaten en brengt de index terug naar één clean exemplaar).  
-**Fix (structureel):** Los Bug B1 op — daarna werken deletes in ExampleOrg even correct als in ExampleOrg en ExampleOrg.
-
----
-
-### Overzicht bugs
-
-| ID | Ernst | Titel | Actie vereist |
-|----|-------|-------|---------------|
-| B1 | 🔴 KRITIEK | ExampleRepo dubbele chunks (2× geïndexeerd) | Force reindex ExampleOrg + root cause in indexer fixen |
-| B2 | 🔴 KRITIEK | `status(kind="projects")` toont 0 chunks | Fix aggregatie in serve-status endpoint |
-| B7 | 🔴 HIGH | Schijnbare delete-failure bij ExampleOrg — delete werkt wél, maar B1-duplicaten blijven over | Opgelost door B1 te fixen |
-| B3 | 🟡 MEDIUM | Regex `\w+`/`\b` werkt niet in literal mode | Fix BM25 regex-evaluatie voor backslash-patronen |
-| B4 | 🟡 MEDIUM | Dubbele definities in find_impact (src/ prefix) | Dedupliceer paden in SCIP-positie-index |
-| B5 | 🟠 LOW | JavaScript ruis in `find definition` group-scope | Taalfilter of score-boost voor C# in group-context |
-| B6 | 🟠 LOW | BM25 prefix-matching werkt niet (TestPlan ≠ TestPlanCache) | Subword/prefix tokenisatie of regex-workaround |
-
----
-
-### Geslaagde tests — samenvatting
-
-**Semantisch zoeken:** 5/5 queries correct beantwoord voor alle 3 repos (ExampleOrg, ExampleOrg, ExampleOrg).  
-**Literal zoeken:** Exacte termen en eenvoudige regex werken; backslash-patronen falen (B3).  
-**find definition / find usages:** Werkt correct voor alle geteste symbolen.  
-**explore outline:** Volledig correct voor alle geteste bestanden.  
-**find_impact (C# SCIP):** Werkt via serve-bundled helper; definitie + call-sites correct.  
-**Multi-repo group search:** Routing, dedup, scope-errors — allemaal correct.  
-**File watcher:** Nieuwe bestanden worden correct opgepikt na 60s debounce.  
-**Cleanup (deletes):** ExampleOrg + ExampleOrg correct; ExampleOrg vereist force reindex (Bug B7).  
-**Edge cases:** Unknown alias, NonExistentSymbol, brede regex — allemaal zonder crash.  
-**Performance:** Search <500ms, literal <1s, group search <2s — alle doelen gehaald.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.0.132] - 2026-05-22
+
+### Added
+
+- **Tree-sitter grammars for Bash, Ruby, PHP, YAML, JSON** — codesearch now
+  supports AST-aware chunking for 14 languages total (previously 9: Rust,
+  Python, JavaScript, TypeScript, C, C++, C#, Go, Java). Closes #55.
+- **Bash equivalents of QC and bump-version scripts** — `scripts/qc.sh` and
+  `scripts/bump-version.sh` for Linux/macOS environments, complementing the
+  existing PowerShell scripts.
+- **Platform-aware pre-push hook** — `.git/hooks/pre-push` auto-detects the
+  platform and calls the appropriate QC script before allowing a push.
+- **CodeQL configuration** — added `.github/codeql/codeql-config.yml` to
+  suppress `rust/path-injection` false positives (codesearch is a local dev
+  tool, not a web-facing server).
+
+### Changed
+
+- **SCIP LMDB map_size raised from 64 MB to 512 MB** — the SCIP symbol index
+  LMDB environment now defaults to 512 MB virtual address space, up from 64 MB.
+  This prevents `MDB_MAP_FULL` errors on large solutions. Override with
+  `CODESEARCH_SCIP_LMDB_MAP_MB` environment variable.
+- **Centralized DB open/create logic** — extracted `try_open_stores()` to
+  eliminate duplicate LMDB open paths across the codebase. All serve-context
+  LMDB access now goes through a single entry point.
+
+### Fixed
+
+- **LMDB double-open race in `add_repo_handler`** — a concurrent guard with
+  cancel token now prevents two simultaneous `add_repo` calls from opening the
+  same LMDB database, which caused panics and corrupted indexes.
+- **LMDB double-open in MCP fallback path** — blocked a code path where the
+  MCP handler could open a second LMDB environment on the same directory when
+  `SharedStores` initialization failed.
+- **`TrackedEnv` runtime guard** — a new runtime guard detects LMDB
+  double-open attempts at runtime, producing a clear error instead of a panic.
+- **Force-reindex on missing database** — `try_open_stores()` now creates the
+  database on the fly when it's missing, fixing the case where a previously
+  registered repo had no `.codesearch.db` directory yet.
+- **Explore two-pass fallback** — `explore outline` now falls back to a
+  second lookup strategy when the alias name matches a package subdirectory,
+  preventing empty results on certain project layouts.
+- **TUI C# indexing status** — Phase 2 SCIP rebuilds and Phase 3 pre-warm now
+  correctly signal the TUI `indexing_cb`, so the UI shows "C# Indexing"
+  during background symbol operations.
+- **FSW SCIP rebuild TUI signal** — file-watcher-triggered symbol rebuilds now
+  update `active_reindexes` so the TUI displays the correct indexing state.
+- **CI test resilience** — `test_indexer_returns_empty_when_db_missing` is now
+  resilient to LMDB lock contention on CI runners.
+- **Protect-master workflow** — GitHub Actions workflow that only allows PRs
+  from `develop` to `master`, preventing accidental direct pushes.
+- **`config.save()` failure warnings** — `add_repo_handler` now logs warnings
+  when `config.save()` fails instead of silently dropping the error.
+
+
+
 ## [1.0.97] - 2026-05-15
 
 ### Fixed
@@ -282,6 +338,7 @@ repositories.
 - `codesearch serve` keeps one writer per database (LMDB invariant). Concurrent
   reindex from a second process is rejected.
 
+[1.0.132]: https://github.com/flupkede/codesearch/compare/v1.0.97...v1.0.132
 [1.0.97]: https://github.com/flupkede/codesearch/compare/v1.0.96...v1.0.97
 [1.0.96]: https://github.com/flupkede/codesearch/compare/v1.0.95...v1.0.96
 [1.0.95]: https://github.com/flupkede/codesearch/compare/v1.0.94...v1.0.95

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.130"
+version = "1.0.131"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.130"
+version = "1.0.131"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Consolidated CHANGELOG entry covering all changes from v1.0.97 through v1.0.132. Includes tree-sitter Bash/Ruby/PHP/YAML/JSON (closes #55), LMDB stability fixes, CI improvements, and more.