### PR TITLE
Add Docker startup support for codesearch serve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM rust:1-trixie AS builder
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src ./src
+COPY helpers ./helpers
+
+RUN cargo build --release
+
+FROM debian:trixie-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libgcc-s1 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/codesearch /usr/local/bin/codesearch
+
+ENV CODESEARCH_SERVE_HOST=0.0.0.0
+ENV CODESEARCH_SERVE_PORT=39725
+
+EXPOSE 39725
+
+CMD ["codesearch", "serve", "--no-tui"]

--- a/README.md
+++ b/README.md
@@ -350,6 +350,33 @@ codesearch mcp --mode client  # force serve connection
 
 The serve endpoint is available at `/mcp` (Streamable HTTP transport).
 
+### Docker / Headless Serve
+
+For containerized or daemon-style deployments, disable the embedded TUI and bind
+to `0.0.0.0` inside the container:
+
+```bash
+codesearch serve --host 0.0.0.0 --no-tui
+```
+
+The same can be configured with environment variables:
+
+```bash
+CODESEARCH_SERVE_HOST=0.0.0.0 CODESEARCH_SERVE_PORT=39725 codesearch serve --no-tui
+```
+
+When running in Docker, mount both the global config directory and the repositories
+you want to index:
+
+```bash
+docker run --rm \
+  -p 39725:39725 \
+  -v "$HOME/.codesearch:/root/.codesearch" \
+  -v "/path/to/repos:/repos" \
+  codesearch:local \
+  codesearch serve --host 0.0.0.0 --no-tui --register /repos/my-project
+```
+
 ## CLI Reference
 
 | Command | Description |
@@ -371,6 +398,7 @@ The serve endpoint is available at `/mcp` (Streamable HTTP transport).
 
 | Variable | Description |
 |----------|-------------|
+| `CODESEARCH_SERVE_HOST` | Serve mode host/interface (default: `127.0.0.1`) |
 | `CODESEARCH_SERVE_PORT` | Serve mode port (default: 39725) |
 | `CODESEARCH_MCP_MODE` | MCP mode: auto, client, local |
 | `CODESEARCH_REPOS_CONFIG` | Path to repos.json |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  codesearch:
+    build: .
+    ports:
+      - "39725:39725"
+    environment:
+      CODESEARCH_SERVE_HOST: 0.0.0.0
+      CODESEARCH_SERVE_PORT: 39725
+    volumes:
+      - ${HOME}/.codesearch:/root/.codesearch
+      - .:/repos/codesearch:ro
+    command:
+      - codesearch
+      - serve
+      - --no-tui
+      - --register
+      - /repos/codesearch

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -258,6 +258,10 @@ pub enum Commands {
         #[arg(default_value = "start")]
         action: ServeAction,
 
+        /// Host/interface to listen on (default: 127.0.0.1, override with CODESEARCH_SERVE_HOST)
+        #[arg(long)]
+        host: Option<String>,
+
         /// Port to listen on (default: 39725, override with CODESEARCH_SERVE_PORT)
         #[arg(short, long)]
         port: Option<u16>,
@@ -611,6 +615,7 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
         Commands::Stats { path } => crate::index::stats(path).await,
         Commands::Serve {
             action,
+            host,
             port,
             register,
             quiet,
@@ -630,7 +635,8 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
                     if let Err(e) = crate::logger::init_serve_logger(log_level, effective_quiet) {
                         eprintln!("Warning: failed to initialize serve logger: {}", e);
                     }
-                    crate::serve::run_serve(port, register, no_tui, cancel_token.clone()).await
+                    crate::serve::run_serve(host, port, register, no_tui, cancel_token.clone())
+                        .await
                 }
             }
         }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -146,8 +146,15 @@ pub const WRITER_LOCK_FILE: &str = ".writer.lock";
 /// Override with `--port` or `CODESEARCH_SERVE_PORT`.
 pub const DEFAULT_SERVE_PORT: u16 = 39725;
 
+/// Default host/interface for `codesearch serve`.
+/// Override with `--host` or `CODESEARCH_SERVE_HOST`.
+pub const DEFAULT_SERVE_HOST: &str = "127.0.0.1";
+
 /// Environment variable to override the serve port.
 pub const SERVE_PORT_ENV: &str = "CODESEARCH_SERVE_PORT";
