### PR TITLE
📝 docs: add Dart to README + changelog for reopen-500 fix & TUI reindex feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instance via `POST /repos`.
 - **`ServeState::remove_repo()` method**: extracted from `remove_repo_handler`
   for reuse by both the HTTP endpoint and the embedded TUI.
+- **Immediate reindex feedback in the embedded TUI**: pressing `n` now shows a
+  transient footer confirmation (`⟳ Reindex started for '<alias>' …`,
+  `already running`, or a failure notice) instead of silently spawning the
+  background task. The pulsing `⟳ idx…` status label is unchanged.
 
 ### Fixed
 
+- **`500 "an environment is already opened with different options"` on repo
+  reopen**: reopening a database (e.g. the idle reaper dropping a repo while a
+  force-reindex reopens it) could fail with a raw heed error. Two causes fixed:
+  `TrackedEnv::drop` now releases the underlying `heed::Env` *before* freeing its
+  registry slot (closing a drop-order window), and the LMDB `map_size` is now
+  pinned per canonical path for the process lifetime (monotonic, capped at MAX)
+  so every reopen uses a consistent size and never mismatches a still-live env.
 - **FileWatcher missing repo-local `.codesearchignore`**: `build_gitignore()` now
   loads `.codesearchignore` from the repository root alongside the global file.
   Previously only the global file was loaded, causing repo-local ignores to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
-
 ## [1.0.207] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.207] - 2026-06-12
+
 ### Added
 
+- **`serve --host` — bind beyond localhost (#114)**: `codesearch serve` now
+  accepts `--host` (env `CODESEARCH_SERVE_HOST`); set `0.0.0.0` to bind all
+  interfaces (e.g. inside a container). IPv4 and IPv6 literals are supported
+  (`[::]`). Because this exposes the management endpoints, pair it with
+  `CODESEARCH_SERVE_API_KEY` to require an API key on `POST /repos`, `/reindex`,
+  and `/reload`.
 - **Global `.codesearchignore`**: `~/.codesearch/.codesearchignore` is now loaded
   as the lowest-priority ignore file, applying to all indexed repositories.
   Precedence: global < `.git/info/exclude` < `.gitignore` < repo-local

--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Tree-sitter AST-aware chunking:
 | C# | `.cs` |
 | Go | `.go` |
 | Java | `.java` |
+| Dart | `.dart` |
 | Shell | `.sh`, `.bash`, `.zsh` |
 | Ruby | `.rb`, `.rake` |
 | PHP | `.php` |


### PR DESCRIPTION
## Summary
Documentation catch-up after PR #120.

- **README** — add **Dart** to the Supported Languages table (the 16th tree-sitter grammar was already counted at line 18; only the table row was missing).
- **CHANGELOG `[Unreleased]`**:
  - *Fixed* — the `500 "an environment is already opened with different options"` reopen bug (`TrackedEnv` drop-order + per-path `map_size` pin).
  - *Added* — immediate reindex feedback in the embedded TUI (the `n` key now shows a transient footer confirmation).

## Testing
- [x] Docs-only; no code change.

## Checklist
- [x] Self-review done
