### PR TITLE
fix: Windows 8.3 short-name path mismatch in relocation tests (v1.0.154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.0.154] - 2026-06-02
+
+### Fixed
+
+- **Windows CI: path-comparison failures in relocation tests** — `scan_for_remote`
+  now canonicalizes discovered paths via `safe_canonicalize()` before recording
+  them, resolving 8.3 short names (e.g. `RUNNER~1`) to their long-name form
+  (`runneradmin`). Test assertions updated to use the same canonicalization so
+  `tempfile::tempdir()` short-name paths and `read_dir` long-name paths compare
+  equal on Windows.
+
 ## [1.0.153] - 2026-06-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.153"
+version = "1.0.154"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.153"
+version = "1.0.154"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/db_discovery/repos.rs
+++ b/src/db_discovery/repos.rs
@@ -569,7 +569,9 @@ fn is_skippable_scan_dir(path: &Path) -> bool {
 fn scan_for_remote(dir: &Path, target_remote: &str, depth: usize, out: &mut Vec<PathBuf>) {
     if dir.join(".git").exists() {
         if git_remote_url(dir).as_deref() == Some(target_remote) {
-            out.push(dir.to_path_buf());
+            // Canonicalize to resolve 8.3 short names on Windows (e.g. RUNNER~1 →
+            // runneradmin) so stored and found paths are always in the same form.
+            out.push(safe_canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf()));
         }
         return;
     }
@@ -592,6 +594,17 @@ fn scan_for_remote(dir: &Path, target_remote: &str, depth: usize, out: &mut Vec<
 mod tests {
     use super::*;
     use std::io::Write;
+
+    /// Canonicalize then normalize a path for use in test assertions.
+    ///
+    /// On Windows, `tempfile::tempdir()` may return an 8.3 short-name path
+    /// (e.g. `C:/Users/RUNNER~1/...`) while `std::fs::read_dir` can resolve the
+    /// same directory to its long-name form (`C:/Users/runneradmin/...`).
+    /// Applying `safe_canonicalize` before `normalize_path_for_compare` ensures
+    /// both sides of an assertion use the same form.
+    fn canon_norm(p: &Path) -> String {
+        normalize_path_for_compare(&safe_canonicalize(p).unwrap_or_else(|_| p.to_path_buf()))
+    }
 
     /// Initialise a git repo at `dir` with an `origin` remote pointing at `url`.
     fn init_git_remote(dir: &Path, url: &str) {
@@ -654,10 +667,7 @@ mod tests {
         let found = cfg
             .try_relocate(&alias)
             .expect("should relocate via renamed parent");
-        assert_eq!(
-            normalize_path_for_compare(&found),
-            normalize_path_for_compare(&expected)
-        );
+        assert_eq!(canon_norm(&found), canon_norm(&expected));
     }
 
     #[test]
@@ -704,13 +714,13 @@ mod tests {
         assert_eq!(relocated.len(), 1);
         assert_eq!(relocated[0].0, moved_alias);
         assert_eq!(
-            normalize_path_for_compare(cfg.repos.get(&moved_alias).unwrap()),
-            normalize_path_for_compare(&renamed)
+            canon_norm(cfg.repos.get(&moved_alias).unwrap()),
+            canon_norm(&renamed)
         );
         // The stable repo is untouched.
         assert_eq!(
-            normalize_path_for_compare(cfg.repos.get(&stable_alias).unwrap()),
-            normalize_path_for_compare(&stable)
+            canon_norm(cfg.repos.get(&stable_alias).unwrap()),
+            canon_norm(&stable)
         );
     }
 
@@ -792,10 +802,7 @@ mod tests {
         let found = cfg
             .try_relocate(&alias)
             .expect("should relocate renamed leaf");
-        assert_eq!(
-            normalize_path_for_compare(&found),
-            normalize_path_for_compare(&renamed)
-        );
+        assert_eq!(canon_norm(&found), canon_norm(&renamed));
     }
 
     #[test]


### PR DESCRIPTION
## Fixed

- **Windows CI: 3 relocation tests failing** — `try_relocate_finds_renamed_leaf`, `try_relocate_finds_renamed_parent`, and `relocate_missing_rewrites_only_moved_repos` panicked on Windows CI with a left/right mismatch between `C:/Users/RUNNER~1/...` (8.3 short name from `tempfile::tempdir()`) and `C:/Users/runneradmin/...` (long name from `std::fs::read_dir`).

  **Root cause:** `scan_for_remote()` pushed the raw `dir.to_path_buf()` which could be in either form depending on how the OS resolved the directory entry.

  **Fix:** `scan_for_remote()` now calls `safe_canonicalize()` on each matched path before recording it, normalizing to the long-name form. Test assertions use a new `canon_norm()` helper (canonicalize → normalize) so both sides of the `assert_eq!` are always in the same form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)