### PR TITLE
✨ feat: user-configurable extension→language map (closes #138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+
+- **User-configurable extension→language map (#138).** A new optional `~/.codesearch/extensions.json` (or the path in `$CODESEARCH_EXTENSION_MAP`) maps a file extension to a language name, e.g. `{ "inc": "php", "h": "cpp" }`. Files with an unrecognised extension are `Unknown` and skipped **entirely** during indexing (there is no line-based fallback for `Unknown`), so a codebase using a non-standard convention — the reported case is legacy PHP in `*.class.inc` files — was previously invisible to codesearch. The map lets users opt in per codebase; entries take precedence over the built-in extension table (so a known extension can be remapped too). Kept **generic on purpose**: `.inc` is not hardcoded to PHP because it's language-agnostic (assembly, SQL, C/PHP includes). Missing/malformed maps and unknown language names are logged and ignored, never fatal.
+
 ## [1.1.29] - 2026-07-10
 
 **Project-level federation + cloud reindex hardening.** Builds on the 1.1.0 federation release: a peer's individual projects can now be **opt-in mounted** and queried by name, the serve TUI surfaces and inspects those mounts, and the cloud indexer was reworked to reindex reliably without OOM-killing itself.

--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ In the `codesearch serve` TUI, mounts appear in **italic/cyan**, distinguishing 
 | `CODESEARCH_CACHE_MAX_MEMORY` | Embedding cache MB (default: 500) |
 | `CODESEARCH_BATCH_SIZE` | Embedding batch size |
 | `CODESEARCH_SCIP_CSHARP` | Override path to `scip-csharp` helper |
+| `CODESEARCH_EXTENSION_MAP` | Path to the extension→language map (default: `~/.codesearch/extensions.json`) — see [Extension map](#extension-map) |
 | `RUST_LOG` | Log level (e.g. `codesearch=debug`) |
 
 ### `.codesearchignore`
@@ -557,6 +558,38 @@ node_modules/
 ```
 
 A **global** `.codesearchignore` can be placed at `~/.codesearch/.codesearchignore`. It applies to all repos with the lowest priority (repo-local `.codesearchignore`, `.gitignore`, and `.git/info/exclude` all override it). This is useful for patterns you want everywhere without modifying each repo.
+
+### Extension map
+
+By default codesearch recognises the fixed extension list in [Supported
+Languages](#supported-languages); any other extension is `Unknown` and is
+**skipped entirely** (never indexed). To teach codesearch about a non-standard
+extension — or to deliberately remap a known one — drop a small JSON object at
+`~/.codesearch/extensions.json` mapping extension → language name:
+
+```json
+{
+  "inc": "php",
+  "phtml": "php",
+  "h": "cpp"
+}
+```
+
+- Keys are file extensions, with or without a leading dot, case-insensitive
+  (`"inc"`, `".inc"`, `".INC"` are equivalent). Only the **last** dot-suffix is
+  matched, so `Foo.class.inc` maps via `"inc"`.
+- Values are language names — the names from the table above plus common aliases
+  (`php`, `cpp`/`c++`, `csharp`/`c#`, `golang`, `js`, `ts`, …), case-insensitive.
+- The map applies to **all** indexed repos, and user entries **take precedence**
+  over the built-ins (so `"h": "cpp"` overrides the default C mapping).
+- It's fully optional and fail-safe: a missing, empty, or malformed file simply
+  means "no overrides" and is logged, never fatal. Unknown language names are
+  skipped with a warning.
+- Set `CODESEARCH_EXTENSION_MAP` to load the file from a different path.
+
+> This is the supported answer to "my PHP is in `*.inc` files" (issue #138):
+> `.inc` is intentionally not a built-in because it's language-agnostic
+> (assembly, SQL, C/PHP includes all use it), so you opt in per your codebase.
 
 ### `repos.json`
 
@@ -648,6 +681,11 @@ headings, and code fences. Jupyter notebooks are parsed as JSON; code and
 markdown cells are extracted, tagged with `[code]` or `[markdown]`, and
 adjacent same-type cells under 50 lines are merged into single chunks.
 All other text files use line-based chunking as fallback.
+
+Files whose extension isn't recognised are treated as `Unknown` and **skipped
+entirely** (not indexed). If your codebase uses a non-standard extension for a
+supported language — e.g. legacy PHP in `*.inc` files, or `.h` you want parsed
+as C++ — map it explicitly with the [extension map](#extension-map).
 
 ## Core Technology
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -115,6 +115,34 @@ pub fn global_codesearchignore_path() -> Option<PathBuf> {
     })
 }
 
+/// Name of the global extension→language map file in ~/.codesearch/
+pub const GLOBAL_EXTENSION_MAP_FILE: &str = "extensions.json";
+
+/// Env var overriding the location of the extension-map file.
+///
+/// Mainly for tests and power users who keep config outside `~/.codesearch/`.
+pub const EXTENSION_MAP_ENV: &str = "CODESEARCH_EXTENSION_MAP";
+
+/// Get the path to the global extension→language map.
+///
+/// This is a small JSON object mapping a file extension (with or without the
+/// leading dot) to a language name, e.g. `{ "inc": "php", "h": "cpp" }`. It is
+/// applied to every indexed repo and lets users teach codesearch about
+/// non-standard extensions (or deliberately remap known ones) without touching
+/// the binary. User overrides take precedence over the built-in extension table.
+///
+/// The path resolves to `$CODESEARCH_EXTENSION_MAP` when set and non-empty,
+/// otherwise `~/.codesearch/extensions.json`. Returns `None` only when neither
+/// the env var nor the home directory is available.
+pub fn global_extension_map_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var(EXTENSION_MAP_ENV) {
+        if !p.is_empty() {
+            return Some(PathBuf::from(p));
+        }
+    }
+    dirs::home_dir().map(|home| home.join(CONFIG_DIR_NAME).join(GLOBAL_EXTENSION_MAP_FILE))
+}
+
 /// Name of the repos configuration file
 pub const REPOS_CONFIG_FILE: &str = "repos.json";
 

--- a/src/file/language.rs
+++ b/src/file/language.rs
@@ -1,4 +1,13 @@
+use crate::constants::global_extension_map_path;
+use std::collections::HashMap;
 use std::path::Path;
+use std::sync::OnceLock;
+use tracing::warn;
+
+/// Process-global, user-defined extension→language overrides, loaded once from
+/// `~/.codesearch/extensions.json` (or the path in `$CODESEARCH_EXTENSION_MAP`).
+/// Empty when no file is present — a missing/invalid map never fails indexing.
+static EXTENSION_OVERRIDES: OnceLock<HashMap<String, Language>> = OnceLock::new();
 
 /// Supported programming languages
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -31,19 +40,77 @@ pub enum Language {
 }
 
 impl Language {
-    /// Detect language from file path (extension + known extensionless filenames)
+    /// Detect language from file path (extension + known extensionless filenames).
+    ///
+    /// User-defined extension overrides (see [`global_extension_map_path`]) are
+    /// consulted first, so a repo using a non-standard convention (e.g.
+    /// `*.class.inc` PHP, or `.h` as C++) can be mapped to the right grammar.
     pub fn from_path(path: &Path) -> Self {
+        Self::from_path_with_overrides(path, extension_overrides())
+    }
+
+    /// Same as [`Self::from_path`] but against an explicit override map instead
+    /// of the process-global one — the testable core of extension resolution.
+    ///
+    /// Resolution order: user override (by extension) → built-in extension
+    /// table → built-in extensionless-filename table. User overrides therefore
+    /// take precedence over the built-ins (a user may deliberately remap a
+    /// known extension), while unmapped extensions behave exactly as before.
+    pub fn from_path_with_overrides(path: &Path, overrides: &HashMap<String, Language>) -> Self {
         let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
-        // Try extension first
+        // User overrides win — keyed on the lowercased, dot-less extension.
+        if !extension.is_empty() {
+            if let Some(&lang) = overrides.get(&extension.to_lowercase()) {
+                return lang;
+            }
+        }
+
+        // Built-in extension table.
         let by_ext = Self::from_extension(extension);
         if by_ext != Self::Unknown {
             return by_ext;
         }
 
-        // Fallback: match on exact filename for extensionless files
+        // Fallback: match on exact filename for extensionless files.
         let filename = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
         Self::from_filename(filename)
+    }
+
+    /// Parse a language name (as written in the extension map) into a variant.
+    ///
+    /// Accepts the canonical names from [`Self::name`] plus common aliases,
+    /// case-insensitively (`"php"`, `"C++"`, `"c#"`, `"golang"`, …). Returns
+    /// `None` for unrecognised names and for `"unknown"` (never a valid target).
+    pub fn from_name(name: &str) -> Option<Self> {
+        let lang = match name.trim().to_lowercase().as_str() {
+            "rust" | "rs" => Self::Rust,
+            "python" | "py" => Self::Python,
+            "javascript" | "js" => Self::JavaScript,
+            "typescript" | "ts" => Self::TypeScript,
+            "go" | "golang" => Self::Go,
+            "java" => Self::Java,
+            "c" => Self::C,
+            "cpp" | "c++" => Self::Cpp,
+            "csharp" | "c#" | "cs" => Self::CSharp,
+            "ruby" | "rb" => Self::Ruby,
+            "php" => Self::Php,
+            "swift" => Self::Swift,
+            "kotlin" | "kt" => Self::Kotlin,
+            "dart" => Self::Dart,
+            "shell" | "sh" | "bash" => Self::Shell,
+            "markdown" | "md" => Self::Markdown,
+            "json" => Self::Json,
+            "yaml" | "yml" => Self::Yaml,
+            "toml" => Self::Toml,
+            "sql" => Self::Sql,
+            "html" => Self::Html,
+            "css" => Self::Css,
+            "xml" => Self::Xml,
+            "jupyter" => Self::Jupyter,
+            _ => return None,
+        };
+        Some(lang)
     }
 
     /// Detect language from extensionless filename
@@ -152,6 +219,74 @@ impl Language {
     }
 }
 
+/// Lazily-loaded, process-global extension→language overrides.
+fn extension_overrides() -> &'static HashMap<String, Language> {
+    EXTENSION_OVERRIDES.get_or_init(load_extension_overrides)
+}
+
+/// Load user-defined extension→language overrides from the extension-map file.
+///
+/// Fail-safe by design: a missing file yields an empty map (no overrides), and
+/// a malformed file or unknown language name is logged and skipped rather than
+/// aborting indexing. Keys are normalised to a lowercased, dot-less extension
+/// (`".INC"`, `"inc"` and `".inc"` all map to `"inc"`).
+fn load_extension_overrides() -> HashMap<String, Language> {
+    let mut map = HashMap::new();
+
+    let Some(path) = global_extension_map_path() else {
+        return map;
+    };
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        // No file = no overrides. Only surface genuinely unexpected read errors.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return map,
+        Err(e) => {
+            warn!(
+                "Could not read extension map {}: {e} — ignoring",
+                path.display()
+            );
+            return map;
+        }
+    };
+
+    let raw: HashMap<String, String> = match serde_json::from_str(&text) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(
+                "Ignoring malformed extension map {} (expected {{\"ext\": \"language\"}}): {e}",
+                path.display()
+            );
+            return map;
+        }
+    };
+
+    for (ext, lang_name) in raw {
+        let key = ext.trim().trim_start_matches('.').to_lowercase();
+        if key.is_empty() {
+            continue;
+        }
+        match Language::from_name(&lang_name) {
+            Some(lang) => {
+                map.insert(key, lang);
+            }
+            None => warn!(
+                "Extension map {}: unknown language {lang_name:?} for extension .{ext} — skipping",
+                path.display()
+            ),
+        }
+    }
+
+    if !map.is_empty() {
+        tracing::info!("Loaded {} extension override(s) from {}", map.len(), {
+            global_extension_map_path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default()
+        });
+    }
+
+    map
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,6 +312,65 @@ mod tests {
         assert_eq!(Language::from_extension("ts"), Language::TypeScript);
         assert_eq!(Language::from_extension("tsx"), Language::TypeScript);
         assert_eq!(Language::from_extension("jsx"), Language::TypeScript);
+    }
+
+    #[test]
+    fn test_php_detection() {
+        assert_eq!(Language::from_extension("php"), Language::Php);
+        // `.inc` is deliberately NOT a built-in mapping: it is language-agnostic
+        // (assembly, SQL, C/C++ and PHP includes all use it). A repo that uses
+        // the legacy `*.class.inc` PHP convention (#138) opts in via the
+        // user-configurable extension map instead — see the override tests below.
+        assert_eq!(Language::from_extension("inc"), Language::Unknown);
+    }
+
+    #[test]
+    fn test_from_name_parses_canonical_and_aliases() {
+        assert_eq!(Language::from_name("php"), Some(Language::Php));
+        assert_eq!(Language::from_name("PHP"), Some(Language::Php));
+        assert_eq!(Language::from_name("  Php  "), Some(Language::Php));
+        assert_eq!(Language::from_name("c++"), Some(Language::Cpp));
+        assert_eq!(Language::from_name("c#"), Some(Language::CSharp));
+        assert_eq!(Language::from_name("golang"), Some(Language::Go));
+        assert_eq!(Language::from_name("nonsense"), None);
+        // "Unknown" is never a valid override target.
+        assert_eq!(Language::from_name("unknown"), None);
+    }
+
+    #[test]
+    fn test_extension_overrides_apply_and_take_precedence() {
+        let mut overrides = HashMap::new();
+        overrides.insert("inc".to_string(), Language::Php);
+        // A user may deliberately remap a *known* extension too (.h → C++).
+        overrides.insert("h".to_string(), Language::Cpp);
+
+        // New mapping for a previously-unknown extension; note Path::extension()
+        // returns only the last dot-suffix, so `Foo.class.inc` → "inc".
+        assert_eq!(
+            Language::from_path_with_overrides(&PathBuf::from("Foo.class.inc"), &overrides),
+            Language::Php
+        );
+        // Override wins over the built-in (.h is normally C).
+        assert_eq!(
+            Language::from_path_with_overrides(&PathBuf::from("legacy.h"), &overrides),
+            Language::Cpp
+        );
+        // Case-insensitive on the extension.
+        assert_eq!(
+            Language::from_path_with_overrides(&PathBuf::from("MODULE.INC"), &overrides),
+            Language::Php
+        );
+        // Extensions not in the map still use the built-in table.
+        assert_eq!(
+            Language::from_path_with_overrides(&PathBuf::from("main.rs"), &overrides),
+            Language::Rust
+        );
+        // An empty override map == pure built-in behaviour (so `.inc` stays Unknown).
+        let empty = HashMap::new();
+        assert_eq!(
+            Language::from_path_with_overrides(&PathBuf::from("Foo.class.inc"), &empty),
+            Language::Unknown
+        );
     }
 
     #[test]

