### PR TITLE
chore: simplify release workflow — feature-only version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.132"
+version = "1.0.133"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.132"
+version = "1.0.133"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,60 @@
+# Release Workflow
+
+## Branch model
+
+```
+feature/fix branches  →  develop  →  master (tagged = release)
+```
+
+## Pre-commit hook
+
+Install once:
+```bash
+cp scripts/pre-commit .git/hooks/pre-commit
+```
+
+Behavior:
+- **Always**: runs `cargo fmt`, stages formatted files
+- **Feature branches** (`fix/*`, `feature/*`, `features/*`): auto-bumps patch version + rebuilds binary
+- **develop / master / release/***: only fmt, no version bump
+
+## Step-by-step
+
+### 1. Feature branch
+
+```bash
+git checkout -b fix/my-fix origin/develop
+# ... make code changes ...
+git commit -m "fix: describe the change"
+# pre-commit hook auto-bumps version + rebuilds
+git push -u origin fix/my-fix
+```
+
+Create PR → `develop`. **Squash merge.**
+
+### 2. Develop → master (when requested)
+
+```bash
+git checkout -b release/v1.0.X origin/develop
+git push -u origin release/v1.0.X
+```
+
+Create PR → `master`. **Squash merge.**
+
+### 3. Tag release
+
+```bash
+git checkout master && git pull
+git tag v1.0.X
+git push origin v1.0.X
+```
+
+CI (`release.yml`) builds binaries and creates a GitHub Release with auto-generated notes from PR titles.
+
+## Rules
+
+- **Version bumps** happen only on feature branches (pre-commit hook)
+- **No manual CHANGELOG.md edits** — GitHub Releases auto-generate release notes
+- **No version bumps** on develop, master, or release branches
+- **Squash merge** all PRs to keep history linear
+- **Tag format**: `v1.0.X` on master HEAD

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Pre-commit hook:
+#   1. Run cargo fmt (prevents CI fmt-check failures)
+#   2. On feature branches only: auto-bump patch version + rebuild binary
+#      On develop/master/release: only fmt, no version bump
+
+set -e
+
+# ── Step 1: cargo fmt ────────────────────────────────────────────────────
+echo "pre-commit: running cargo fmt..."
+cargo fmt --all --quiet 2>/dev/null || cargo fmt --all --quiet
+FMT_CHANGED=$(git diff --name-only -- '*.rs')
+if [ -n "$FMT_CHANGED" ]; then
+    git add -- '*.rs'
+    echo "pre-commit: staged rustfmt changes ($FMT_CHANGED)"
+fi
+
+# ── Step 2: version bump (feature branches only) ─────────────────────────
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+IS_FEATURE=false
+case "$BRANCH" in
+    fix/*|feature/*|features/*) IS_FEATURE=true ;;
+esac
+
+if [ "$IS_FEATURE" = false ]; then
+    echo "pre-commit: branch '$BRANCH' — skipping version bump (feature branches only)"
+    exit 0
+fi
+
+CARGO_TOML="Cargo.toml"
+
+# Working tree version (what's on disk right now)
+WT_VER=$(grep -m1 '^version = ' "$CARGO_TOML" | sed 's/version = "\(.*\)"/\1/')
+if [ -z "$WT_VER" ]; then
+    echo "pre-commit: could not read version from $CARGO_TOML" >&2
+    exit 1
+fi
+
+# HEAD version (last committed)
+HEAD_VER=$(git show HEAD:"$CARGO_TOML" 2>/dev/null | grep -m1 '^version = ' | sed 's/version = "\(.*\)"/\1/' || echo "")
+
+if [ "$WT_VER" != "$HEAD_VER" ]; then
+    # Developer already changed the version — don't bump again
+    echo "pre-commit: version already changed ($HEAD_VER -> $WT_VER), skipping auto-bump"
+    NEED_REBUILD=true
+else
+    IFS='.' read -r MAJOR MINOR PATCH <<< "$WT_VER"
+    NEW_PATCH=$((PATCH + 1))
+    NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+
+    sed -i "0,/^version = \"$WT_VER\"/s//version = \"$NEW_VERSION\"/" "$CARGO_TOML"
+    cargo update --workspace --quiet 2>/dev/null || true
+    echo "pre-commit: bumped $WT_VER -> $NEW_VERSION"
+    NEED_REBUILD=true
+fi
+
+# Rebuild
+if [ "$NEED_REBUILD" = true ]; then
+    CURRENT_VER=$(grep -m1 '^version = ' "$CARGO_TOML" | sed 's/version = "\(.*\)"/\1/')
+    echo "pre-commit: rebuilding binary at $CURRENT_VER..."
+    if cargo build --bin codesearch --quiet; then
+        git add "$CARGO_TOML" Cargo.lock
+        echo "pre-commit: binary rebuilt at $CURRENT_VER"
+    else
+        echo "pre-commit: cargo build failed" >&2
+        exit 1
+    fi
+fi


### PR DESCRIPTION
## Changes

- **Pre-commit hook**: auto-bumps patch version + rebuilds binary only on feature branches (`fix/*`, `feature/*`, `features/*`). On develop/master/release branches: only `cargo fmt`, no bump.
- **RELEASING.md**: documents the simplified release workflow
- No more CHANGELOG.md maintenance — GitHub Releases auto-generate notes from PR titles

## Workflow summary

```
feature/fix branches → develop (squash merge) → master (squash merge) → tag = release
```

- Feature branches: version auto-bumps on each commit
- develop/master/release: NO version changes
- Tag push triggers CI build + GitHub Release with auto-generated notes

## Test results

- Hook bumped 1.0.132 → 1.0.133 on feature branch ✅  
- Hook printed "skipping version bump (feature branches only)" on develop ✅  
- `cargo check --all-targets` clean ✅  
- QC gate: fmt + check + clippy + 394 tests passed ✅