### PR TITLE
fix: replace last raw .canonicalize() with safe_canonicalize (v1.0.140)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.139"
+version = "1.0.140"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.139"
+version = "1.0.140"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -61,13 +61,9 @@ fn get_db_path_smart(
     let target = path.as_deref();
     let project_path = path.as_deref().unwrap_or(Path::new("."));
 
-    // Try to canonicalize, but fall back to original path if it fails
-    // Then normalize: strip UNC prefix (\\?\) and use forward slashes for consistency
-    let canonical_path = PathBuf::from(normalize_path(
-        &project_path
-            .canonicalize()
-            .unwrap_or_else(|_| PathBuf::from(project_path)),
-    ));
+    // Canonicalize and strip any Windows UNC prefix (\\?\) via the central helper.
+    let canonical_path =
+        safe_canonicalize(project_path).unwrap_or_else(|_| PathBuf::from(project_path));
 
     // Step 1: Handle --force flag — delete databases
     if force {


### PR DESCRIPTION
Closes the one remaining raw  call missed in the v1.0.139 central refactor.  used the old  pattern — functionally correct (normalize_path also strips UNC) but inconsistent with the policy. Now all raw  calls outside 's own definition are eliminated.