+
+/// Environment variable to override the serve host/interface.
+pub const SERVE_HOST_ENV: &str = "CODESEARCH_SERVE_HOST";
 
 /// Default base URL for connecting to a local `codesearch serve` instance.
 /// Used as the clap `--url` default and in `serve_base_url()`.

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -1,6 +1,6 @@
 //! `codesearch serve` — MCP streamable HTTP server mode.
 //!
-//! Binds on `127.0.0.1:{port}` and serves:
+//! Binds on `{host}:{port}` and serves:
 //! - `GET /health` → JSON health check
 //! - `POST /repos` → register + index + warmup a new repo
 //! - `DELETE /repos/:alias` → stop FSW + evict + unregister + delete DB
@@ -34,9 +34,9 @@ use tracing::{info, warn};
 
 use crate::constants::{
     CSHARP_PREWARM_ENABLED_ENV, CSHARP_PREWARM_MAX_SYMBOLS, CSHARP_SCIP_CONCURRENCY_DEFAULT,
-    CSHARP_SCIP_CONCURRENCY_ENV, DB_DIR_NAME, DEFAULT_SERVE_PORT, HEALTH_PATH, LANG_CSHARP,
-    MCP_ENDPOINT_PATH, PERSIST_DEBOUNCE_SECS, REAPER_INTERVAL_SECS, REPO_IDLE_TIMEOUT_ENV,
-    REPO_IDLE_TIMEOUT_SECS, SERVE_PORT_ENV, STATUS_PATH,
+    CSHARP_SCIP_CONCURRENCY_ENV, DB_DIR_NAME, DEFAULT_SERVE_HOST, DEFAULT_SERVE_PORT,
+    HEALTH_PATH, LANG_CSHARP, MCP_ENDPOINT_PATH, PERSIST_DEBOUNCE_SECS, REAPER_INTERVAL_SECS,
+    REPO_IDLE_TIMEOUT_ENV, REPO_IDLE_TIMEOUT_SECS, SERVE_HOST_ENV, SERVE_PORT_ENV, STATUS_PATH,
 };
 use crate::db_discovery::repos::ReposConfig;
 use crate::index::{CSharpRebuildNotifier, IndexManager, IndexingStatusCallback, SharedStores};
@@ -2770,11 +2770,18 @@ pub async fn run_tui_standalone(serve_url: String) -> Result<()> {
 ///
 /// This is the entry point called from CLI when `codesearch serve` is invoked.
 pub async fn run_serve(
+    host: Option<String>,
     port: Option<u16>,
     register_paths: Vec<PathBuf>,
     no_tui: bool,
     cancel_token: CancellationToken,
 ) -> Result<()> {
+    let effective_host = host.unwrap_or_else(|| {
+        std::env::var(SERVE_HOST_ENV)
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_SERVE_HOST.to_string())
+    });
     let effective_port = port.unwrap_or_else(|| {
         std::env::var(SERVE_PORT_ENV)
             .ok()
@@ -2805,7 +2812,9 @@ pub async fn run_serve(
     let serve_state = Arc::new(ServeState::new(config, None));
 
     // Log startup
-    let addr = SocketAddr::from(([127, 0, 0, 1], effective_port));
+    let addr: SocketAddr = format!("{}:{}", effective_host, effective_port)
+        .parse()
+        .context("Invalid serve host/port combination")?;
     info!(
         "🚀 Starting codesearch serve v{} on {}",
         env!("CARGO_PKG_VERSION"),


### PR DESCRIPTION
## Summary
- add a Dockerfile and docker-compose example for running  headlessly
- make the serve bind host configurable via  and 
- document Docker/headless usage in the README

## Motivation
 could already run without the embedded TUI, but it was still bound to , which made container usage awkward. This change makes it practical to run  as a local Docker service and expose the MCP/HTTP endpoints cleanly.

## Validation
- built the Docker image successfully
- ran the container with 
- verified  returns 
- verified  returns repo status successfully

## Note
The Docker build required moving the base images from  to  to resolve the ONNX Runtime linker issue on ARM ( / libstdc++ ABI mismatch).