### PR TITLE
docs: fix groups add syntax in README (fixes #107)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.162"
+version = "1.0.163"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.162"
+version = "1.0.163"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ crashing.
 Groups let you search across related repositories:
 
 ```bash
-codesearch groups add my-group repo1 repo2 repo3
+codesearch groups add my-group --aliases repo1 repo2 repo3
 codesearch groups list
 ```
 


### PR DESCRIPTION
## Fix

Corrects the `codesearch groups add` example in README.md to match the actual CLI behavior.

### Issue
Fixes #107

### What changed
- **Line 356**: `codesearch groups add my-group repo1 repo2 repo3` → `codesearch groups add my-group --aliases repo1 repo2 repo3`

The CLI only accepts the group name as a positional argument. Members must be added via the `--aliases` (`-a`) flag.

### Documentation audit
Full audit of all CLI examples in README.md against actual `--help` output — no other discrepancies found:
- ✅ All `index add/rm/list/prune/symbol` examples match CLI
- ✅ All `serve`, `mcp`, `search`, `doctor`, `cache` references match CLI  
- ✅ All MCP configuration JSON snippets are correct
- ✅ CLI Reference table at line 378–391 is accurate
- ✅ CHANGELOG.md has no stale groups add syntax
- ✅ README_CSharp.md has no groups add references

### QC
```
cargo fmt ✅ | cargo check ✅ | cargo clippy ✅ | 432/432 tests passed ✅
```