### PR TITLE
fix: strip UNC prefix in repos.json + auto-add on missing DB (v1.0.138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.0.138] - 2026-06-01
+
+### Fixed
+
+- **`\\?\`-prefixed UNC paths stored in repos.json caused spurious "Database
+  not found" errors** — `Path::canonicalize()` on Windows returns an
+  extended-length UNC path (`\\?\C:\...`). When stored verbatim in
+  `repos.json`, downstream `.join(".codesearch.db")` and `Path::exists()`
+  calls failed inconsistently (e.g. `\\?\C:\foo\.codesearch.db` returned
+  `false` even when `C:\foo\.codesearch.db` existed). This affected 7 repos
+  in repos.json and caused a cascade of "Database not found" 500 errors and
+  fallbacks to local duplicate indexes. `register()` and `register_with_alias()`
+  now strip the `\\?\` prefix before storage so repos.json always holds plain
+  `C:\...` paths. Existing UNC entries are automatically corrected at the next
+  registration. (Existing repos.json was also patched in-place.)
+- **500 "Database not found" on reindex caused a local duplicate index** —
+  when a registered repo's database was deleted externally (e.g. serve killed
+  mid-index), the reindex endpoint returned 500 "Database not found". The CLI
+  treated this as a generic failure and fell back to local indexing, recreating
+  the duplicate. It now triggers the same auto-register (`POST /repos`) path as
+  a 404, which recreates the database via serve without any local fallback.
+
+
 ## [1.0.137] - 2026-06-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.137"
+version = "1.0.138"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.137"
+version = "1.0.138"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/db_discovery/repos.rs
+++ b/src/db_discovery/repos.rs
@@ -93,7 +93,7 @@ impl ReposConfig {
     }
 
     pub fn register(&mut self, path: PathBuf) -> String {
-        let canonical = path.canonicalize().unwrap_or(path);
+        let canonical = strip_unc(path.canonicalize().unwrap_or(path));
 
         if let Some((alias, _)) = self
             .repos
@@ -109,7 +109,7 @@ impl ReposConfig {
     }
 
     pub fn register_with_alias(&mut self, path: PathBuf, alias: Option<String>) -> Result<String> {
-        let canonical = path.canonicalize().unwrap_or(path);
+        let canonical = strip_unc(path.canonicalize().unwrap_or(path));
 
         if let Some((existing_alias, _)) = self
             .repos
@@ -348,6 +348,21 @@ fn normalize_path_for_compare(path: &Path) -> String {
     crate::cache::normalize_path(path)
 }
 
+/// Strip the Windows extended-length UNC prefix (`\\?\`) from a path so it is
+/// never persisted to repos.json in that form. `Path::canonicalize()` on Windows
+/// returns `\\?\C:\...`, which causes `Path::exists()` / `.join()` to behave
+/// inconsistently for sub-paths (e.g. `\\?\C:\foo\.codesearch.db` may not exist
+/// even when `C:\foo\.codesearch.db` does). Stripping the prefix before storage
+/// ensures all downstream path operations use the plain `C:\...` form.
+fn strip_unc(path: PathBuf) -> PathBuf {
+    let s = path.to_string_lossy();
+    if let Some(stripped) = s.strip_prefix(r"\\?\") {
+        PathBuf::from(stripped)
+    } else {
+        path
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -449,5 +464,38 @@ mod tests {
 
         assert!(cfg.unregister_alias("repo-a"));
         assert!(!cfg.repos_meta.contains_key("repo-a"));
+    }
+
+    /// Regression: `Path::canonicalize()` on Windows returns a `\\?\`-prefixed UNC
+    /// extended-length path. If stored verbatim in repos.json, downstream `.join()`
+    /// and `.exists()` calls fail (e.g. `\\?\C:\foo\.codesearch.db` may not exist
+    /// even when `C:\foo\.codesearch.db` does). `register` and `register_with_alias`
+    /// must strip the prefix before storage so repos.json always holds plain paths.
+    #[test]
+    fn register_strips_unc_prefix_from_stored_path() {
+        let mut cfg = ReposConfig::default();
+
+        // Simulate what canonicalize() returns on Windows: a \\?\ UNC path.
+        let unc_path = PathBuf::from(r"\\?\C:\WorkArea\AI\myrepo");
+        // register() calls canonicalize() internally, but also accepts any path.
+        // Test strip_unc directly (the private fn is in scope via pub(crate) isn't
+        // exposed, so we exercise it via register_with_alias on a pre-formed path
+        // by bypassing canonicalize with a path that starts with \\?\).
+        let alias = cfg
+            .register_with_alias(unc_path.clone(), Some("myrepo".to_string()))
+            .unwrap();
+
+        let stored = cfg.resolve(&alias).unwrap();
+        let stored_str = stored.to_string_lossy();
+        assert!(
+            !stored_str.starts_with(r"\\?\"),
+            "repos.json must not contain UNC prefix, got: {}",
+            stored_str
+        );
+        assert!(
+            stored_str.starts_with("C:\\") || stored_str.starts_with("C:/"),
+            "stored path should be a plain Windows path, got: {}",
+            stored_str
+        );
     }
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1842,6 +1842,45 @@ async fn try_delegate_reindex_to_serve(
             alias
         );
         Ok((alias, project_path))
+    } else if status == reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        && body.contains("Database not found")
+    {
+        // Serve knows the alias but its database was deleted externally (e.g. the
+        // previous serve run was killed mid-index and the DB never fully formed).
+        // Treat this the same as 404: auto-register so serve creates the DB fresh.
+        tracing::info!(
+            "alias '{}' has no database on serve (500 Database not found), \
+             auto-registering via POST /repos to recreate",
+            alias
+        );
+
+        let mut add_body = serde_json::json!({
+            "path": project_path,
+            "global": false,
+        });
+        add_body["alias"] = serde_json::Value::String(alias.clone());
+
+        let add_resp = client
+            .post(format!("{}/repos", base_url))
+            .json(&add_body)
+            .send()
+            .await
+            .map_err(|e| format!("auto-register POST /repos failed: {}", e))?;
+
+        if !add_resp.status().is_success() {
+            let add_status = add_resp.status();
+            let add_text = add_resp.text().await.unwrap_or_default();
+            return Err(DelegateError::Failed(format!(
+                "auto-register returned {} for alias '{}': {}",
+                add_status, alias, add_text
+            )));
+        }
+
+        tracing::info!(
+            "auto-register accepted for alias '{}' (DB recreate), indexing in background",
+            alias
+        );
+        Ok((alias, project_path))
     } else {
         Err(DelegateError::Failed(format!(
             "serve returned {} for alias '{}': {}",


### PR DESCRIPTION
Two Windows path bugs that caused the same symptom as the previous release (local duplicate index, "Database not found" errors).

## Bug #1 — `\?\` UNC paths stored in repos.json
`register()` and `register_with_alias()` stored `Path::canonicalize()` output verbatim. On Windows `canonicalize()` returns `\?\C:\...`. Downstream `.join(".codesearch.db")` and `Path::exists()` fail inconsistently for these paths (`\?\C:\foo\.codesearch.db` returns `false` even when `C:\foo\.codesearch.db` exists) → "Database not found" 500 → local duplicate.
**Fix:** `strip_unc()` removes the prefix before storage. **7 repos** in `repos.json` were affected and patched in-place.
**Test:** `register_strips_unc_prefix_from_stored_path` — verified to fail without fix.

## Bug #2 — 500 "Database not found" on reindex → local fallback
When a registered repo's DB was missing (e.g. serve killed mid-index), reindex returned 500 "Database not found". CLI treated this as a generic failure and created a local duplicate.
**Fix:** 500 + "Database not found" now triggers the same auto-register (`POST /repos`) path as 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)