### PR TITLE
sync: align develop with master (post-v1.0.137)

### DIFF
--- a/.github/workflows/protect-master.yml
+++ b/.github/workflows/protect-master.yml
@@ -8,11 +8,12 @@ jobs:
   check-source-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure PR targets master only from develop
+      - name: Ensure PR targets master only from develop or release branches
         run: |
-          if [ "${{ github.head_ref }}" != "develop" ]; then
-            echo "::error::PRs to master must come from the develop branch. Got: ${{ github.head_ref }}"
+          SOURCE="${{ github.head_ref }}"
+          if [[ "$SOURCE" != "develop" && ! "$SOURCE" =~ ^release/ ]]; then
+            echo "::error::PRs to master must come from develop or release/* branches. Got: $SOURCE"
             echo "Please target your PR to develop instead."
             exit 1
           fi
-          echo "OK: PR source is develop"
+          echo "OK: PR source is '$SOURCE'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (caller refuses to create a local duplicate).
 
 
+## [1.0.135] - 2026-05-27
+
+### Fixed
+
+- **MCP local/stdio mode ignores `project`/`group` params** — when running
+  `codesearch mcp` without `codesearch serve` (Local mode), passing `project` or
+  `group` parameters caused a hard error: *"project/group routing requires
+  `codesearch serve` to be running."* The LLM (Claude Code) auto-fills these
+  params from the tool schema. Now they are silently ignored with a warning log,
+  and the local database is used. Closes #65.
+- **QC script `YELLOW` color variable undefined** — `scripts/qc.sh` referenced
+  `YELLOW` without defining it, causing `set -u` failures on Linux. Fixed by
+  adding the missing color constant.
+
+### Changed
+
+- **`protect-master.yml` allows `release/*` branches** — CI branch protection
+  workflow now accepts PRs from both `develop` and `release/*` branches into
+  `master`, enabling clean release branches when develop has diverged.
+
+
 ## [1.0.132] - 2026-05-22
 
 ### Added


### PR DESCRIPTION
Post-release sync. After tagging **v1.0.137** on master, only two files had drifted between `develop` and `master`:
- `.github/workflows/protect-master.yml` — master's version (allows `release/*` branches).
- `CHANGELOG.md` — adds the `[1.0.135]` entry that was on master but not develop.

After merge, `develop` and `master` trees are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)