### PR TITLE
Reserved "all" virtual group resolving to all repos (fixes #131)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.210"
+version = "1.0.211"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.0.209"
+version = "1.0.210"
 dependencies = [
  "anyhow",
  "arroy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.210"
+version = "1.0.211"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codesearch"
-version = "1.0.209"
+version = "1.0.210"
 edition = "2021"
 authors = ["codesearch contributors"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -371,6 +371,19 @@ codesearch groups list
 
 Then in MCP tools: `group="my-group"` fans out the query to all repos in the group.
 
+#### The `all` group
+
+The name `all` is a **reserved virtual group** that always resolves to *every* registered repository — no setup required:
+
+```
+group="all"   # fans out to all repos, equivalent to listing every alias
+```
+
+- It is **not stored** in `repos.json` and always reflects the current set of registered repos (register or remove a repo and `all` updates automatically).
+- It appears in `codesearch groups list` (marked `virtual`) and in the `scope_required` error's `available_groups`, so agents discover it without extra setup.
+- It is **not the default** — when no `project`/`group` is specified in multi-repo mode, codesearch still returns `scope_required` (safe-by-default). Use `group="all"` explicitly when you want to search everywhere.
+- `codesearch groups add all` and `codesearch groups remove all` are **rejected** — the name is reserved.
+
 ### Git Worktree Auto-Index
 
 When using `git worktree add` to create parallel working directories, codesearch can auto-register new worktrees via a `post-checkout` git hook.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -865,19 +865,32 @@ async fn run_cache_clear(model: Option<String>, yes: bool) -> Result<()> {
 
 /// Handle groups subcommands
 async fn run_groups_command(command: GroupsCommands) -> Result<()> {
+    use crate::constants::ALL_GROUP_NAME;
     match command {
         GroupsCommands::List => {
             let config = crate::db_discovery::load_repos_config()?;
-            if config.groups.is_empty() {
+            // The virtual "all" group is always present when repos are registered.
+            let has_all = !config.repos.is_empty();
+            if config.groups.is_empty() && !has_all {
                 println!("No groups defined.");
                 return Ok(());
             }
             println!("Groups:");
+            if has_all {
+                let count = config.repos.len();
+                println!("  {} (virtual): {} repos", ALL_GROUP_NAME, count);
+            }
             for (name, aliases) in &config.groups {
                 println!("  {}: {}", name, aliases.join(", "));
             }
         }
         GroupsCommands::Add { name, aliases } => {
+            if name == ALL_GROUP_NAME {
+                return Err(anyhow::anyhow!(
+                    "Group name '{}' is reserved — it always resolves to all registered repos automatically.",
+                    name
+                ));
+            }
             if aliases.is_empty() {
                 return Err(anyhow::anyhow!(
                     "--aliases is required and must specify at least one alias."
@@ -898,6 +911,12 @@ async fn run_groups_command(command: GroupsCommands) -> Result<()> {
             println!("Group '{}' created/updated.", name);
         }
         GroupsCommands::Remove { name } => {
+            if name == ALL_GROUP_NAME {
+                return Err(anyhow::anyhow!(
+                    "Group '{}' is reserved and cannot be removed.",
+                    name
+                ));
+            }
             let mut config = crate::db_discovery::load_repos_config()?;
             if config.remove_group(&name) {
                 config.save()?;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -118,6 +118,14 @@ pub fn global_codesearchignore_path() -> Option<PathBuf> {
 /// Name of the repos configuration file
 pub const REPOS_CONFIG_FILE: &str = "repos.json";
 
+/// Reserved name of the virtual group that resolves to ALL registered repos.
+///
+/// This group is NOT stored in `repos.json` — it is resolved dynamically by
+/// `ServeState::resolve_group_aliases` and `ReposConfig::resolve_group`, so it
+/// always reflects the current set of registered aliases. Because it is reserved,
+/// `codesearch groups add all` is rejected. See issue #131.
+pub const ALL_GROUP_NAME: &str = "all";
+
 /// Default LMDB map size in megabytes (1024MB).
 ///
 /// This is the maximum virtual address space reserved for the memory-mapped database.

--- a/src/db_discovery/repos.rs
+++ b/src/db_discovery/repos.rs
@@ -303,6 +303,14 @@ impl ReposConfig {
 
     #[allow(dead_code)] // Used in tests only — dead in bin targets
     pub fn resolve_group(&self, group: &str) -> Vec<(String, PathBuf)> {
+        // Virtual "all" group: resolves to every registered repo, never stored.
+        if group == crate::constants::ALL_GROUP_NAME {
+            return self
+                .repos
+                .iter()
+                .map(|(a, p)| (a.clone(), p.clone()))
+                .collect();
+        }
         let Some(aliases) = self.groups.get(group) else {
             return Vec::new();
         };
@@ -314,6 +322,12 @@ impl ReposConfig {
     }
 
     pub fn add_group(&mut self, name: String, aliases: Vec<String>) -> Result<()> {
+        if name == crate::constants::ALL_GROUP_NAME {
+            return Err(anyhow::anyhow!(
+                "Group name '{}' is reserved — it always resolves to all registered repos automatically.",
+                name
+            ));
+        }
         if aliases.is_empty() {
             return Err(anyhow::anyhow!(
                 "Group '{}' must contain at least one alias",
@@ -340,6 +354,20 @@ impl ReposConfig {
 
         self.groups.insert(name, deduped);
         Ok(())
+    }
+
+    /// Return a groups map that includes the virtual `ALL_GROUP_NAME` group
+    /// (mapping to every registered alias), for display/discoverability surfaces
+    /// such as the `status` tool. The returned map is a clone — `self.groups` is
+    /// untouched and "all" is never persisted to `repos.json`.
+    pub fn groups_with_virtual_all(&self) -> std::collections::HashMap<String, Vec<String>> {
+        let mut out = self.groups.clone();
+        if !self.repos.is_empty() {
+            let mut all: Vec<String> = self.repos.keys().cloned().collect();
+            all.sort();
+            out.insert(crate::constants::ALL_GROUP_NAME.to_string(), all);
+        }
+        out
     }
 
     pub fn remove_group(&mut self, name: &str) -> bool {
@@ -1121,6 +1149,75 @@ mod tests {
             stored_str.starts_with("C:\\") || stored_str.starts_with("C:/"),
             "stored path should be a plain Windows path, got: {}",
             stored_str
+        );
+    }
+
+    // ── Virtual "all" group (issue #131) ───────────────────────────────
+
+    #[test]
+    fn add_group_rejects_reserved_all_name() {
+        let mut cfg = ReposConfig::default();
+        cfg.repos
+            .insert("repo-a".to_string(), PathBuf::from("/tmp/repo-a"));
+
+        let err = cfg
+            .add_group("all".to_string(), vec!["repo-a".to_string()])
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("reserved"),
+            "expected 'reserved' in error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn resolve_group_all_returns_every_registered_repo() {
+        let mut cfg = ReposConfig::default();
+        cfg.repos
+            .insert("repo-a".to_string(), PathBuf::from("/tmp/repo-a"));
+        cfg.repos
+            .insert("repo-b".to_string(), PathBuf::from("/tmp/repo-b"));
+
+        let resolved = cfg.resolve_group(crate::constants::ALL_GROUP_NAME);
+        let mut names: Vec<String> = resolved.into_iter().map(|(a, _)| a).collect();
+        names.sort();
+        assert_eq!(names, vec!["repo-a".to_string(), "repo-b".to_string()]);
+    }
+
+    #[test]
+    fn resolve_group_all_is_empty_when_no_repos_registered() {
+        let cfg = ReposConfig::default();
+        let resolved = cfg.resolve_group(crate::constants::ALL_GROUP_NAME);
+        assert!(resolved.is_empty());
+    }
+
+    #[test]
+    fn groups_with_virtual_all_advertises_all_without_storing_it() {
+        let mut cfg = ReposConfig::default();
+        cfg.repos
+            .insert("repo-a".to_string(), PathBuf::from("/tmp/repo-a"));
+        cfg.repos
+            .insert("repo-b".to_string(), PathBuf::from("/tmp/repo-b"));
+        cfg.add_group("platform".to_string(), vec!["repo-a".to_string()])
+            .unwrap();
+
+        // The advertised map includes both the real group and "all".
+        let advertised = cfg.groups_with_virtual_all();
+        assert_eq!(advertised.len(), 2);
+        let mut all_members = advertised
+            .get(crate::constants::ALL_GROUP_NAME)
+            .unwrap()
+            .clone();
+        all_members.sort();
+        assert_eq!(
+            all_members,
+            vec!["repo-a".to_string(), "repo-b".to_string()]
+        );
+
+        // But the stored config is untouched — "all" must never be persisted.
+        assert!(
+            !cfg.groups.contains_key(crate::constants::ALL_GROUP_NAME),
+            "\"all\" must not leak into the stored groups map"
         );
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -3744,7 +3744,7 @@ impl CodesearchService {
     /// `available_groups`, and `hint_for_agent` so that LLM agents can programmatically
     /// react to the scope requirement.
     fn format_scope_error(&self) -> String {
-        let (projects, groups) = if let Some(ref serve_state) = self.serve_state {
+        let (projects, mut groups) = if let Some(ref serve_state) = self.serve_state {
             let cfg = serve_state.config_snapshot();
             let mut projects: Vec<String> = cfg.repos.keys().cloned().collect();
             projects.sort();
@@ -3754,6 +3754,14 @@ impl CodesearchService {
         } else {
             (vec![], vec![])
         };
+        // The "all" virtual group is always available when there are projects to
+        // search — advertise it so agents discover the cross-repo shortcut.
+        // (scope_required only fires when >1 repo is registered, so this is safe.)
+        let all = crate::constants::ALL_GROUP_NAME.to_string();
+        if !projects.is_empty() && !groups.contains(&all) {
+            groups.push(all);
+            groups.sort();
+        }
 
         let payload = serde_json::json!({
             "error_code": "scope_required",
@@ -7080,7 +7088,7 @@ impl CodesearchService {
 
             let response = ListProjectsResponse {
                 repos: repos_info,
-                groups: config.groups,
+                groups: config.groups_with_virtual_all(),
                 serve_active,
                 serve_url,
                 current_directory: current_dir.display().to_string(),
@@ -7137,7 +7145,7 @@ impl CodesearchService {
 
         let response = ListProjectsResponse {
             repos: repos_info,
-            groups: config.groups,
+            groups: config.groups_with_virtual_all(),
             serve_active,
             serve_url,
             current_directory: current_dir.display().to_string(),

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -6815,7 +6815,9 @@ impl CodesearchService {
             if let Some(ref serve_state) = self.serve_state {
                 let config = serve_state.config_snapshot();
                 let repo_count = config.repos.len();
-                let group_count = config.groups.len();
+                // Count the virtual "all" group when repos are registered, so the
+                // summary doesn't read "0 group(s)" while `all` is actually available.
+                let group_count = config.groups.len() + if config.repos.is_empty() { 0 } else { 1 };
                 let statuses = serve_state.repo_statuses_lightweight();
                 let open_count = statuses
                     .iter()

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -4612,4 +4612,33 @@ mod tests {
             clear_env();
         }
     }
+
+    /// The reserved virtual "all" group must resolve to every registered alias
+    /// via the serve-layer entry point used by MCP tools (issue #131).
+    #[test]
+    fn resolve_group_aliases_all_returns_every_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_a = tmp.path().join("repo-a");
+        let repo_b = tmp.path().join("repo-b");
+        std::fs::create_dir(&repo_a).unwrap();
+        std::fs::create_dir(&repo_b).unwrap();
+
+        let mut config = ReposConfig::default();
+        config
+            .register_with_alias(repo_a, Some("alpha".to_string()))
+            .unwrap();
+        config
+            .register_with_alias(repo_b, Some("beta".to_string()))
+            .unwrap();
+
+        let state = state_with_config(config);
+
+        let aliases = state
+            .resolve_group_aliases(crate::constants::ALL_GROUP_NAME)
+            .expect("'all' should resolve");
+        assert_eq!(aliases, vec!["alpha".to_string(), "beta".to_string()]);
+
+        // "all" is never stored — an unknown real group still errors.
+        assert!(state.resolve_group_aliases("does-not-exist").is_err());
+    }
 }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -1945,6 +1945,9 @@ impl ServeState {
 
     /// Resolve a group name to its constituent aliases.
     /// Returns an error if the group doesn't exist.
+    ///
+    /// The reserved name `ALL_GROUP_NAME` ("all") is a virtual group: it is never
+    /// stored in `repos.json` but resolves dynamically to every registered alias.
     pub(crate) fn resolve_group_aliases(
         &self,
         group: &str,
@@ -1954,6 +1957,13 @@ impl ServeState {
             Ok(c) => c,
             Err(e) => return Err(format!("Config lock poisoned: {}", e)),
         };
+        // Virtual "all" group: resolve to every registered alias (sorted for
+        // deterministic ordering). Not stored in repos.json.
+        if group == crate::constants::ALL_GROUP_NAME {
+            let mut all: Vec<String> = config.repos.keys().cloned().collect();
+            all.sort();
+            return Ok(all);
+        }
         config
             .groups
             .get(group)


### PR DESCRIPTION
## Summary

Implements a reserved virtual `"all"` group that resolves to **every registered repository** — the core ask of #131. It is never stored in `repos.json` and always reflects the current set of aliases.

### Behavior
- `group="all"` fans out a query to all registered repos (cross-repo RRF ranking).
- `codesearch groups add all` and `codesearch groups remove all` are **rejected** — the name is reserved.
- `all` is **not the default** — omitting `project`/`group` in multi-repo mode still returns `scope_required` (safe-by-default preserved). Use `group="all"` explicitly.
- `all` is **discoverable**: appears in the `scope_required` error's `available_groups`, in the `status` tool's `groups` map, and in `codesearch groups list` (marked `virtual`).
- Register/remove a repo → `all` updates automatically (dynamic resolution, no stale membership).

### Changes
- `src/constants.rs` — `ALL_GROUP_NAME = "all"` constant (single source of truth).
- `src/db_discovery/repos.rs` — `resolve_group` special-cases `all`; `add_group` rejects the reserved name; new `groups_with_virtual_all()` helper for display surfaces.
- `src/serve/mod.rs` — `resolve_group_aliases` (MCP hot path) special-cases `all` (sorted, all keys).
- `src/mcp/mod.rs` — `format_scope_error` advertises `all`; status tool uses `groups_with_virtual_all()`; status summary `group_count` includes the virtual group.
- `src/cli/mod.rs` — `groups list` shows the virtual `all`; `groups add all` / `groups remove all` rejected with a clear message.
- `README.md` — documents the virtual `all` group.

### Tests
5 new unit tests (all passing):
- `add_group_rejects_reserved_all_name`
- `resolve_group_all_returns_every_registered_repo`
- `resolve_group_all_is_empty_when_no_repos_registered`
- `groups_with_virtual_all_advertises_all_without_storing_it` (non-persistence invariant)
- `resolve_group_aliases_all_returns_every_repo` (serve-layer hot path)

`cargo check --all-targets` ✅, `cargo clippy --all-targets -- -D warnings` ✅.

Fixes #131
