### PR TITLE
📝 docs: add Branching & PR workflow section (PRs target develop)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,19 @@
 - **Status:** `cargo check` + `cargo clippy` clean
 - **Validation:** `cargo check` for iteration, `cargo clippy` for lint. No `--release` builds.
 
+## ⚠️ Branching & PR workflow (READ FIRST)
+
+This repo uses a **`develop`-based** gitflow. The GitHub default branch is `master` (`origin/HEAD → origin/master`), but `master` is **NOT** the integration branch.
+
+- **Integration branch = `develop`.** All feature/fix/release branches merge into `develop`.
+- **ALL PRs target `develop`** — pass `--base develop` to `gh pr create`, and to `/git pr create` / `/git merge`. NEVER target `master`.
+- **`master`** only receives release merges from `develop` (cut at release time).
+- **Merge style = merge commits** (`--merge`), not squash. Repo history is full of `Merge pull request #N`.
+- **Review requirement** is enforced by a repo ruleset (not branch protection). As repo owner, override with `gh pr merge <n> --merge --admin --delete-branch`.
+- Before creating a PR, **verify the base**: `gh pr view <n> --json baseRefName`. If it says `master`, retarget: `gh pr edit <n> --base develop`.
+
+Common mistake: a subagent runs `/git pr create` with no explicit `--base`, the tooling picks `master` (GitHub default), and the PR lands against the wrong branch. Always specify `--base develop`.
+
 ## Features for this branch
 
 Addresses GitHub Issue #115 (flupkede/codesearch).


### PR DESCRIPTION
Adds a prominent "⚠️ Branching & PR workflow (READ FIRST)" section to AGENTS.md so subagents stop defaulting PRs to `master` (the GitHub default branch).

**Why:** PR #124 was initially created against `master` instead of `develop` because the `/git pr create` tooling picks the GitHub default branch. This repo's integration branch is `develop`; `master` only receives release merges.

**Documented rules:**
- Integration branch = `develop`; ALL PRs use `--base develop`
- `master` only receives release merges from `develop`
- Merge style = merge commits (`--merge`), not squash
- Review requirement is a repo ruleset; owner overrides with `gh pr merge <n> --merge --admin --delete-branch`
- Always verify base with `gh pr view <n> --json baseRefName`; retarget if needed

Docs-only change. No code impact.