--- a/src/file/language.rs
+++ b/src/file/language.rs
@@ -249,7 +249,9 @@ fn load_extension_overrides() -> HashMap<String, Language> {
         }
     };
 
-    let raw: HashMap<String, String> = match serde_json::from_str(&text) {
+    // Parse into a generic object so a single bad value (e.g. `{"inc": 3}`)
+    // only drops that one entry rather than discarding the whole map.
+    let raw: serde_json::Map<String, serde_json::Value> = match serde_json::from_str(&text) {
         Ok(r) => r,
         Err(e) => {
             warn!(
@@ -260,12 +262,19 @@ fn load_extension_overrides() -> HashMap<String, Language> {
         }
     };
 
-    for (ext, lang_name) in raw {
+    for (ext, value) in raw {
         let key = ext.trim().trim_start_matches('.').to_lowercase();
         if key.is_empty() {
             continue;
         }
-        match Language::from_name(&lang_name) {
+        let Some(lang_name) = value.as_str() else {
+            warn!(
+                "Extension map {}: value for extension .{ext} must be a language name string — skipping",
+                path.display()
+            );
+            continue;
+        };
+        match Language::from_name(lang_name) {
             Some(lang) => {
                 map.insert(key, lang);
             }
@@ -277,11 +286,11 @@ fn load_extension_overrides() -> HashMap<String, Language> {
     }
 
     if !map.is_empty() {
-        tracing::info!("Loaded {} extension override(s) from {}", map.len(), {
-            global_extension_map_path()
-                .map(|p| p.display().to_string())
-                .unwrap_or_default()
-        });
+        tracing::info!(
+            "Loaded {} extension override(s) from {}",
+            map.len(),
+            path.display()
+        );
     }
 
     map
@@ -292,13 +301,17 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    /// Resolve a path against an *empty* override map — keeps `from_path`-style
+    /// tests hermetic (the real `from_path` reads process-global user config
+    /// from `~/.codesearch/extensions.json`, which must not influence tests).
+    fn detect(path: &str) -> Language {
+        Language::from_path_with_overrides(&PathBuf::from(path), &HashMap::new())
+    }
+
     #[test]
     fn test_rust_detection() {
         assert_eq!(Language::from_extension("rs"), Language::Rust);
-        assert_eq!(
-            Language::from_path(&PathBuf::from("main.rs")),
-            Language::Rust
-        );
+        assert_eq!(detect("main.rs"), Language::Rust);
     }
 
     #[test]
@@ -378,10 +391,7 @@ mod tests {
         assert_eq!(Language::from_extension("sh"), Language::Shell);
         assert_eq!(Language::from_extension("bash"), Language::Shell);
         assert_eq!(Language::from_extension("zsh"), Language::Shell);
-        assert_eq!(
-            Language::from_path(&PathBuf::from("scripts/deploy.sh")),
-            Language::Shell
-        );
+        assert_eq!(detect("scripts/deploy.sh"), Language::Shell);
         // Extensionless shell filenames
         assert_eq!(Language::from_filename("Dockerfile"), Language::Shell);
         assert_eq!(Language::from_filename("Makefile"), Language::Shell);
@@ -409,10 +419,7 @@ mod tests {
     #[test]
     fn test_jupyter_detection() {
         assert_eq!(Language::from_extension("ipynb"), Language::Jupyter);
-        assert_eq!(
-            Language::from_path(&PathBuf::from("analysis.ipynb")),
-            Language::Jupyter
-        );
+        assert_eq!(detect("analysis.ipynb"), Language::Jupyter);
         assert!(
             Language::Jupyter.is_indexable(),
             "Jupyter should be indexable"


### PR DESCRIPTION
## Summary
- Resolves #138 — a PHP codebase stored in `*.class.inc` files was completely invisible to codesearch (unrecognised extension → `Language::Unknown` → skipped entirely during indexing; there is no line-based fallback for `Unknown`).
- Rather than hardcode `.inc → PHP` (`.inc` is language-agnostic — assembly, SQL, C/PHP includes all use it, so a global mapping would misclassify everyone else's `.inc` files), this adds a **generic, opt-in** extension→language map. Users decide what maps to what.

## Changes
- `src/file/language.rs`:
  - New optional map at `~/.codesearch/extensions.json` (path overridable via `$CODESEARCH_EXTENSION_MAP`), e.g. `{ "inc": "php", "h": "cpp" }`, loaded once into a process-global `OnceLock`.
  - `Language::from_path` now consults user overrides before the built-in extension table, so all ~10 call sites honour them with no config threading. `from_path_with_overrides` is the pure, testable core; user overrides take precedence over built-ins (a known extension can be remapped too).
  - `Language::from_name` parses canonical names + common aliases (`php`, `cpp`/`c++`, `csharp`/`c#`, `golang`, …), case-insensitively; `"unknown"` is never a valid target.
  - Fail-safe loader: missing/malformed map or unknown language name is logged and ignored, never fatal; per-entry tolerant (one bad value doesn't discard the whole map).
- `src/constants.rs`: `GLOBAL_EXTENSION_MAP_FILE` / `EXTENSION_MAP_ENV` / `global_extension_map_path()`, mirroring the existing global `.codesearchignore` precedent.
- `README.md`: new "Extension map" section under Configuration + `CODESEARCH_EXTENSION_MAP` env-var row + a note that unrecognised extensions are skipped.
- `CHANGELOG.md`: `[Unreleased] > Added` entry.

## Testing
- [x] `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` green (592 tests); new unit tests for `from_name` aliases + override precedence (new-extension, override-of-known, case-insensitivity, empty-map == builtin)
- [x] Hermetic tests: `from_path`-style assertions route through an explicit empty override map so ambient machine config can't make them flaky

## Checklist
- [x] Self-review done (2 independent reviewer passes: PASS)
- [x] No new warnings
- [x] `.inc` deliberately NOT hardcoded — opt-in per codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)