### PR TITLE
📝 docs: derive release version from git tags in /release (Part 0)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -16,13 +16,48 @@ triggers the build/publish pipeline.
 - Pushing a `vX.Y.Z` tag triggers `.github/workflows/release.yml` (builds Windows/Linux/macOS
   archives, plain + `-with-csharp`, and publishes the GitHub release). **Push the tag only
   AFTER the develop→master PR has merged.**
-- The version is fixed by the feature-branch commit (the pre-commit hook bumps only on
-  feature branches). develop/master merges and the tag all carry that same version.
+- **The version is NOT auto-bumped anymore.** The old pre-commit hook that bumped the patch
+  per feature-branch commit was dropped (commit `b8208d8` — the hook now only runs `cargo fmt`).
+  The version therefore does **not** advance on its own; it is reconciled once, at release time,
+  in **Part 0** below. develop/master merges and the tag all carry that same reconciled version.
 
 ## Guardrails
 - NEVER use `--no-verify`. NEVER force-push shared branches.
 - Push the tag exactly once, only after master has the release commit.
 - If CI fails at any gate, STOP and report — do not promote or tag a red build.
+
+## Part 0 — reconcile the version (do this FIRST, before anything else)
+
+The version can no longer be trusted to be correct (no auto-bump — see facts above), so derive
+it from the **git tags**, which are the only source of truth for "what was actually released".
+This single step makes the version impossible to leave stale *and* impossible to double-cut.
+
+1. **Latest released version** (source of truth): `LATEST=$(git tag -l 'v*' | sort -V | tail -1)`.
+2. **Current declared version**: `CUR=v$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"(.+)".*/\1/')`.
+3. **Decide the target version**:
+   - If `CUR` is greater than `LATEST` (someone already bumped ahead of the last tag) → use `CUR`
+     as-is; skip to Part 1.
+   - Otherwise (`CUR` ≤ `LATEST`, i.e. equal to or behind the last release — the stale case) a
+     bump is required. Base it on `LATEST`, not on `CUR`:
+     - Inspect the unreleased delta: `git log --oneline "$LATEST"..develop` (and its content diff).
+     - If that delta contains a **new feature** (`✨ feat:` / new user-facing capability),
+       **prompt** the user for **patch vs minor** (default recommendation: patch, matching this
+       repo's convention where feature sets have historically shipped as patch bumps).
+     - If it is only fixes/chores/docs, take the **next patch** silently
+       (`LATEST` `vX.Y.Z` → `vX.Y.(Z+1)`).
+4. **Apply the bump** (only if step 3 required one):
+   - Edit `Cargo.toml` `version = "X.Y.Z"` and the `codesearch` entry in `Cargo.lock`.
+   - Roll `CHANGELOG.md`: rename the `[Unreleased]` section to `[X.Y.Z] - <today>` and leave a
+     fresh empty `[Unreleased]` above it.
+   - Commit on a branch (or develop, per the merge flow) as `🔖 release: bump version to X.Y.Z`.
+5. **Guard**: after reconciliation, `$VERSION` (= target) must **not** already exist as a tag
+   locally or on the remote (`git tag -l "$VERSION"`, `git ls-remote --tags origin "$VERSION"`).
+   If it does, STOP — the release was already cut.
+
+> **Why this exists:** two earlier approaches both failed. A per-commit auto-bump caused version
+> churn and Cargo.toml merge conflicts ("double" bumps); dropping it entirely meant the version
+> went stale and a release collided with an already-tagged version. Deriving from tags at release
+> time bumps **exactly once**, can't drift, and can't double-cut.
 
 ## Part 1 — land on `develop` (the `/merge` workflow)
 Execute every step of **`/merge`** (README/CHANGELOG checks → commit → push → PR → auto-merge


### PR DESCRIPTION
## Why
The pre-commit auto-bump was dropped in `b8208d8` (hook now only runs `cargo fmt`), but the `/release` skill still assumed the version was pre-set. So the version went stale and today's release collided with the already-cut tag `v1.1.29` — requiring a manual bump to `v1.1.30`.

## What
- **New `Part 0 — reconcile the version`** in `.claude/commands/release.md`: derive the target from the latest `git tag` (the source of truth). Use `Cargo.toml`'s version if it's already ahead; otherwise bump from the latest tag — **prompt patch/minor when the unreleased delta adds a feature**, else silent patch. Includes the double-cut tag guard.
- **Fix the stale "version facts"** (old lines 19-20) that claimed the hook still bumps the version.

## Effect
Version is bumped **exactly once**, at release time, from tags — it can't drift (the no-bump failure) and can't double-cut (the per-commit-bump failure). Encodes the manual dance done for v1.1.30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)