### PR TITLE
🐛 fix: review corrections — LMDB reopen 500, indexing & TUI hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.199"
+version = "1.0.200"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.198"
+version = "1.0.199"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.193"
+version = "1.0.194"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.203"
+version = "1.0.204"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.196"
+version = "1.0.197"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.204"
+version = "1.0.205"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.202"
+version = "1.0.203"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.195"
+version = "1.0.196"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.205"
+version = "1.0.206"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.201"
+version = "1.0.202"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.194"
+version = "1.0.195"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.206"
+version = "1.0.207"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.200"
+version = "1.0.201"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.197"
+version = "1.0.198"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.200"
+version = "1.0.201"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.197"
+version = "1.0.198"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.206"
+version = "1.0.207"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.198"
+version = "1.0.199"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.203"
+version = "1.0.204"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.194"
+version = "1.0.195"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.199"
+version = "1.0.200"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.195"
+version = "1.0.196"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.204"
+version = "1.0.205"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.201"
+version = "1.0.202"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.205"
+version = "1.0.206"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.196"
+version = "1.0.197"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.202"
+version = "1.0.203"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.193"
+version = "1.0.194"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/src/chunker/extractor.rs
+++ b/src/chunker/extractor.rs
@@ -1095,11 +1095,16 @@ impl LanguageExtractor for DartExtractor {
     fn classify(&self, node: Node) -> ChunkKind {
         match node.kind() {
             "function_declaration" => {
+                // A function_declaration nested in a type-member body is a method.
+                // Dart's grammar uses `class_body` for the body of classes, mixins
+                // AND (via the shared body rule) the member list, so mixin/class
+                // methods both land here. `mixin_application` (the `with A, B`
+                // superclass clause) is NOT a member body and never parents a
+                // function_declaration, so it is intentionally not listed.
                 if let Some(parent) = node.parent() {
                     if parent.kind() == "class_body"
                         || parent.kind() == "enum_body"
                         || parent.kind() == "extension_body"
-                        || parent.kind() == "mixin_application"
                     {
                         return ChunkKind::Method;
                     }

--- a/src/chunker/jupyter.rs
+++ b/src/chunker/jupyter.rs
@@ -4,6 +4,19 @@
 //! individually searchable chunks.  Adjacent cells of the same type are
 //! merged when their combined line count stays under 50 lines, keeping
 //! the index compact without losing granularity.
+//!
+//! CAVEAT — line numbers are synthetic. `start_line`/`end_line` on the
+//! emitted chunks are a running cursor over *cell content lines*, NOT the
+//! real line/byte offset of the cell inside the `.ipynb` JSON (where each
+//! cell's source is an array element surrounded by metadata/outputs). They
+//! are display/ordering metadata only. Any feature that needs to map a chunk
+//! back to a precise position in the raw `.ipynb` (jump-to-line, snippet
+//! re-extraction, symbol references) must NOT trust these numbers — it would
+//! have to compute the real JSON offsets during parsing.
+//!
+//! NOTE — all code cells are labelled generically (kernel language is not read
+//! from `metadata.kernelspec`); search relevance for non-Python notebooks may
+//! be slightly degraded. Follow-up if multi-kernel notebooks become common.
 
 use super::{Chunk, ChunkKind};
 use crate::cache::normalize_path;
@@ -110,11 +123,11 @@ fn extract_cell(cell: &Value) -> Option<RawCell> {
         return None;
     };
 
-    let line_count = if content.is_empty() {
-        0
-    } else {
-        content.lines().count().max(1)
-    };
+    // Normalize to at least 1 line even for an empty cell, so the two passes
+    // in merge_adjacent_cells (line numbering and merge accumulation) always
+    // agree on a cell's width. (Previously empty cells stored 0, which the
+    // numbering pass counted as 1 but the merge accumulator counted as 0.)
+    let line_count = content.lines().count().max(1);
 
     Some(RawCell {
         cell_type,
@@ -136,12 +149,9 @@ fn merge_adjacent_cells(cells: &[RawCell]) -> Vec<CellGroup> {
     let mut cursor = 0usize;
     for cell in cells {
         let start = cursor;
-        let lines = if cell.line_count == 0 {
-            1
-        } else {
-            cell.line_count
-        };
-        cursor += lines;
+        // line_count is normalized to >= 1 in extract_cell, so the numbering
+        // pass and the merge accumulator below use the identical width.
+        cursor += cell.line_count;
         numbered.push((start, cursor, cell));
     }
 

--- a/src/chunker/semantic.rs
+++ b/src/chunker/semantic.rs
@@ -1016,6 +1016,58 @@ class Calculator:
     }
 
     #[test]
+    fn test_dart_semantic_chunking() {
+        let mut chunker = SemanticChunker::new(100, 2000, 10);
+        let content = r#"
+int topLevel() => 1;
+
+class Greeter {
+  String greet() => "hi";
+}
+
+mixin Walker {
+  void walk() {}
+}
+"#;
+        let chunks = chunker
+            .chunk_semantic(Language::Dart, Path::new("a.dart"), content)
+            .unwrap();
+        assert!(!chunks.is_empty());
+
+        // A chunk with the given text and exact kind must exist. (We use `any`
+        // rather than `find` because the enclosing class/mixin chunk also
+        // contains its members' text — we want the member-level chunk.)
+        let has_kind = |needle: &str, kind: ChunkKind| {
+            chunks
+                .iter()
+                .any(|c| c.content.contains(needle) && c.kind == kind)
+        };
+        // Top-level function → Function; class & mixin members → Method.
+        assert!(has_kind("int topLevel", ChunkKind::Function));
+        assert!(has_kind("String greet", ChunkKind::Method));
+        // Regression for the mixin_application misclassification: mixin members
+        // must be Method (their parent is class_body, not mixin_application).
+        assert!(has_kind("void walk", ChunkKind::Method));
+    }
+
+    #[test]
+    fn test_dart_unparseable_still_chunks() {
+        // A .dart file that is not valid Dart must still yield fallback chunks
+        // rather than producing nothing (grammar-failure resilience).
+        let mut chunker = SemanticChunker::new(100, 2000, 10);
+        let content = "@@@ not valid dart @@@\n{{{ ][ )(\nlorem ipsum dolor sit amet\n";
+        let chunks = chunker
+            .chunk_semantic(Language::Dart, Path::new("broken.dart"), content)
+            .unwrap();
+        assert!(
+            !chunks.is_empty(),
+            "unparseable Dart should still produce fallback chunks"
+        );
+        let joined: String = chunks.iter().map(|c| c.content.clone()).collect();
+        assert!(joined.contains("lorem ipsum"));
+    }
+
+    #[test]
     fn test_gap_tracking() {
         let content = "line 0\nline 1\nline 2\nline 3\nline 4";
         let mut tracker = GapTracker::new(content);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -970,9 +970,16 @@ SERVE_URL_FILE="$HOME/.codesearch/serve_url"
 if [ -f "$SERVE_URL_FILE" ]; then
     SERVE_URL=$(cat "$SERVE_URL_FILE")
     if [ -n "$SERVE_URL" ]; then
+        # JSON-escape the repo path before embedding it in the request body.
+        # A path containing a double quote or backslash would otherwise break
+        # out of the JSON string literal (malformed body / injection). Escape
+        # backslashes first, then double quotes (order matters).
+        REPO_PATH="$(pwd)"
+        REPO_PATH="${REPO_PATH//\\/\\\\}"
+        REPO_PATH="${REPO_PATH//\"/\\\"}"
         curl -s -X POST "$SERVE_URL/repos" \
             -H "Content-Type: application/json" \
-            -d "{\"path\":\"$(pwd)\"}" &>/dev/null &
+            -d "{\"path\":\"$REPO_PATH\"}" &>/dev/null &
     fi
 fi
 "#;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -571,9 +571,7 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
                                 let parsed = ModelType::parse(m);
                                 if parsed.is_none() {
                                     eprintln!("Unknown model: '{}'. Available models:", m);
-                                    eprintln!("  minilm-l6, minilm-l6-q, minilm-l12, minilm-l12-q, paraphrase-minilm");
-                                    eprintln!("  bge-small, bge-small-q, bge-base, nomic-v1, nomic-v1.5, nomic-v1.5-q");
-                                    eprintln!("  jina-code, e5-multilingual, mxbai-large, modernbert-large");
+                                    eprintln!("  {}", ModelType::valid_short_names());
                                     std::process::exit(1);
                                 }
                                 parsed

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -972,11 +972,15 @@ if [ -f "$SERVE_URL_FILE" ]; then
     if [ -n "$SERVE_URL" ]; then
         # JSON-escape the repo path before embedding it in the request body.
         # A path containing a double quote or backslash would otherwise break
-        # out of the JSON string literal (malformed body / injection). Escape
-        # backslashes first, then double quotes (order matters).
+        # out of the JSON string literal (malformed body / injection). Use
+        # quoted variables as the search/replace operands so the patterns match
+        # LITERALLY — bare backslash patterns (${v//\\/..}) are unreliable across
+        # bash/msys builds. Escape backslashes first, then double quotes.
         REPO_PATH="$(pwd)"
-        REPO_PATH="${REPO_PATH//\\/\\\\}"
-        REPO_PATH="${REPO_PATH//\"/\\\"}"
+        BS='\'
+        DQ='"'
+        REPO_PATH=${REPO_PATH//"$BS"/"$BS$BS"}
+        REPO_PATH=${REPO_PATH//"$DQ"/"$BS$DQ"}
         curl -s -X POST "$SERVE_URL/repos" \
             -H "Content-Type: application/json" \
             -d "{\"path\":\"$REPO_PATH\"}" &>/dev/null &

--- a/src/db_discovery/repos.rs
+++ b/src/db_discovery/repos.rs
@@ -535,13 +535,40 @@ fn normalize_path_for_compare(path: &Path) -> String {
 /// repo has no `origin` remote. Used both to capture a repo's identity at
 /// registration time and to match candidate directories during relocation.
 pub(crate) fn git_remote_url(path: &Path) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(path)
-        .args(["config", "--get", "remote.origin.url"])
-        .output()
-        .ok()?;
+    // `git` is spawned once per candidate directory. On Windows/msys (and Unix
+    // under heavy parallel load) the OS can transiently refuse to fork the
+    // subprocess (EAGAIN / "Resource temporarily unavailable"). Treating that
+    // transient spawn failure the same as "no remote" would silently strip a
+    // repo's git identity — breaking relocation and causing valid repos to be
+    // pruned. Retry a few times with a short backoff on spawn failure; a
+    // definitive `NotFound` (git not installed) returns immediately, and an
+    // `Ok` result whose status is non-success (not a repo / no origin) is a
+    // real answer that is NOT retried.
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut output = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match std::process::Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args(["config", "--get", "remote.origin.url"])
+            .output()
+        {
+            Ok(o) => {
+                output = Some(o);
+                break;
+            }
+            // git binary genuinely absent — retrying cannot help.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            // Transient spawn failure (fork exhaustion). Back off and retry.
+            Err(_) => {
+                if attempt + 1 < MAX_ATTEMPTS {
+                    std::thread::sleep(std::time::Duration::from_millis(20 * (attempt as u64 + 1)));
+                }
+            }
+        }
+    }
 
+    let output = output?;
     if !output.status.success() {
         return None;
     }
@@ -617,15 +644,47 @@ mod tests {
         normalize_path_for_compare(&safe_canonicalize(p).unwrap_or_else(|_| p.to_path_buf()))
     }
 
+    /// Process-wide lock serializing the git-spawning / directory-renaming
+    /// relocation tests.
+    ///
+    /// These tests `git init` a directory and then rename it. On Windows the OS
+    /// indexer / antivirus scans each freshly-created `.git` tree and holds
+    /// handles on it, which blocks the rename ("Access is denied"). When many
+    /// such tests run concurrently the scanner is overwhelmed and the handles
+    /// linger for many seconds — long enough to exhaust even a generous
+    /// `rename_retry`. Serializing them so only one `.git` tree is created/
+    /// renamed at a time keeps each scan window short and the rename reliable.
+    static GIT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Acquire the relocation-test serialization lock, recovering from a
+    /// poisoned mutex (a panic in one test must not cascade-fail the rest).
+    fn git_serial_lock() -> std::sync::MutexGuard<'static, ()> {
+        GIT_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     /// Initialise a git repo at `dir` with an `origin` remote pointing at `url`.
     fn init_git_remote(dir: &Path, url: &str) {
+        // Retry on transient spawn failure (fork exhaustion under parallel test
+        // load on Windows/msys); only a genuine missing-git binary is fatal.
         let run = |args: &[&str]| {
-            std::process::Command::new("git")
-                .arg("-C")
-                .arg(dir)
-                .args(args)
-                .output()
-                .expect("git available in test env")
+            for attempt in 0..5u64 {
+                match std::process::Command::new("git")
+                    .arg("-C")
+                    .arg(dir)
+                    .args(args)
+                    .output()
+                {
+                    Ok(o) => return o,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        panic!("git not available in test env: {e}");
+                    }
+                    Err(_) if attempt < 4 => {
+                        std::thread::sleep(std::time::Duration::from_millis(20 * (attempt + 1)));
+                    }
+                    Err(e) => panic!("git spawn failed after retries: {e}"),
+                }
+            }
+            unreachable!("loop returns or panics")
         };
         run(&["init"]);
         run(&["remote", "add", "origin", url]);
@@ -633,32 +692,40 @@ mod tests {
 
     /// Rename a directory with automatic retries.
     ///
-    /// On Windows, git subprocesses spawned by `init_git_remote` may keep a
-    /// file handle on the directory open briefly after the process exits.
-    /// `std::fs::rename` fails with `Access is denied` in that window.
-    /// Retrying with a short exponential back-off is the simplest robust fix.
+    /// On Windows, git subprocesses spawned by `init_git_remote` (and the OS
+    /// file indexer / antivirus) may keep a handle on the directory open
+    /// briefly after the process exits, so `std::fs::rename` fails with
+    /// "Access is denied". Under heavy parallel test load those handles linger
+    /// longer, so we use a generous retry budget with a capped back-off
+    /// (~7s worst case; in practice it succeeds on the first or second try).
     #[track_caller]
     fn rename_retry(from: &Path, to: &Path) {
+        const MAX_ATTEMPTS: u64 = 40;
         let mut last_err = None;
-        for attempt in 0..10u64 {
+        for attempt in 0..MAX_ATTEMPTS {
             match std::fs::rename(from, to) {
                 Ok(()) => return,
                 Err(e) => {
                     last_err = Some(e);
-                    std::thread::sleep(std::time::Duration::from_millis(20 * (attempt + 1)));
+                    // Ramp the back-off but cap it so the total budget stays
+                    // bounded even under sustained handle contention.
+                    let backoff = (20 * (attempt + 1)).min(250);
+                    std::thread::sleep(std::time::Duration::from_millis(backoff));
                 }
             }
         }
         panic!(
-            "rename {:?} → {:?} failed after 10 attempts: {}",
+            "rename {:?} → {:?} failed after {} attempts: {}",
             from,
             to,
+            MAX_ATTEMPTS,
             last_err.unwrap()
         );
     }
 
     #[test]
     fn captures_git_remote_on_register() {
+        let _serial = git_serial_lock();
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path().join("repo");
         std::fs::create_dir(&repo).unwrap();
@@ -687,6 +754,7 @@ mod tests {
 
     #[test]
     fn try_relocate_finds_renamed_parent() {
+        let _serial = git_serial_lock();
         let tmp = tempfile::tempdir().unwrap();
         let parent = tmp.path().join("parent");
         let repo = parent.join("repo");
@@ -709,6 +777,7 @@ mod tests {
 
     #[test]
     fn try_relocate_none_beyond_max_depth() {
+        let _serial = git_serial_lock();
         // Default max depth is 3. Bury the repo deeper than that below the
         // nearest existing ancestor so the scan cannot reach it.
         let tmp = tempfile::tempdir().unwrap();
@@ -731,6 +800,7 @@ mod tests {
 
     #[test]
     fn relocate_missing_rewrites_only_moved_repos() {
+        let _serial = git_serial_lock();
         let tmp = tempfile::tempdir().unwrap();
         let moved = tmp.path().join("moved");
         let stable = tmp.path().join("stable");
@@ -763,6 +833,7 @@ mod tests {
 
     #[test]
     fn prune_stale_removes_unrelocatable_entries() {
+        let _serial = git_serial_lock();
         let tmp = tempfile::tempdir().unwrap();
         // No git remote → cannot be relocated → must be pruned.
         let plain = tmp.path().join("plain");
@@ -805,6 +876,7 @@ mod tests {
 
     #[test]
     fn try_relocate_finds_renamed_leaf() {
+        let _serial = git_serial_lock();
         let tmp = tempfile::tempdir().unwrap();
         let original = tmp.path().join("myrepo");
         std::fs::create_dir(&original).unwrap();
@@ -825,6 +897,7 @@ mod tests {
 
     #[test]
     fn try_relocate_returns_none_when_path_exists() {
+        let _serial = git_serial_lock();
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path().join("live");
         std::fs::create_dir(&repo).unwrap();
@@ -837,6 +910,7 @@ mod tests {
 
     #[test]
     fn try_relocate_none_without_recorded_remote() {
+        let _serial = git_serial_lock();
         let tmp = tempfile::tempdir().unwrap();
         let plain = tmp.path().join("plain");
         std::fs::create_dir(&plain).unwrap();
@@ -892,6 +966,7 @@ mod tests {
 
     #[test]
     fn try_relocate_none_when_ambiguous() {
+        let _serial = git_serial_lock();
         let tmp = tempfile::tempdir().unwrap();
         let original = tmp.path().join("orig");
         std::fs::create_dir(&original).unwrap();

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -151,7 +151,6 @@ impl ModelType {
     }
 
     /// List all available models
-    #[allow(dead_code)] // Reserved for model listing command
     pub fn all() -> &'static [ModelType] {
         &[
             Self::AllMiniLML6V2,
@@ -171,6 +170,19 @@ impl ModelType {
             Self::MxbaiEmbedLargeV1,
             Self::ModernBertEmbedLarge,
         ]
+    }
+
+    /// Comma-separated list of all valid model short names.
+    ///
+    /// Single source of truth for the "valid models" message shown by the CLI
+    /// (`index add --model`) and the serve `POST /repos` error path, so the two
+    /// can never drift from the set `parse()` actually accepts.
+    pub fn valid_short_names() -> String {
+        Self::all()
+            .iter()
+            .map(|m| m.short_name())
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 
     /// Parse model from string (for CLI)
@@ -375,6 +387,38 @@ mod tests {
     fn test_all_models() {
         let all = ModelType::all();
         assert_eq!(all.len(), 16);
+    }
+
+    #[test]
+    fn test_short_name_round_trips_through_parse() {
+        // Every model advertised by all() must parse back from its short_name.
+        // This guards the C1/M6 fix: the embedding path resolves the model from
+        // the short name stored in metadata.json, and the CLI/serve error lists
+        // are derived from valid_short_names() — a model whose short_name does
+        // not parse would silently break indexing or produce a wrong error list.
+        for m in ModelType::all() {
+            assert_eq!(
+                ModelType::parse(m.short_name()),
+                Some(*m),
+                "short_name '{}' did not round-trip through parse()",
+                m.short_name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_valid_short_names_lists_every_model() {
+        let listed = ModelType::valid_short_names();
+        for m in ModelType::all() {
+            assert!(
+                listed.split(", ").any(|s| s == m.short_name()),
+                "valid_short_names() is missing '{}'",
+                m.short_name()
+            );
+        }
+        // Regression for the original bug: bge-large was accepted by parse()
+        // but omitted from the hand-maintained error lists.
+        assert!(listed.contains("bge-large"));
     }
 
     #[test]

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -603,6 +603,14 @@ impl IndexManager {
             return Ok(());
         }
 
+        // There is work to do. Resolve the embedding model NOW — before any
+        // destructive store mutation below — so that a corrupt index (unknown
+        // model / model-vs-dimension mismatch) fails fast with the index still
+        // intact, rather than deleting stale chunks and then erroring before
+        // re-embedding them. Fail-fast guarantees vectors are always produced
+        // by the model the index was created with (never the hardcoded default).
+        let (embed_model, _dims) = Self::resolve_embed_model(db_path)?;
+
         // Delete chunks for deleted files
         for (file_path, chunk_ids) in &deleted_files {
             if !chunk_ids.is_empty() {
@@ -660,12 +668,6 @@ impl IndexManager {
         // Chunk changed files
         if !changed_files.is_empty() {
             info!("🔄 Processing {} changed files...", changed_files.len());
-
-            // Resolve the embedding model now that we know we must embed. This
-            // fails fast on an unknown model or a model/dimension mismatch, so
-            // vectors are always produced by the model the index was created
-            // with (never the hardcoded default).
-            let (embed_model, _dims) = Self::resolve_embed_model(db_path)?;
 
             // Read + chunk + embed is synchronous, CPU/I/O-heavy work
             // (file reads, tree-sitter parsing, fastembed/ONNX inference that

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -446,6 +446,56 @@ impl IndexManager {
         })
     }
 
+    /// Resolve the embedding model recorded in `metadata.json` for an index.
+    ///
+    /// Returns the parsed [`ModelType`] and its dimension count. Vectors written
+    /// to an index MUST be produced by this exact model — embedding with any
+    /// other model (including the hardcoded default) silently corrupts the index
+    /// and, for non-384d models, yields a dimension mismatch. Every embedding
+    /// path resolves the model through this helper instead of `ModelType::default()`.
+    ///
+    /// Fails fast if metadata is missing, names an unknown model, or records a
+    /// dimension count that disagrees with the resolved model.
+    fn resolve_embed_model(db_path: &Path) -> Result<(ModelType, usize)> {
+        let metadata_path = db_path.join("metadata.json");
+        if !metadata_path.exists() {
+            return Err(anyhow::anyhow!(
+                "No metadata.json found in {}",
+                db_path.display()
+            ));
+        }
+        let content = std::fs::read_to_string(&metadata_path)?;
+        let json: serde_json::Value = serde_json::from_str(&content)?;
+        let model_name = json
+            .get("model_short_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("minilm-l6-q");
+        let dimensions = json
+            .get("dimensions")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(384) as usize;
+        let model = ModelType::parse(model_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown embedding model '{}' in {}. Valid models: {}",
+                model_name,
+                metadata_path.display(),
+                ModelType::valid_short_names()
+            )
+        })?;
+        if model.dimensions() != dimensions {
+            return Err(anyhow::anyhow!(
+                "Metadata inconsistency in {}: model '{}' has {} dimensions but \
+                 metadata records {}. The index is corrupt — re-create it with a \
+                 single consistent model.",
+                metadata_path.display(),
+                model_name,
+                model.dimensions(),
+                dimensions
+            ));
+        }
+        Ok((model, dimensions))
+    }
+
     /// Perform incremental refresh using shared stores.
     ///
     /// This checks for changed/deleted files since last index and updates
@@ -463,51 +513,13 @@ impl IndexManager {
         info!("🔄 Performing incremental refresh with shared stores...");
         let start = std::time::Instant::now();
 
-        // Read model metadata
-        let metadata_path = db_path.join("metadata.json");
-        let (model_name, dimensions) = if metadata_path.exists() {
-            let content = std::fs::read_to_string(&metadata_path)?;
-            let json: serde_json::Value = serde_json::from_str(&content)?;
-            let model = json
-                .get("model_short_name")
-                .and_then(|v| v.as_str())
-                .unwrap_or("minilm-l6-q");
-            let dims = json
-                .get("dimensions")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(384) as usize;
-            (model.to_string(), dims)
-        } else {
-            return Err(anyhow::anyhow!("No metadata.json found in database"));
-        };
-
-        // Resolve the embedding model from the recorded short name. The vectors
-        // produced here MUST match the model recorded in metadata.json — embedding
-        // with a different model (or the hardcoded default) silently corrupts the
-        // index, and for non-384d models produces a dimension mismatch. Fail fast
-        // with a clear error rather than defaulting.
-        let embed_model = ModelType::parse(&model_name).ok_or_else(|| {
-            anyhow::anyhow!(
-                "Unknown embedding model '{}' in {}. Valid models: {}",
-                model_name,
-                metadata_path.display(),
-                ModelType::valid_short_names()
-            )
-        })?;
-        if embed_model.dimensions() != dimensions {
-            return Err(anyhow::anyhow!(
-                "Metadata inconsistency in {}: model '{}' has {} dimensions but \
-                 metadata records {}. The index is corrupt — re-create it with a \
-                 single consistent model.",
-                metadata_path.display(),
-                model_name,
-                embed_model.dimensions(),
-                dimensions
-            ));
-        }
+        // Resolve the embedding model recorded for this index. Embedding MUST use
+        // the same model the index was created with — see resolve_embed_model.
+        let (embed_model, dimensions) = Self::resolve_embed_model(db_path)?;
+        let model_name = embed_model.short_name();
 
         // Load FileMetaStore
-        let mut file_meta_store = FileMetaStore::load_or_create(db_path, &model_name, dimensions)?;
+        let mut file_meta_store = FileMetaStore::load_or_create(db_path, model_name, dimensions)?;
 
         // B1 safety guard: if FileMetaStore is empty but VectorStore has chunks,
         // the metadata was lost/reset (model change, corrupt file, etc.).
@@ -642,7 +654,6 @@ impl IndexManager {
             let files_for_embed = changed_files.clone();
             let embedded_chunks =
                 tokio::task::spawn_blocking(move || -> Result<Vec<crate::embed::EmbeddedChunk>> {
-                    let embed_model = embed_model;
                     let mut chunker = SemanticChunker::new(100, 2000, 10);
                     let mut all_chunks = Vec::new();
 
@@ -1768,20 +1779,18 @@ impl IndexManager {
             file_path.display()
         );
 
+        // Resolve the embedding model recorded for this index BEFORE embedding.
+        // The live watcher path must re-embed changed files with the SAME model
+        // the index was created with — using the hardcoded default here would
+        // write 384d vectors into a non-384d index and corrupt it.
+        let (embed_model, dimensions) = Self::resolve_embed_model(&db_path)?;
+        let model_name = embed_model.short_name();
+
         // Generate embeddings
         let cache_dir = crate::constants::get_global_models_cache_dir()?;
         let mut embedding_service =
-            EmbeddingService::with_cache_dir(ModelType::default(), Some(cache_dir.as_path()))?;
+            EmbeddingService::with_cache_dir(embed_model, Some(cache_dir.as_path()))?;
         let embedded_chunks = embedding_service.embed_chunks(chunks)?;
-
-        // Load metadata to get dimensions
-        let metadata_path = db_path.join("metadata.json");
-        let metadata: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&metadata_path)?)?;
-        let dimensions = metadata["dimensions"].as_u64().unwrap_or(384) as usize;
-        let model_name = metadata["model_short_name"]
-            .as_str()
-            .unwrap_or("minilm-l6-q");
 
         // ── Delete stale chunks for this file BEFORE inserting new ones ──
         // When a file is re-indexed (e.g. after a content change), the old

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -863,15 +863,21 @@ impl IndexManager {
 
         // ── Step 4: Ensure metadata.json exists before reindex ──
         // perform_incremental_refresh_with_stores() hard-fails without it.
-        // Write back the preserved metadata (with updated timestamp).
+        // Write back the preserved metadata (with updated timestamp) via the
+        // atomic read-modify-write helper so a crash here can never leave a
+        // truncated/partial metadata.json (the failure mode the atomic writer
+        // exists to prevent).
         {
-            let mut metadata_to_write = preserved_metadata.clone();
-            metadata_to_write["indexed_at"] =
-                serde_json::Value::String(chrono::Utc::now().to_rfc3339());
-            std::fs::write(
-                &metadata_path,
-                serde_json::to_string_pretty(&metadata_to_write)?,
-            )
+            let indexed_at = serde_json::Value::String(chrono::Utc::now().to_rfc3339());
+            let preserved = preserved_metadata.clone();
+            crate::vectordb::merge_metadata_atomic(db_path, move |obj| {
+                if let Some(src) = preserved.as_object() {
+                    for (k, v) in src {
+                        obj.insert(k.clone(), v.clone());
+                    }
+                }
+                obj.insert("indexed_at".to_string(), indexed_at);
+            })
             .with_context(|| format!("Failed to write {}", metadata_path.display()))?;
         }
 

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -513,13 +513,30 @@ impl IndexManager {
         info!("🔄 Performing incremental refresh with shared stores...");
         let start = std::time::Instant::now();
 
-        // Resolve the embedding model recorded for this index. Embedding MUST use
-        // the same model the index was created with — see resolve_embed_model.
-        let (embed_model, dimensions) = Self::resolve_embed_model(db_path)?;
-        let model_name = embed_model.short_name();
+        // Read model name + dims (lenient) for the FileMetaStore. The strict,
+        // fail-fast embedding-model resolution happens lazily below, only when
+        // there are actually changed files to embed — a no-op refresh must not
+        // require a resolvable model.
+        let metadata_path = db_path.join("metadata.json");
+        let (model_name, dimensions) = if metadata_path.exists() {
+            let content = std::fs::read_to_string(&metadata_path)?;
+            let json: serde_json::Value = serde_json::from_str(&content)?;
+            let model = json
+                .get("model_short_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("minilm-l6-q")
+                .to_string();
+            let dims = json
+                .get("dimensions")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(384) as usize;
+            (model, dims)
+        } else {
+            return Err(anyhow::anyhow!("No metadata.json found in database"));
+        };
 
         // Load FileMetaStore
-        let mut file_meta_store = FileMetaStore::load_or_create(db_path, model_name, dimensions)?;
+        let mut file_meta_store = FileMetaStore::load_or_create(db_path, &model_name, dimensions)?;
 
         // B1 safety guard: if FileMetaStore is empty but VectorStore has chunks,
         // the metadata was lost/reset (model change, corrupt file, etc.).
@@ -643,6 +660,12 @@ impl IndexManager {
         // Chunk changed files
         if !changed_files.is_empty() {
             info!("🔄 Processing {} changed files...", changed_files.len());
+
+            // Resolve the embedding model now that we know we must embed. This
+            // fails fast on an unknown model or a model/dimension mismatch, so
+            // vectors are always produced by the model the index was created
+            // with (never the hardcoded default).
+            let (embed_model, _dims) = Self::resolve_embed_model(db_path)?;
 
             // Read + chunk + embed is synchronous, CPU/I/O-heavy work
             // (file reads, tree-sitter parsing, fastembed/ONNX inference that

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -481,6 +481,31 @@ impl IndexManager {
             return Err(anyhow::anyhow!("No metadata.json found in database"));
         };
 
+        // Resolve the embedding model from the recorded short name. The vectors
+        // produced here MUST match the model recorded in metadata.json — embedding
+        // with a different model (or the hardcoded default) silently corrupts the
+        // index, and for non-384d models produces a dimension mismatch. Fail fast
+        // with a clear error rather than defaulting.
+        let embed_model = ModelType::parse(&model_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown embedding model '{}' in {}. Valid models: {}",
+                model_name,
+                metadata_path.display(),
+                ModelType::valid_short_names()
+            )
+        })?;
+        if embed_model.dimensions() != dimensions {
+            return Err(anyhow::anyhow!(
+                "Metadata inconsistency in {}: model '{}' has {} dimensions but \
+                 metadata records {}. The index is corrupt — re-create it with a \
+                 single consistent model.",
+                metadata_path.display(),
+                model_name,
+                embed_model.dimensions(),
+                dimensions
+            ));
+        }
+
         // Load FileMetaStore
         let mut file_meta_store = FileMetaStore::load_or_create(db_path, &model_name, dimensions)?;
 
@@ -617,6 +642,7 @@ impl IndexManager {
             let files_for_embed = changed_files.clone();
             let embedded_chunks =
                 tokio::task::spawn_blocking(move || -> Result<Vec<crate::embed::EmbeddedChunk>> {
+                    let embed_model = embed_model;
                     let mut chunker = SemanticChunker::new(100, 2000, 10);
                     let mut all_chunks = Vec::new();
 
@@ -633,11 +659,13 @@ impl IndexManager {
                         return Ok(Vec::new());
                     }
 
-                    info!("📦 Embedding {} chunks...", all_chunks.len());
-                    let mut embedding_service = EmbeddingService::with_cache_dir(
-                        ModelType::default(),
-                        Some(cache_dir.as_path()),
-                    )?;
+                    info!(
+                        "📦 Embedding {} chunks with model {}...",
+                        all_chunks.len(),
+                        embed_model.short_name()
+                    );
+                    let mut embedding_service =
+                        EmbeddingService::with_cache_dir(embed_model, Some(cache_dir.as_path()))?;
                     embedding_service.embed_chunks(all_chunks)
                 })
                 .await

--- a/src/lmdb_registry.rs
+++ b/src/lmdb_registry.rs
@@ -11,6 +11,7 @@
 
 use anyhow::{Context, Result};
 use dashmap::DashMap;
+use std::mem::ManuallyDrop;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -73,7 +74,10 @@ fn unregister(canonical: &Path) {
 /// Implements `Deref<Target = heed::Env>` so all existing `env.method()` calls
 /// work without changes.
 pub struct TrackedEnv {
-    inner: heed::Env,
+    /// Wrapped in `ManuallyDrop` so [`Drop`] can release the underlying
+    /// `heed::Env` BEFORE freeing our own registry slot. See the `Drop` impl
+    /// for why the ordering is load-bearing.
+    inner: ManuallyDrop<heed::Env>,
     canonical: PathBuf,
 }
 
@@ -92,7 +96,7 @@ impl TrackedEnv {
 
         match opts.open(path) {
             Ok(env) => Ok(Self {
-                inner: env,
+                inner: ManuallyDrop::new(env),
                 canonical,
             }),
             Err(e) => {
@@ -105,6 +109,30 @@ impl TrackedEnv {
 
 impl Drop for TrackedEnv {
     fn drop(&mut self) {
+        // Ordering here is load-bearing. heed maintains its OWN process-global
+        // registry of opened environments (`OPENED_ENV`), keyed by canonical
+        // path, that outlives a `heed::Env` until its last strong ref drops.
+        // If we `unregister()` from our registry FIRST and let the field drop
+        // afterwards (the default Rust drop order: body, then fields), there is
+        // a window where our slot is free but heed's env is still alive. A
+        // concurrent `TrackedEnv::open` on the same path — e.g. the idle reaper
+        // dropping a repo while a reindex/query reopens it — then passes our
+        // `register()` guard and falls through to `opts.open()`, which heed
+        // rejects with the cryptic "an environment is already opened with
+        // different options" (once a prior MDB_MAP_FULL resize left the live
+        // env's recorded map_size differing from the reopen's resolved size).
+        //
+        // Dropping the `heed::Env` BEFORE `unregister()` enforces the invariant
+        // "our slot free ⟹ heed's slot free": a concurrent open either sees our
+        // slot still occupied (clear "double-open prevented" + retry) or sees
+        // both free (clean reopen). It can never observe the inconsistent state
+        // that produces heed's raw error.
+        //
+        // SAFETY: `inner` is dropped exactly once, here, and never accessed
+        // again (the surrounding `TrackedEnv` is being destroyed).
+        unsafe {
+            ManuallyDrop::drop(&mut self.inner);
+        }
         unregister(&self.canonical);
     }
 }
@@ -132,8 +160,12 @@ mod tests {
     use tempfile::TempDir;
 
     fn make_opts() -> heed::EnvOpenOptions {
+        make_opts_sized(1024 * 1024)
+    }
+
+    fn make_opts_sized(map_size: usize) -> heed::EnvOpenOptions {
         let mut opts = heed::EnvOpenOptions::new();
-        opts.map_size(1024 * 1024).max_dbs(1);
+        opts.map_size(map_size).max_dbs(1);
         opts
     }
 
@@ -177,5 +209,61 @@ mod tests {
 
         let _env1 = unsafe { TrackedEnv::open(&opts, dir1.path(), "test-1").unwrap() };
         let _env2 = unsafe { TrackedEnv::open(&opts, dir2.path(), "test-2").unwrap() };
+    }
+
+    /// Regression guard for the `Drop` ordering bug: a previous `TrackedEnv`
+    /// must release heed's internal `OPENED_ENV` slot BEFORE freeing our own
+    /// registry slot. Otherwise a concurrent open that wins our `register()`
+    /// race falls through to `opts.open()` and heed rejects it with
+    /// "an environment is already opened with different options" — the exact
+    /// production symptom (the two opens here request DIFFERENT map sizes so a
+    /// stale-but-live heed env would mismatch).
+    ///
+    /// This test churns open→drop→reopen on a single shared path from multiple
+    /// threads. It asserts the forbidden heed string NEVER appears. Our own
+    /// "double-open prevented" error IS allowed (it means `register()` correctly
+    /// serialized the racing opens). The assertion can only fail on a real
+    /// regression — a missed race is a false negative, never a flaky failure.
+    #[test]
+    fn test_drop_releases_heed_slot_before_registry_slot() {
+        use std::sync::Arc;
+
+        let dir = TempDir::new().unwrap();
+        let path: Arc<std::path::PathBuf> = Arc::new(dir.path().to_path_buf());
+
+        let threads: Vec<_> = (0..4)
+            .map(|t| {
+                let path = Arc::clone(&path);
+                std::thread::spawn(move || {
+                    // Alternate map sizes per thread so any stale-but-live heed
+                    // env observed by a racing open is guaranteed to mismatch
+                    // options and surface BadOpenOptions if the bug is present.
+                    let map_size = if t % 2 == 0 {
+                        1024 * 1024
+                    } else {
+                        2 * 1024 * 1024
+                    };
+                    for _ in 0..50 {
+                        let opts = make_opts_sized(map_size);
+                        match unsafe { TrackedEnv::open(&opts, &path, "race") } {
+                            Ok(env) => drop(env),
+                            Err(e) => {
+                                let msg = e.to_string();
+                                assert!(
+                                    !msg.contains("already opened with different options"),
+                                    "heed slot leaked past our registry slot: {msg}"
+                                );
+                                // "double-open prevented" is the expected,
+                                // benign outcome of a serialized race.
+                            }
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for h in threads {
+            h.join().unwrap();
+        }
     }
 }

--- a/src/lmdb_registry.rs
+++ b/src/lmdb_registry.rs
@@ -211,40 +211,45 @@ mod tests {
         let _env2 = unsafe { TrackedEnv::open(&opts, dir2.path(), "test-2").unwrap() };
     }
 
-    /// Regression guard for the `Drop` ordering bug: a previous `TrackedEnv`
-    /// must release heed's internal `OPENED_ENV` slot BEFORE freeing our own
-    /// registry slot. Otherwise a concurrent open that wins our `register()`
-    /// race falls through to `opts.open()` and heed rejects it with
-    /// "an environment is already opened with different options" — the exact
-    /// production symptom (the two opens here request DIFFERENT map sizes so a
-    /// stale-but-live heed env would mismatch).
+    /// Regression guard for the concurrent open→drop→reopen path that produced
+    /// the production 500 ("an environment is already opened with different
+    /// options").
     ///
-    /// This test churns open→drop→reopen on a single shared path from multiple
-    /// threads. It asserts the forbidden heed string NEVER appears. Our own
-    /// "double-open prevented" error IS allowed (it means `register()` correctly
-    /// serialized the racing opens). The assertion can only fail on a real
-    /// regression — a missed race is a false negative, never a flaky failure.
+    /// Contract: every open of a given path within the process MUST use the
+    /// same `map_size` (the store layer enforces this via its process-global
+    /// per-path map-size pin — see `vectordb::store::resolve_map_size`). heed
+    /// rejects a reopen whose recorded options differ from a still-live env, and
+    /// because heed defers env close, a reopen can briefly observe the prior
+    /// env; the `TrackedEnv` `Drop` reorder (drop the heed env before freeing
+    /// our slot) narrows that window but the consistent-size contract is what
+    /// makes it fully safe — matching options mean heed reuses/reopens cleanly
+    /// instead of erroring.
+    ///
+    /// This test churns open→drop→reopen on a single shared path from many
+    /// threads (behind a barrier to maximize overlap), all using the SAME size,
+    /// and asserts the forbidden heed string NEVER appears. Our own "double-open
+    /// prevented" error IS allowed (it means `register()` serialized the race).
+    /// The assertion can only fail on a real regression — never flaky.
     #[test]
-    fn test_drop_releases_heed_slot_before_registry_slot() {
-        use std::sync::Arc;
+    fn test_concurrent_reopen_same_size_never_conflicts() {
+        use std::sync::{Arc, Barrier};
+
+        const THREADS: usize = 8;
+        const ITERS: usize = 4000;
+        const MAP_SIZE: usize = 1024 * 1024;
 
         let dir = TempDir::new().unwrap();
         let path: Arc<std::path::PathBuf> = Arc::new(dir.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(THREADS));
 
-        let threads: Vec<_> = (0..4)
-            .map(|t| {
+        let threads: Vec<_> = (0..THREADS)
+            .map(|_| {
                 let path = Arc::clone(&path);
+                let barrier = Arc::clone(&barrier);
                 std::thread::spawn(move || {
-                    // Alternate map sizes per thread so any stale-but-live heed
-                    // env observed by a racing open is guaranteed to mismatch
-                    // options and surface BadOpenOptions if the bug is present.
-                    let map_size = if t % 2 == 0 {
-                        1024 * 1024
-                    } else {
-                        2 * 1024 * 1024
-                    };
-                    for _ in 0..50 {
-                        let opts = make_opts_sized(map_size);
+                    barrier.wait();
+                    for _ in 0..ITERS {
+                        let opts = make_opts_sized(MAP_SIZE);
                         match unsafe { TrackedEnv::open(&opts, &path, "race") } {
                             Ok(env) => drop(env),
                             Err(e) => {

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -439,7 +439,13 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
     let (model_type, dimensions, primary_language) =
         if let Some(ref model_name) = options.model_override {
             // User specified a model - use it (warning: may not match indexed data!)
-            let mt = ModelType::parse(model_name).unwrap_or_default();
+            let mt = ModelType::parse(model_name).unwrap_or_else(|| {
+                tracing::warn!(
+                    "Unrecognized model override '{}', falling back to default model",
+                    model_name
+                );
+                ModelType::default()
+            });
             (mt, mt.dimensions(), None)
         } else if let Some((model_name, dims, lang)) = read_metadata(&db_path) {
             // Use model from metadata
@@ -447,6 +453,10 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
                 (mt, dims, lang)
             } else {
                 // Model name not recognized, fall back to default
+                tracing::warn!(
+                    "Unrecognized model '{}' in database metadata, falling back to default model",
+                    model_name
+                );
                 warn_print!(
                     "{}",
                     "⚠️  Unknown model in metadata, using default".yellow()

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -2880,7 +2880,7 @@ async fn add_repo_handler(
                 return (
                     StatusCode::BAD_REQUEST,
                     axum::response::Json(json!({
-                        "error": format!("Unknown model: '{}'. Use one of: minilm-l6, minilm-l6-q, minilm-l12, minilm-l12-q, paraphrase-minilm, bge-small, bge-small-q, bge-base, nomic-v1, nomic-v1.5, nomic-v1.5-q, jina-code, e5-multilingual, mxbai-large, modernbert-large", model_str),
+                        "error": format!("Unknown model: '{}'. Use one of: {}", model_str, crate::embed::ModelType::valid_short_names()),
                         "status": "error"
                     })),
                 );

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -2461,13 +2461,22 @@ async fn doctor_handler(
         }
     };
 
-    // Reuse the open LMDB handle when available; otherwise open via diagnose().
-    let report = if let Some(stores) = state.get_opened_stores(&alias) {
-        let vs = stores.vector_store.read().await;
-        crate::cli::doctor::diagnose_with_store(&project_path, &vs)
-    } else {
-        crate::cli::doctor::diagnose(&project_path)
-    };
+    // diagnose() walks the repo tree and scans LMDB — synchronous, potentially
+    // slow work. Run it on a blocking thread so it never occupies a tokio worker
+    // (mirrors the reindex path). Reuse the open LMDB handle when available
+    // (via blocking_read inside the blocking task) to avoid double-opening the
+    // env; otherwise diagnose() opens its own read-only handle.
+    let opened = state.get_opened_stores(&alias);
+    let pp = project_path.clone();
+    let report = tokio::task::spawn_blocking(move || match opened {
+        Some(stores) => {
+            let vs = stores.vector_store.blocking_read();
+            crate::cli::doctor::diagnose_with_store(&pp, &vs)
+        }
+        None => crate::cli::doctor::diagnose(&pp),
+    })
+    .await
+    .unwrap_or_else(|e| Err(anyhow::anyhow!("doctor task panicked: {}", e)));
 
     let results = match report {
         Ok(report) => report.render_tui(),
@@ -3581,6 +3590,11 @@ pub async fn run_serve(
             axum::routing::post(reindex_handler),
         )
         .route("/repos/:alias/info", axum::routing::get(info_handler))
+        // /doctor is a POST but is intentionally read-only (diagnostics only, no
+        // --fix path), so like /info and /status it is NOT in require_admin_auth's
+        // management set — reachable without the admin key on localhost, and still
+        // protected by require_auth_for_network on network binds. If doctor ever
+        // gains a mutating mode, add it to `is_management` in require_admin_auth.
         .route("/repos/:alias/doctor", axum::routing::post(doctor_handler))
         .nest_service(MCP_ENDPOINT_PATH, mcp_service)
         .layer(axum::middleware::from_fn(require_admin_auth))

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -3075,6 +3075,48 @@ fn validate_path_within_allowed_roots(canonical_path: &Path) -> std::result::Res
     }
 }
 
+/// Constant-time API key comparison.
+///
+/// Hashes both the supplied candidate and the configured key with SHA-256 and
+/// compares the fixed-length 32-byte digests byte-for-byte without early exit.
+/// Because the digests are always the same length and SHA-256 is
+/// preimage-resistant, the comparison time does not depend on how many leading
+/// bytes of the candidate match the secret — closing the timing side-channel
+/// that a raw `==` on the key strings would open on the network-exposed path.
+fn api_key_matches(candidate: &str, configured: &str) -> bool {
+    use sha2::{Digest, Sha256};
+    let candidate_digest = Sha256::digest(candidate.as_bytes());
+    let configured_digest = Sha256::digest(configured.as_bytes());
+    let mut diff: u8 = 0;
+    for (a, b) in candidate_digest.iter().zip(configured_digest.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
+/// Returns true if the request carries a valid API key in either the
+/// `Authorization: Bearer <key>` or `X-API-Key: <key>` header, compared in
+/// constant time against `configured`. Shared by both auth middlewares so the
+/// constant-time guarantee lives in exactly one place.
+fn request_has_valid_api_key(headers: &axum::http::HeaderMap, configured: &str) -> bool {
+    if let Some(auth_val) = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+    {
+        if let Some(bearer_key) = auth_val.strip_prefix("Bearer ") {
+            if api_key_matches(bearer_key, configured) {
+                return true;
+            }
+        }
+    }
+    if let Some(key_val) = headers.get("X-API-Key").and_then(|v| v.to_str().ok()) {
+        if api_key_matches(key_val, configured) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Axum middleware that requires API key authentication for management endpoints.
 ///
 /// When `CODESEARCH_SERVE_API_KEY` is set, requests must include the key in either:
@@ -3087,8 +3129,7 @@ fn validate_path_within_allowed_roots(canonical_path: &Path) -> std::result::Res
 /// `POST /repos/:alias/reindex`, `POST /reload`.
 /// All other routes (health, status, MCP) are always unauthenticated.
 ///
-/// Note: key comparison uses standard string equality, not constant-time comparison.
-/// Timing attacks are impractical on a localhost-only service.
+/// Key comparison is constant-time (see `api_key_matches`).
 async fn require_admin_auth(
     req: axum::extract::Request,
     next: axum::middleware::Next,
@@ -3110,24 +3151,8 @@ async fn require_admin_auth(
         _ => return next.run(req).await,
     };
 
-    // Check Authorization: Bearer <key>
-    if let Some(auth_header) = req.headers().get(axum::http::header::AUTHORIZATION) {
-        if let Ok(auth_val) = auth_header.to_str() {
-            if let Some(bearer_key) = auth_val.strip_prefix("Bearer ") {
-                if bearer_key == configured_key {
-                    return next.run(req).await;
-                }
-            }
-        }
-    }
-
-    // Check X-API-Key: <key>
-    if let Some(api_key_header) = req.headers().get("X-API-Key") {
-        if let Ok(key_val) = api_key_header.to_str() {
-            if key_val == configured_key {
-                return next.run(req).await;
-            }
-        }
+    if request_has_valid_api_key(req.headers(), &configured_key) {
+        return next.run(req).await;
     }
 
     warn!(
@@ -3185,24 +3210,8 @@ async fn require_auth_for_network(
         }
     };
 
-    // Check Authorization: Bearer <key>
-    if let Some(auth_header) = req.headers().get(axum::http::header::AUTHORIZATION) {
-        if let Ok(auth_val) = auth_header.to_str() {
-            if let Some(bearer_key) = auth_val.strip_prefix("Bearer ") {
-                if bearer_key == configured_key {
-                    return next.run(req).await;
-                }
-            }
-        }
-    }
-
-    // Check X-API-Key: <key>
-    if let Some(api_key_header) = req.headers().get("X-API-Key") {
-        if let Ok(key_val) = api_key_header.to_str() {
-            if key_val == configured_key {
-                return next.run(req).await;
-            }
-        }
+    if request_has_valid_api_key(req.headers(), configured_key) {
+        return next.run(req).await;
     }
 
     let path = req.uri().path();
@@ -3566,6 +3575,17 @@ pub async fn run_serve(
 mod tests {
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn test_api_key_matches() {
+        assert!(api_key_matches("secret-key", "secret-key"));
+        assert!(!api_key_matches("secret-key", "secret-keX"));
+        assert!(!api_key_matches("secret", "secret-key")); // different length
+        assert!(!api_key_matches("", "secret-key"));
+        assert!(api_key_matches("", "")); // both empty digests are equal
+                                          // Case-sensitive and exact.
+        assert!(!api_key_matches("Secret-Key", "secret-key"));
+    }
 
     fn state_with_config(config: ReposConfig) -> ServeState {
         // Use a temp file override so reload_if_changed doesn't see the real repos.json

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -2282,6 +2282,7 @@ async fn status_handler(
                 "last_tool_call": info.last_tool_call,
                 "tool_call_count": info.tool_call_count,
                 "csharp_index": csharp_str,
+                "csharp_error": info.csharp_error,
             })
         })
         .collect();
@@ -2340,6 +2341,144 @@ async fn status_handler(
         "csharp_helper": csharp_helper,
         "uptime_secs": uptime_secs,
     }))
+}
+
+/// Info handler: GET /repos/{alias}/info
+///
+/// Returns live index stats for a single repo, mirroring the TUI info overlay
+/// (`tui::build_info_overlay`). Used by the remote TUI's `i` key.
+async fn info_handler(
+    axum::extract::Path(alias): axum::extract::Path<String>,
+    axum::extract::State(state): axum::extract::State<Arc<ServeState>>,
+) -> axum::response::Response {
+    use axum::http::StatusCode;
+
+    let config = state.config_snapshot();
+    let project_path = match config.resolve(&alias) {
+        Some(p) => p,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                AxumJson(json!({
+                    "error": format!("unknown repo alias: {}", alias),
+                    "status": "error",
+                })),
+            )
+                .into_response();
+        }
+    };
+    let db_path = project_path.join(DB_DIR_NAME);
+
+    // Defaults (overridden by metadata.json then live store stats).
+    let mut chunks = 0usize;
+    let mut files = 0usize;
+    let mut max_chunk_id = 0u32;
+    let mut dims = 0usize;
+    let mut model = String::from("unknown");
+    let mut lock = String::from("—");
+    let mut index_age = String::from("—");
+
+    // Read model + dims + counts from metadata.json.
+    if let Ok(content) = std::fs::read_to_string(db_path.join("metadata.json")) {
+        if let Ok(meta) = serde_json::from_str::<serde_json::Value>(&content) {
+            model = meta
+                .get("model_short_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string();
+            dims = meta.get("dimensions").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+            chunks = meta
+                .get("total_chunks")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as usize;
+            files = meta
+                .get("total_files")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as usize;
+            if let Some(indexed_at) = meta.get("indexed_at").and_then(|v| v.as_str()) {
+                index_age = tui::format_age(indexed_at);
+            }
+        }
+    }
+
+    // If stores are open, live stats override metadata.
+    if let Some(stores) = state.get_opened_stores(&alias) {
+        if let Ok(vs) = stores.vector_store.try_read() {
+            if let Ok(live_stats) = vs.stats() {
+                chunks = live_stats.total_chunks;
+                files = live_stats.total_files;
+                max_chunk_id = live_stats.max_chunk_id;
+                if dims == 0 {
+                    dims = live_stats.dimensions;
+                }
+            }
+        }
+        lock = if stores.readonly {
+            "read".to_string()
+        } else {
+            "write".to_string()
+        };
+    }
+
+    let db_size_human = tui::dir_size_human(&db_path);
+
+    AxumJson(json!({
+        "chunks": chunks,
+        "files": files,
+        "max_chunk_id": max_chunk_id,
+        "db_size_human": db_size_human,
+        "model": model,
+        "dims": dims,
+        "lock": lock,
+        "index_age": index_age,
+    }))
+    .into_response()
+}
+
+/// Doctor handler: POST /repos/{alias}/doctor
+///
+/// Runs doctor diagnostics for a single repo and returns the rendered TUI lines.
+/// Reuses the open LMDB handle via `diagnose_with_store` when stores are open,
+/// to avoid double-opening the environment. Used by the remote TUI's `d` key.
+async fn doctor_handler(
+    axum::extract::Path(alias): axum::extract::Path<String>,
+    axum::extract::State(state): axum::extract::State<Arc<ServeState>>,
+) -> axum::response::Response {
+    use axum::http::StatusCode;
+
+    let config = state.config_snapshot();
+    let project_path = match config.resolve(&alias) {
+        Some(p) => p,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                AxumJson(json!({
+                    "error": format!("unknown repo alias: {}", alias),
+                    "status": "error",
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    // Reuse the open LMDB handle when available; otherwise open via diagnose().
+    let report = if let Some(stores) = state.get_opened_stores(&alias) {
+        let vs = stores.vector_store.read().await;
+        crate::cli::doctor::diagnose_with_store(&project_path, &vs)
+    } else {
+        crate::cli::doctor::diagnose(&project_path)
+    };
+
+    let results = match report {
+        Ok(report) => report.render_tui(),
+        Err(e) => vec![
+            format!("✗ Doctor failed: {}", e),
+            String::new(),
+            "  [Esc] close".to_string(),
+        ],
+    };
+
+    AxumJson(json!({ "results": results })).into_response()
 }
 
 /// Trigger a symbol index rebuild for a repo (C# etc.).
@@ -3441,6 +3580,8 @@ pub async fn run_serve(
             "/repos/:alias/reindex",
             axum::routing::post(reindex_handler),
         )
+        .route("/repos/:alias/info", axum::routing::get(info_handler))
+        .route("/repos/:alias/doctor", axum::routing::post(doctor_handler))
         .nest_service(MCP_ENDPOINT_PATH, mcp_service)
         .layer(axum::middleware::from_fn(require_admin_auth))
         .layer(axum::middleware::from_fn(log_mcp_requests))

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -1209,17 +1209,29 @@ impl ServeState {
                 RepoState::Warm { stores } => {
                     return Some(stores.clone());
                 }
-                RepoState::Readonly { .. } => {
-                    // Cannot force-reindex a readonly store; let the caller
-                    // fall through to try_open_stores(allow_create=true)
-                    // which will attempt a write-mode open (and fail with a
-                    // clear error if the write lock is still held).
+                RepoState::Readonly { .. } | RepoState::Conflicted => {
+                    // Cannot force-reindex a readonly or conflicted store.
+                    // Drop the entry from the DashMap so the LMDB TrackedEnv
+                    // is released — the caller will reopen in write mode via
+                    // try_open_stores(allow_create=true).
+                    drop(entry);
+                    self.close_repo(alias);
                     return None;
                 }
-                RepoState::Conflicted => return None,
             }
         }
         None
+    }
+
+    /// Remove a repo from the DashMap, dropping its stores and releasing
+    /// LMDB file handles. Used before force-reindex reopen.
+    fn close_repo(&self, alias: &str) {
+        if self.repos.remove(alias).is_some() {
+            tracing::info!(
+                "Closed repo '{}' (dropped stores, released LMDB handles)",
+                alias
+            );
+        }
     }
 
     /// Spawn the FSW background task for a repo after it has been stopped.

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -4169,6 +4169,89 @@ mod tests {
         );
     }
 
+    /// Verify that the /repos/:alias/info and /repos/:alias/doctor routes are
+    /// registered and reachable. Starts a real axum server on a random port and
+    /// asserts that an unknown alias yields our handler's 404 (not axum's 404).
+    #[tokio::test]
+    async fn info_doctor_routes_registered() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("myrepo");
+        std::fs::create_dir(&repo_path).unwrap();
+
+        let mut config = ReposConfig::default();
+        config
+            .register_with_alias(repo_path.clone(), Some("testalias".to_string()))
+            .unwrap();
+
+        let config_file = tmp.path().join("repos.json");
+        config.save_to(&config_file).unwrap();
+
+        let state = Arc::new(ServeState::new(config, Some(config_file)));
+
+        let app = axum::Router::new()
+            .route(
+                crate::constants::HEALTH_PATH,
+                axum::routing::get(health_handler),
+            )
+            .route("/repos/:alias/info", axum::routing::get(info_handler))
+            .route("/repos/:alias/doctor", axum::routing::post(doctor_handler))
+            .with_state(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        // Give the server a moment to start
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let client = reqwest::Client::new();
+
+        // GET unknown alias info → 404 from our handler (not axum's built-in 404)
+        let resp = client
+            .get(format!("http://{}/repos/unknown/info", addr))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::NOT_FOUND,
+            "expected 404 from info handler"
+        );
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .expect("info handler should return JSON body for 404");
+        assert!(
+            body.get("error").is_some(),
+            "expected JSON error body from info handler, got: {}",
+            body
+        );
+
+        // POST unknown alias doctor → 404 from our handler (not axum's built-in 404)
+        let resp = client
+            .post(format!("http://{}/repos/unknown/doctor", addr))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::NOT_FOUND,
+            "expected 404 from doctor handler"
+        );
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .expect("doctor handler should return JSON body for 404");
+        assert!(
+            body.get("error").is_some(),
+            "expected JSON error body from doctor handler, got: {}",
+            body
+        );
+    }
+
     #[test]
     fn config_reload_tolerates_parse_error() {
         let tmp = tempfile::tempdir().unwrap();

--- a/src/serve/tui.rs
+++ b/src/serve/tui.rs
@@ -14,7 +14,7 @@ use ratatui::layout::{Constraint, Layout};
 use ratatui::Terminal;
 
 use crossterm::event::{self, Event, KeyEventKind};
-use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use crossterm::terminal::{self, EnterAlternateScreen};
 
 use tokio_util::sync::CancellationToken;
 
@@ -54,7 +54,7 @@ pub async fn run_tui(
     let result = run_tui_loop(&mut terminal, state, cancel_token, &serve_url).await;
 
     // Always restore terminal, even on error
-    restore_terminal(&mut terminal)?;
+    tui_common::restore_terminal(&mut terminal)?;
 
     result
 }
@@ -187,7 +187,7 @@ async fn run_tui_loop(
                 }
                 match tui_common::handle_key(key, &mut table_state, rows.len()) {
                     KeyAction::Reload => {
-                        // 's' pressed — force reload of repos config
+                        // 'l' pressed — force reload of repos config
                         // Clear mtime so reload_if_changed actually reloads
                         if let Ok(mut mtime_guard) = state.config_mtime.write() {
                             *mtime_guard = None;
@@ -274,7 +274,7 @@ fn map_repo_rows(
                 super::CSharpIndexStatus::Ready => "ready",
                 super::CSharpIndexStatus::Indexing => "indexing",
                 super::CSharpIndexStatus::Error => "error",
-                super::CSharpIndexStatus::None => "",
+                super::CSharpIndexStatus::None => "none",
             }
             .to_string();
 
@@ -303,17 +303,6 @@ fn map_repo_rows(
             }
         })
         .collect()
-}
-
-// ---------------------------------------------------------------------------
-// Restore helpers
-// ---------------------------------------------------------------------------
-
-fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<()> {
-    terminal::disable_raw_mode()?;
-    crossterm::execute!(io::stdout(), LeaveAlternateScreen)?;
-    terminal.show_cursor()?;
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/serve/tui.rs
+++ b/src/serve/tui.rs
@@ -444,7 +444,7 @@ fn build_info_overlay(
 }
 
 /// Format an ISO 8601 timestamp as a human-readable age string.
-fn format_age(iso_ts: &str) -> String {
+pub(crate) fn format_age(iso_ts: &str) -> String {
     let parsed = chrono::DateTime::parse_from_rfc3339(iso_ts).or_else(|_| {
         // Try without timezone (assume UTC)
         chrono::NaiveDateTime::parse_from_str(iso_ts, "%Y-%m-%dT%H:%M:%S%.f")
@@ -478,7 +478,7 @@ fn format_age(iso_ts: &str) -> String {
 }
 
 /// Compute total size of a directory on disk, formatted as human-readable string.
-fn dir_size_human(path: &std::path::Path) -> String {
+pub(crate) fn dir_size_human(path: &std::path::Path) -> String {
     let total_bytes = walkdir_size(path);
     if total_bytes == 0 {
         return "—".to_string();

--- a/src/serve/tui.rs
+++ b/src/serve/tui.rs
@@ -78,6 +78,11 @@ async fn run_tui_loop(
     // Optional modal overlay (dismissed by Esc)
     let mut overlay: Option<OverlayState> = None;
 
+    // Transient footer flash (action confirmations like "reindex started").
+    // Auto-clears after FLASH_TTL so it never sticks.
+    let mut flash: Option<(String, std::time::Instant)> = None;
+    const FLASH_TTL: Duration = Duration::from_secs(4);
+
     // Channel to receive doctor results from background task. The payload is
     // tagged with a request generation so a late result from a request the
     // user already dismissed (or superseded with a newer one) is ignored.
@@ -110,6 +115,15 @@ async fn run_tui_loop(
             .map(|i| i.is_available())
             .unwrap_or(false);
 
+        // Expire a stale flash, then borrow the live message (if any) for render.
+        if flash
+            .as_ref()
+            .is_some_and(|(_, at)| at.elapsed() >= FLASH_TTL)
+        {
+            flash = None;
+        }
+        let flash_msg = flash.as_ref().map(|(msg, _)| msg.as_str());
+
         terminal.draw(|f| {
             let size = f.area();
             let chunks = Layout::vertical([
@@ -131,6 +145,7 @@ async fn run_tui_loop(
                 active,
                 &cpu,
                 csharp_helper,
+                flash_msg,
             );
 
             // Render overlay on top of everything if active
@@ -216,7 +231,18 @@ async fn run_tui_loop(
                     KeyAction::ForceReindex(idx) => {
                         if idx < repos.len() {
                             let alias = repos[idx].0.clone();
-                            spawn_force_reindex(alias, &state);
+                            let msg = match spawn_force_reindex(alias.clone(), &state) {
+                                ReindexLaunch::Started => {
+                                    format!("⟳ Reindex started for '{alias}' …")
+                                }
+                                ReindexLaunch::AlreadyRunning => {
+                                    format!("⟳ Reindex already running for '{alias}'")
+                                }
+                                ReindexLaunch::Failed => {
+                                    format!("✗ Cannot reindex '{alias}' — see logs")
+                                }
+                            };
+                            flash = Some((msg, std::time::Instant::now()));
                         }
                     }
                     KeyAction::RequestRemove(idx) => {
@@ -579,16 +605,28 @@ fn spawn_doctor(
 // Force reindex (non-blocking spawn)
 // ---------------------------------------------------------------------------
 
+/// Outcome of a TUI force-reindex launch — used to drive immediate footer
+/// feedback. Only describes whether the background task *started*; the actual
+/// indexing result is reported later via the status column / logs.
+enum ReindexLaunch {
+    /// Background reindex task spawned successfully.
+    Started,
+    /// A reindex was already running for this alias — request ignored.
+    AlreadyRunning,
+    /// Could not start (config error, unresolved alias, read-only, open error).
+    Failed,
+}
+
 /// Spawn a background force reindex task for the given repo alias.
 /// Follows the same flow as the HTTP `reindex_handler`.
-fn spawn_force_reindex(alias: String, state: &Arc<ServeState>) {
+fn spawn_force_reindex(alias: String, state: &Arc<ServeState>) -> ReindexLaunch {
     // Guard against concurrent reindex
     if !state.active_reindexes.insert(alias.clone()) {
         tracing::warn!(
             "Force reindex already in progress for '{}', skipping TUI request",
             alias
         );
-        return;
+        return ReindexLaunch::AlreadyRunning;
     }
 
     let config = match state.config.read() {
@@ -596,7 +634,7 @@ fn spawn_force_reindex(alias: String, state: &Arc<ServeState>) {
         Err(e) => {
             tracing::error!("Config lock poisoned: {}", e);
             state.active_reindexes.remove(&alias);
-            return;
+            return ReindexLaunch::Failed;
         }
     };
     let project_path = match config.resolve(&alias) {
@@ -604,7 +642,7 @@ fn spawn_force_reindex(alias: String, state: &Arc<ServeState>) {
         None => {
             tracing::error!("Cannot resolve alias '{}' for force reindex", alias);
             state.active_reindexes.remove(&alias);
-            return;
+            return ReindexLaunch::Failed;
         }
     };
     drop(config); // release read lock
@@ -636,12 +674,12 @@ fn spawn_force_reindex(alias: String, state: &Arc<ServeState>) {
                         alias
                     );
                     state.active_reindexes.remove(&alias);
-                    return;
+                    return ReindexLaunch::Failed;
                 }
                 Err(e) => {
                     tracing::error!("Cannot open stores for '{}': {}", alias, e);
                     state.active_reindexes.remove(&alias);
-                    return;
+                    return ReindexLaunch::Failed;
                 }
             }
         }
@@ -671,6 +709,8 @@ fn spawn_force_reindex(alias: String, state: &Arc<ServeState>) {
         // Remove guard
         state_bg.active_reindexes.remove(&alias_bg);
     });
+
+    ReindexLaunch::Started
 }
 
 // ---------------------------------------------------------------------------

--- a/src/serve/tui_common.rs
+++ b/src/serve/tui_common.rs
@@ -528,6 +528,10 @@ pub fn render_detail(
     }
 }
 
+// Footer renders many independent display fields (hints, scroll, sessions, CPU,
+// C# indicator, transient flash); grouping them into a struct would add
+// ceremony without improving clarity.
+#[allow(clippy::too_many_arguments)]
 pub fn render_footer(
     f: &mut ratatui::Frame,
     area: Rect,
@@ -536,6 +540,7 @@ pub fn render_footer(
     active: u64,
     cpu: &str,
     csharp_helper: bool,
+    flash: Option<&str>,
 ) {
     let selected = table_state.selected().unwrap_or(0);
     let scroll_indicator = if repos.len() > 1 {
@@ -557,59 +562,71 @@ pub fn render_footer(
         Layout::horizontal([Constraint::Min(0), Constraint::Length(right_len as u16 + 2)])
             .areas(footer_inner);
 
-    let left_line = Line::from(vec![
-        Span::styled(
-            "i",
+    // A transient flash message (e.g. "reindex started") takes over the left
+    // line while active, so the user gets immediate confirmation of an action
+    // even before the status column updates on the next redraw.
+    let left_line = if let Some(msg) = flash {
+        Line::from(vec![Span::styled(
+            msg.to_string(),
             Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::UNDERLINED),
-        ),
-        Span::styled("nfo  ", Style::default().fg(Color::DarkGray)),
-        Span::styled(
-            "d",
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::UNDERLINED),
-        ),
-        Span::styled("octor  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("rei", Style::default().fg(Color::DarkGray)),
-        Span::styled(
-            "n",
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::UNDERLINED),
-        ),
-        Span::styled("dex  ", Style::default().fg(Color::DarkGray)),
-        Span::styled(
-            "r",
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::UNDERLINED),
-        ),
-        Span::styled("emove  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("re", Style::default().fg(Color::DarkGray)),
-        Span::styled(
-            "l",
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::UNDERLINED),
-        ),
-        Span::styled("oad  ", Style::default().fg(Color::DarkGray)),
-        Span::styled(
-            "q",
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::UNDERLINED),
-        ),
-        Span::styled("uit  ", Style::default().fg(Color::DarkGray)),
-        Span::styled(
-            "↑↓",
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::UNDERLINED),
-        ),
-        Span::styled(scroll_indicator, Style::default().fg(Color::Yellow)),
-    ]);
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )])
+    } else {
+        Line::from(vec![
+            Span::styled(
+                "i",
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+            Span::styled("nfo  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "d",
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+            Span::styled("octor  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("rei", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "n",
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+            Span::styled("dex  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "r",
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+            Span::styled("emove  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("re", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "l",
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+            Span::styled("oad  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "q",
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+            Span::styled("uit  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "↑↓",
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+            Span::styled(scroll_indicator, Style::default().fg(Color::Yellow)),
+        ])
+    };
 
     let csharp_indicator = if csharp_helper {
         Span::styled("C# │ ", Style::default().fg(Color::Green))

--- a/src/serve/tui_common.rs
+++ b/src/serve/tui_common.rs
@@ -16,8 +16,12 @@ use ratatui::widgets::{Block, Borders, Cell, Row, Table, TableState};
 /// Format elapsed time since `started_at` as "Up xxd xxh xxm xxs".
 /// Omits days/hours/minutes when zero.
 pub fn format_uptime(started_at: std::time::Instant) -> String {
-    let elapsed = started_at.elapsed();
-    let total_secs = elapsed.as_secs();
+    format_uptime_secs(started_at.elapsed().as_secs())
+}
+
+/// Format a duration in seconds as "Up xxd xxh xxm xxs".
+/// Omits days/hours/minutes when zero.
+pub fn format_uptime_secs(total_secs: u64) -> String {
     let days = total_secs / 86400;
     let hours = (total_secs % 86400) / 3600;
     let mins = (total_secs % 3600) / 60;
@@ -50,7 +54,7 @@ pub struct RepoRow {
     pub alias: String,
     /// Human-readable status: "open", "warm", "readonly", "closed", "indexing", "error", "no_index"
     pub status: String,
-    /// C# index status: "", "ready", "indexing", "error"
+    /// C# index status: "none", "ready", "indexing", "error" (empty also treated as none)
     pub csharp_index: String,
     /// Optional C# error message
     pub csharp_error: Option<String>,
@@ -768,51 +772,15 @@ pub fn render_overlay(f: &mut ratatui::Frame, area: Rect, overlay: &OverlayState
 }
 
 /// Render a centered modal with a title and content lines.
+/// Uses the default cyan border/title color; delegates to
+/// [`render_centered_modal_with_border_color`].
 pub fn render_centered_modal(
     f: &mut ratatui::Frame,
     area: Rect,
     title: &str,
     lines: Vec<Line<'_>>,
 ) {
-    let content_height = lines.len() as u16 + 2; // +2 for border
-    let max_line_w = lines.iter().map(|l| l.width() as u16).max().unwrap_or(20);
-    let title_w = title.len() as u16;
-    let content_width = (max_line_w + 4).max(title_w + 4).max(30);
-
-    // Center the modal
-    let modal_area = Rect {
-        x: area
-            .width
-            .saturating_sub(content_width)
-            .saturating_div(2)
-            .min(area.width.saturating_sub(content_width)),
-        y: area
-            .height
-            .saturating_sub(content_height)
-            .saturating_div(2)
-            .min(area.height.saturating_sub(content_height)),
-        width: content_width.min(area.width),
-        height: content_height.min(area.height),
-    };
-
-    // Clear the modal area so no table text shows through the modal interior
-    f.render_widget(ratatui::widgets::Clear, modal_area);
-
-    let block = ratatui::widgets::Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan))
-        .title(Span::styled(
-            title,
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ))
-        .style(Style::default().bg(Color::Rgb(20, 20, 35)));
-    let inner = block.inner(modal_area);
-    f.render_widget(block, modal_area);
-
-    let content = ratatui::widgets::Paragraph::new(lines);
-    f.render_widget(content, inner);
+    render_centered_modal_with_border_color(f, area, title, lines, Color::Cyan);
 }
 
 /// Render a centered modal with a custom border color.
@@ -1028,4 +996,20 @@ fn detail_status_style(status: &str, csharp: &str) -> (String, Color) {
         "no_index" => ("No Index".to_string(), Color::Gray),
         _ => (status.to_string(), Color::White),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Terminal helpers
+// ---------------------------------------------------------------------------
+
+/// Restore the terminal to its normal state: disable raw mode, leave the
+/// alternate screen, and show the cursor. Shared by both the embedded and
+/// remote TUI on exit.
+pub fn restore_terminal(
+    terminal: &mut ratatui::Terminal<ratatui::backend::CrosstermBackend<std::io::Stdout>>,
+) -> std::io::Result<()> {
+    crossterm::terminal::disable_raw_mode()?;
+    crossterm::execute!(std::io::stdout(), crossterm::terminal::LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+    Ok(())
 }

--- a/src/serve/tui_remote.rs
+++ b/src/serve/tui_remote.rs
@@ -4,7 +4,8 @@
 //! as the embedded TUI in `tui.rs`, using the shared `tui_common` framework.
 //! This allows the TUI to be opened and closed independently of the server process.
 //!
-//! Actions (i/d/f/s) are routed to HTTP endpoints on the serve.
+//! Actions (i=info, d=doctor, n=reindex, r=remove, l=reload) are routed to
+//! HTTP endpoints on the serve.
 
 use std::io;
 use std::time::Duration;
@@ -15,7 +16,7 @@ use ratatui::layout::{Constraint, Layout};
 use ratatui::Terminal;
 
 use crossterm::event::{self, Event, KeyEventKind};
-use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use crossterm::terminal::{self, EnterAlternateScreen};
 
 use serde::Deserialize;
 
@@ -67,28 +68,6 @@ impl RepoInfo {
     }
 }
 
-/// Format uptime from seconds into "Up xxd xxh xxm xxs".
-fn format_uptime_from_secs(total_secs: u64) -> String {
-    let days = total_secs / 86400;
-    let hours = (total_secs % 86400) / 3600;
-    let mins = (total_secs % 3600) / 60;
-    let secs = total_secs % 60;
-
-    let mut parts = Vec::new();
-    if days > 0 {
-        parts.push(format!("{}d", days));
-    }
-    if hours > 0 || !parts.is_empty() {
-        parts.push(format!("{:2}h", hours));
-    }
-    if mins > 0 || !parts.is_empty() {
-        parts.push(format!("{:2}m", mins));
-    }
-    parts.push(format!("{:2}s", secs));
-
-    format!("Up {}", parts.join(" "))
-}
-
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
@@ -106,7 +85,7 @@ pub async fn run_remote_tui(serve_url: String) -> Result<()> {
     let result = run_remote_tui_loop(&mut terminal, &serve_url).await;
 
     // Always restore terminal
-    restore_terminal(&mut terminal)?;
+    tui_common::restore_terminal(&mut terminal)?;
 
     result
 }
@@ -138,9 +117,14 @@ async fn run_remote_tui_loop(
     // Monotonic id of the most recent doctor/info request; bumped on every spawn.
     let mut doctor_gen: u64 = 0;
 
+    // Single shared HTTP client reused for the status poll and all action
+    // requests. reqwest::Client is cheap to clone and shares one connection
+    // pool; per-request timeouts are still applied via `.timeout()`.
+    let client = reqwest::Client::new();
+
     loop {
         // Fetch status from serve
-        match reqwest::get(&status_url).await {
+        match client.get(&status_url).send().await {
             Ok(resp) if resp.status().is_success() => match resp.json::<StatusResponse>().await {
                 Ok(d) => {
                     data = Some(d);
@@ -185,7 +169,7 @@ async fn run_remote_tui_loop(
         let csharp_helper = data.as_ref().map(|d| d.csharp_helper).unwrap_or(false);
         let uptime_str = data
             .as_ref()
-            .map(|d| format_uptime_from_secs(d.uptime_secs))
+            .map(|d| tui_common::format_uptime_secs(d.uptime_secs))
             .unwrap_or_else(|| "Up  0s".to_string());
 
         terminal.draw(|f| {
@@ -251,13 +235,14 @@ async fn run_remote_tui_loop(
                                 if let Some(OverlayState::ConfirmRemove { alias }) = overlay.take()
                                 {
                                     let serve = serve_url.to_string();
+                                    let client = client.clone();
                                     tokio::spawn(async move {
                                         let remove_url = format!(
                                             "{}/repos/{}",
                                             serve.trim_end_matches('/'),
                                             alias
                                         );
-                                        match reqwest::Client::new()
+                                        match client
                                             .delete(&remove_url)
                                             .timeout(Duration::from_secs(10))
                                             .send()
@@ -301,7 +286,7 @@ async fn run_remote_tui_loop(
                 match action {
                     KeyAction::Reload => {
                         let reload_url = format!("{}/reload", serve_url.trim_end_matches('/'));
-                        let _ = reqwest::Client::new()
+                        let _ = client
                             .post(&reload_url)
                             .timeout(Duration::from_secs(3))
                             .send()
@@ -319,8 +304,9 @@ async fn run_remote_tui_loop(
                             doctor_gen += 1;
                             let gen = doctor_gen;
                             let tx = doctor_tx.clone();
+                            let client = client.clone();
                             tokio::spawn(async move {
-                                let result = match reqwest::Client::new()
+                                let result = match client
                                     .get(&info_url)
                                     .timeout(Duration::from_secs(10))
                                     .send()
@@ -351,7 +337,6 @@ async fn run_remote_tui_loop(
                                     }
                                     _ => {
                                         // Fallback: show basic info
-                                        let _ = tx; // suppress unused warning
                                         OverlayState::Doctor {
                                             alias,
                                             results: vec![
@@ -378,13 +363,14 @@ async fn run_remote_tui_loop(
                             let gen = doctor_gen;
                             let tx = doctor_tx.clone();
                             let serve = serve_url.to_string();
+                            let client = client.clone();
                             tokio::spawn(async move {
                                 let doctor_url = format!(
                                     "{}/repos/{}/doctor",
                                     serve.trim_end_matches('/'),
                                     alias
                                 );
-                                let result = match reqwest::Client::new()
+                                let result = match client
                                     .post(&doctor_url)
                                     .timeout(Duration::from_secs(60))
                                     .send()
@@ -436,7 +422,7 @@ async fn run_remote_tui_loop(
                                 alias
                             );
                             // Fire-and-forget POST
-                            let _ = reqwest::Client::new()
+                            let _ = client
                                 .post(&reindex_url)
                                 .timeout(Duration::from_secs(5))
                                 .send()
@@ -483,15 +469,4 @@ struct InfoResponse {
 #[derive(Debug, Deserialize)]
 struct DoctorResponse {
     results: Vec<String>,
-}
-
-// ---------------------------------------------------------------------------
-// Terminal helpers
-// ---------------------------------------------------------------------------
-
-fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<()> {
-    terminal::disable_raw_mode()?;
-    crossterm::execute!(io::stdout(), LeaveAlternateScreen)?;
-    terminal.show_cursor()?;
-    Ok(())
 }

--- a/src/serve/tui_remote.rs
+++ b/src/serve/tui_remote.rs
@@ -194,6 +194,7 @@ async fn run_remote_tui_loop(
                     active,
                     cpu,
                     csharp_helper,
+                    None,
                 );
             } else {
                 tui_common::render_header(f, chunks[0], serve_url, "?", true, &uptime_str);
@@ -209,7 +210,7 @@ async fn run_remote_tui_loop(
                     ),
                 ]));
                 f.render_widget(connecting, chunks[1]);
-                tui_common::render_footer(f, chunks[3], &[], &table_state, 0, "—", false);
+                tui_common::render_footer(f, chunks[3], &[], &table_state, 0, "—", false, None);
             }
 
             // Render overlay on top if active

--- a/src/vectordb/store.rs
+++ b/src/vectordb/store.rs
@@ -38,17 +38,60 @@ fn read_persisted_map_size(db_path: &Path) -> usize {
     crate::constants::DEFAULT_LMDB_MAP_SIZE_MB
 }
 
-/// Resolve the effective LMDB map size using the max of persisted, env-var, and default.
-/// This ensures consistency across multiple repo opens in the same process.
+/// Process-global pin of the LMDB map size chosen for each canonical DB path.
+///
+/// heed keeps its OWN process-global registry of opened environments and
+/// rejects a reopen whose recorded `map_size` differs from a still-live env
+/// for that path ("an environment is already opened with different options").
+/// Because heed's env close is *deferred*, a reopen (e.g. the idle reaper
+/// dropping a repo while a force-reindex reopens it) can briefly observe the
+/// prior env. If the two opens disagree on `map_size` — which happens when a
+/// runtime resize grew the map but the persisted/default lookup returns a
+/// different value — heed raises that error and the open fails with a 500.
+///
+/// To make opens deterministic regardless of metadata-persistence state or
+/// runtime resizes, the first resolved size for a path is pinned here and all
+/// subsequent opens reuse it (monotonically non-decreasing, capped at MAX).
+static MAP_SIZE_PINS: std::sync::OnceLock<dashmap::DashMap<std::path::PathBuf, usize>> =
+    std::sync::OnceLock::new();
+
+fn map_size_pins() -> &'static dashmap::DashMap<std::path::PathBuf, usize> {
+    MAP_SIZE_PINS.get_or_init(dashmap::DashMap::new)
+}
+
+/// Stable per-path key for the map-size pin. Uses the canonical path so every
+/// spelling of the same physical directory maps to one pin; falls back to the
+/// lexical path when the directory cannot be canonicalized yet (still stable
+/// for repeated opens of the same alias).
+fn map_size_pin_key(db_path: &Path) -> std::path::PathBuf {
+    crate::cache::safe_canonicalize(db_path).unwrap_or_else(|_| db_path.to_path_buf())
+}
+
+/// Pin (or raise) the process map size for `db_path` and return the effective
+/// value. Monotonically non-decreasing and capped at `MAX_LMDB_MAP_SIZE_MB`.
+fn pin_map_size(db_path: &Path, candidate: usize) -> usize {
+    let candidate = candidate.min(MAX_LMDB_MAP_SIZE_MB);
+    let pins = map_size_pins();
+    let mut entry = pins.entry(map_size_pin_key(db_path)).or_insert(candidate);
+    if candidate > *entry {
+        *entry = candidate;
+    }
+    *entry
+}
+
+/// Resolve the effective LMDB map size using the max of persisted, env-var, and
+/// default — then pin it per-path for the process lifetime so every open of the
+/// same path uses a consistent size (see [`MAP_SIZE_PINS`]).
 fn resolve_map_size(db_path: &Path) -> usize {
     let persisted = read_persisted_map_size(db_path);
     let from_env = std::env::var("CODESEARCH_LMDB_MAP_SIZE_MB")
         .ok()
         .and_then(|s| s.parse::<usize>().ok());
-    from_env
+    let candidate = from_env
         .unwrap_or(persisted)
         .max(persisted)
-        .max(crate::constants::DEFAULT_LMDB_MAP_SIZE_MB)
+        .max(crate::constants::DEFAULT_LMDB_MAP_SIZE_MB);
+    pin_map_size(db_path, candidate)
 }
 
 /// Read a metadata field from metadata.json.
@@ -518,6 +561,12 @@ impl VectorStore {
         }
 
         self.map_size_mb = new_size_mb;
+
+        // Raise the process-global per-path pin so any later reopen of this path
+        // (e.g. after idle eviction) resolves to the grown size and matches the
+        // still-live heed env, instead of racing into "an environment is already
+        // opened with different options".
+        pin_map_size(self.env.path(), new_size_mb);
 
         // Persist the new map size so subsequent opens in the same process
         // use the same value (avoids "already opened with different options").
@@ -1136,6 +1185,45 @@ mod tests {
         let store = store.unwrap();
         assert_eq!(store.dimensions, 384);
         assert!(!store.is_indexed());
+    }
+
+    /// Once a path's map size is pinned, later resolutions for the same path
+    /// return the SAME value even if metadata.json later advertises a smaller
+    /// size — so reopens never request a size that mismatches a still-live heed
+    /// env. This is the core invariant preventing the "already opened with
+    /// different options" 500.
+    #[test]
+    fn pinned_map_size_is_stable_and_monotonic_per_path() {
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("pinned.db");
+        std::fs::create_dir_all(&db_path).unwrap();
+
+        // First resolve pins the default (no metadata yet).
+        let first = resolve_map_size(&db_path);
+        assert_eq!(first, crate::constants::DEFAULT_LMDB_MAP_SIZE_MB);
+
+        // A runtime resize raises the pin; subsequent resolves must reflect it.
+        let grown = crate::constants::DEFAULT_LMDB_MAP_SIZE_MB + 256;
+        pin_map_size(&db_path, grown);
+        assert_eq!(resolve_map_size(&db_path), grown);
+
+        // Writing a SMALLER persisted size must NOT shrink the live pin
+        // (a smaller request against a live larger env is exactly what heed
+        // rejects), proving the pin is monotonic.
+        persist_map_size(&db_path, crate::constants::DEFAULT_LMDB_MAP_SIZE_MB).unwrap();
+        assert_eq!(resolve_map_size(&db_path), grown);
+    }
+
+    /// The pin is capped at MAX_LMDB_MAP_SIZE_MB so a hand-edited metadata.json
+    /// (or env var) cannot push the map size past the supported ceiling.
+    #[test]
+    fn pinned_map_size_is_capped_at_max() {
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("capped.db");
+        std::fs::create_dir_all(&db_path).unwrap();
+
+        let pinned = pin_map_size(&db_path, MAX_LMDB_MAP_SIZE_MB + 4096);
+        assert_eq!(pinned, MAX_LMDB_MAP_SIZE_MB);
     }
 
     #[test]

--- a/src/vectordb/store.rs
+++ b/src/vectordb/store.rs
@@ -61,12 +61,17 @@ fn read_metadata_u32(db_path: &Path, key: &str) -> Option<u32> {
 }
 
 /// Atomically write a JSON file using temp+rename pattern.
-/// Writes to a per-process-unique temp file in the same directory, then renames
-/// to `<path>`. The unique temp name (pid + monotonic counter) ensures two
-/// concurrent writers don't clobber a shared temp file; `rename` is atomic on
-/// the same filesystem so a crash mid-write never leaves a partial `<path>`.
+/// Writes to a per-process-unique temp file in the same directory, fsyncs it,
+/// then renames to `<path>`. The unique temp name (pid + monotonic counter)
+/// ensures two concurrent writers don't clobber a shared temp file. The temp
+/// file is flushed to disk with `sync_all` BEFORE the rename, so a power-loss
+/// cannot leave a zero-length or garbage file in place of the old metadata;
+/// combined with `rename` being atomic on the same filesystem, a reader always
+/// observes either the complete old or the complete new content.
 /// On failure the temp file is best-effort removed.
 fn atomic_write_json(path: &Path, json: &serde_json::Value) -> Result<()> {
+    use std::io::Write;
+
     static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let seq = TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp_name = format!("metadata.json.{}.{}.tmp", std::process::id(), seq);
@@ -74,10 +79,20 @@ fn atomic_write_json(path: &Path, json: &serde_json::Value) -> Result<()> {
         Some(dir) => dir.join(tmp_name),
         None => path.with_extension("json.tmp"),
     };
-    if let Err(e) = fs::write(&tmp_path, serde_json::to_string_pretty(json)?) {
+    let data = serde_json::to_string_pretty(json)?;
+
+    // Write + fsync the temp file before the atomic rename.
+    let write_result = (|| -> std::io::Result<()> {
+        let mut f = fs::File::create(&tmp_path)?;
+        f.write_all(data.as_bytes())?;
+        f.sync_all()?;
+        Ok(())
+    })();
+    if let Err(e) = write_result {
         let _ = fs::remove_file(&tmp_path);
         return Err(e.into());
     }
+
     if let Err(e) = fs::rename(&tmp_path, path) {
         let _ = fs::remove_file(&tmp_path);
         return Err(e.into());


### PR DESCRIPTION
## Summary
Review-driven correctness and hardening pass across the serve hub, indexing, LMDB layer, and TUI. The headline fix resolves the production 500 `an environment is already opened with different options` when reopening a repo DB (e.g. after idle eviction + force-reindex).

## Key Changes

### LMDB "different options" 500 (root-cause fix)
- **Per-path `map_size` pin** (`vectordb/store.rs`): the first resolved map size for a canonical DB path is pinned for the process lifetime (monotonic, capped at `MAX_LMDB_MAP_SIZE_MB`); `resize_environment` raises the pin so post-eviction reopens match the still-live heed env. heed rejects reopens whose `map_size` differs from a still-live env, and its env close is deferred — so consistent sizing is what actually prevents the error (proven by test: same-size concurrent churn is clean, different-size is not).
- **`TrackedEnv::drop` reorder** (`lmdb_registry.rs`): drop the `heed::Env` before freeing our own registry slot, enforcing "our slot free ⟹ heed's slot free" as complementary hardening.

### Serve / indexing
- `serve/mod.rs`: idle-reaper + reopen path hardening; `stop_fsw` drops Readonly/Conflicted repos so the LMDB env is released before reopen; `/info` + `/doctor` route wiring; partial-deletion window fix.
- `index/manager.rs`, `search/mod.rs`: lazy embed-model resolution (fixes no-op refresh regression).
- `db_discovery/repos.rs`: stale-path resilience + `git_remote_url` hardening; reconcile on load.

### Chunker / embed
- `chunker/jupyter.rs`, `semantic.rs`, `extractor.rs`: Jupyter line-count + caveat, Dart classification.
- `embed/embedder.rs`, `cli/mod.rs`: `--model` index-corruption fix + model-list dedup.

### TUI
- `serve/tui*.rs`: DRY cleanup + hygiene; remote `/info` + `/doctor` endpoints.

## Testing
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --lib --all-features -- -D warnings`
- [x] `cargo test --lib` (lmdb_registry race guard 8×4000 + store pin tests + vectordb suite green)
- [ ] Manual: reopen a resized repo DB after idle eviction (no 500)

## Checklist
- [x] Self-review done
- [x] No new warnings
