### PR TITLE
Add EmbeddingGemma retrieval support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ codesearch index /path/to/my-project --force
 
 `codesearch index add` is intended to be run from inside the repo you want to register — pass the path explicitly if launched from elsewhere. First-time indexing takes 2–5 minutes; subsequent runs are incremental (10–30s) and branch switches re-index automatically. Use `codesearch index list/rm/prune` to manage registrations (see [Serve Mode](#serve-mode-multi-repo)).
 
+### Embedding model
+
+The default quantized MiniLM model favors startup speed and a small download. For
+multilingual text and notes, EmbeddingGemma 300M is available as a quantized ONNX
+model with retrieval-specific query and document prompts:
+
+```bash
+codesearch --model embeddinggemma-q4 index /path/to/notes --force
+```
+
+Changing models requires a full reindex because embedding dimensions and vector
+spaces are model-specific. Keep the same model selected for later indexing runs.
+
 ## MCP Configuration
 
 codesearch connects to AI agents via MCP. Two modes:

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ codesearch --model embeddinggemma-q4 index /path/to/notes --force
 
 Changing models requires a full reindex because embedding dimensions and vector
 spaces are model-specific. Keep the same model selected for later indexing runs.
+Search rejects a `--model` value that differs from the indexed model and points
+to the required `--force` rebuild instead of mixing incompatible vector spaces.
 
 ## MCP Configuration
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -264,7 +264,7 @@ pub struct Cli {
     /// Embedding model to use (e.g., bge-small, minilm-l6-q, jina-code)
     /// Available: minilm-l6, minilm-l6-q, minilm-l12, minilm-l12-q, paraphrase-minilm,
     ///            bge-small, bge-small-q, bge-base, nomic-v1, nomic-v1.5, nomic-v1.5-q,
-    ///            jina-code, e5-multilingual, mxbai-large, modernbert-large
+    ///            jina-code, e5-multilingual, mxbai-large, modernbert-large, embeddinggemma-q4
     #[arg(long, global = true)]
     pub model: Option<String>,
 }
@@ -883,7 +883,7 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
         );
         eprintln!("  minilm-l6, minilm-l6-q, minilm-l12, minilm-l12-q, paraphrase-minilm");
         eprintln!("  bge-small, bge-small-q, bge-base, nomic-v1, nomic-v1.5, nomic-v1.5-q");
-        eprintln!("  jina-code, e5-multilingual, mxbai-large, modernbert-large");
+        eprintln!("  jina-code, e5-multilingual, mxbai-large, modernbert-large, embeddinggemma-q4");
         std::process::exit(1);
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -261,10 +261,7 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub store: Option<String>,
 
-    /// Embedding model to use (e.g., bge-small, minilm-l6-q, jina-code)
-    /// Available: minilm-l6, minilm-l6-q, minilm-l12, minilm-l12-q, paraphrase-minilm,
-    ///            bge-small, bge-small-q, bge-base, nomic-v1, nomic-v1.5, nomic-v1.5-q,
-    ///            jina-code, e5-multilingual, mxbai-large, modernbert-large, embeddinggemma-q4
+    /// Embedding model to use (e.g., bge-small, jina-code, embeddinggemma-q4)
     #[arg(long, global = true)]
     pub model: Option<String>,
 }
@@ -893,9 +890,7 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
             "Unknown model: '{}'. Available models:",
             cli.model.as_deref().unwrap_or_default()
         );
-        eprintln!("  minilm-l6, minilm-l6-q, minilm-l12, minilm-l12-q, paraphrase-minilm");
-        eprintln!("  bge-small, bge-small-q, bge-base, nomic-v1, nomic-v1.5, nomic-v1.5-q");
-        eprintln!("  jina-code, e5-multilingual, mxbai-large, modernbert-large, embeddinggemma-q4");
+        eprintln!("  {}", ModelType::valid_short_names());
         std::process::exit(1);
     }
 
@@ -942,7 +937,7 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
                 sync,
                 json,
                 filter_path,
-                model_override: model_type.map(|mt| format!("{:?}", mt)),
+                model_override: model_type.map(|mt| mt.short_name().to_string()),
                 vector_only,
                 rrf_k: if rrf_k == 60.0 {
                     None

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -871,6 +871,18 @@ async fn run_remote_reindex(peer_name: &str, alias: &str, force: bool, json: boo
     Ok(())
 }
 
+fn warn_if_heavier_model(model_type: ModelType) {
+    if model_type.is_heavier_than_default() {
+        crate::warn_print!(
+            "Warning: model '{}' produces {}-dimensional vectors (default: {}). \
+             Expect higher vector-index RAM and disk usage.",
+            model_type.short_name(),
+            model_type.dimensions(),
+            ModelType::default().dimensions()
+        );
+    }
+}
+
 pub async fn run(cancel_token: CancellationToken) -> Result<()> {
     let cli = Cli::parse();
 
@@ -917,6 +929,9 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
             // Auto-enable quiet mode for JSON output
             if json {
                 crate::output::set_quiet(true);
+            }
+            if let Some(mt) = model_type {
+                warn_if_heavier_model(mt);
             }
             let options = SearchOptions {
                 max_results,
@@ -981,6 +996,9 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
                                     parsed
                                 })
                                 .or(model_type);
+                            if let Some(mt) = mt {
+                                warn_if_heavier_model(mt);
+                            }
                             crate::index::add_to_index(add_path, global, mt, cancel_token.clone())
                                 .await
                         }
@@ -1040,6 +1058,9 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
 
                 if add || is_add_cmd {
                     let effective_path = if is_add_cmd { None } else { path };
+                    if let Some(mt) = model_type {
+                        warn_if_heavier_model(mt);
+                    }
                     crate::index::add_to_index(
                         effective_path,
                         global,
@@ -1072,6 +1093,9 @@ pub async fn run(cancel_token: CancellationToken) -> Result<()> {
                         ),
                     }
                 } else {
+                    if let Some(mt) = model_type {
+                        warn_if_heavier_model(mt);
+                    }
                     crate::index::index(
                         path,
                         dry_run,

--- a/src/embed/batch.rs
+++ b/src/embed/batch.rs
@@ -1,4 +1,4 @@
-use super::embedder::FastEmbedder;
+use super::embedder::{FastEmbedder, ModelType};
 use crate::chunker::Chunk;
 use anyhow::Result;
 use std::sync::{Arc, Mutex};
@@ -89,13 +89,18 @@ impl BatchEmbedder {
         let total = chunks.len();
         let _start = std::time::Instant::now();
         let mut embedded_chunks = Vec::with_capacity(total);
+        let model_type = self
+            .embedder
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Embedder mutex poisoned: {}", e))?
+            .model_type();
 
         // Process in batches
         for chunk_batch in chunks.chunks(self.batch_size) {
             // Prepare texts for embedding
             let texts: Vec<String> = chunk_batch
                 .iter()
-                .map(|chunk| self.prepare_text(chunk))
+                .map(|chunk| Self::prepare_text(chunk, model_type))
                 .collect();
 
             // Generate embeddings
@@ -117,11 +122,12 @@ impl BatchEmbedder {
     /// Embed a single chunk
     #[allow(dead_code)] // Reserved for single-chunk embedding
     pub fn embed_chunk(&mut self, chunk: Chunk) -> Result<EmbeddedChunk> {
-        let text = self.prepare_text(&chunk);
-        let embedding = self
+        let mut embedder = self
             .embedder
             .lock()
-            .map_err(|e| anyhow::anyhow!("Embedder mutex poisoned: {}", e))?
+            .map_err(|e| anyhow::anyhow!("Embedder mutex poisoned: {}", e))?;
+        let text = Self::prepare_text(&chunk, embedder.model_type());
+        let embedding = embedder
             .embed_documents(vec![text])?
             .into_iter()
             .next()
@@ -137,7 +143,7 @@ impl BatchEmbedder {
     /// - Signature (if available)
     /// - Docstring (if available)
     /// - Content
-    fn prepare_text(&self, chunk: &Chunk) -> String {
+    fn prepare_text(chunk: &Chunk, model_type: ModelType) -> String {
         let mut parts = Vec::new();
 
         // Add context breadcrumbs (e.g., "File: main.rs > Class: Server")
@@ -177,14 +183,9 @@ impl BatchEmbedder {
             }
         }
 
-        // Add main content
-        let label = match std::path::Path::new(&chunk.path)
-            .extension()
-            .and_then(|extension| extension.to_str())
-        {
-            Some("md" | "markdown" | "txt") => "Text",
-            _ => "Code",
-        };
+        // Add main content. Only EmbeddingGemma distinguishes prose from code;
+        // existing models retain their historical input representation.
+        let label = model_type.content_label(&chunk.path);
         parts.push(format!("{label}:\n{}", chunk.content));
 
         parts.join("\n")
@@ -284,44 +285,27 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Requires model — flaky on CI without model cache
-    fn test_prepare_text() {
-        // Set a temporary cache directory to avoid creating .fastembed_cache in project root
-        let temp_dir = std::env::temp_dir().join("codesearch_test_cache");
-        std::fs::create_dir_all(&temp_dir).ok();
-        std::env::set_var(
-            "FASTEMBED_CACHE_DIR",
-            temp_dir.to_string_lossy().to_string(),
-        );
-
-        let embedder = Arc::new(Mutex::new(FastEmbedder::new().unwrap_or_else(|_| {
-            // For tests, create a mock if real embedder fails
-            panic!("Cannot create embedder in test");
-        })));
-
-        let batch = BatchEmbedder::new(embedder);
-
+    fn test_prepare_text_preserves_existing_models_and_labels_gemma_notes() {
         let mut chunk = Chunk::new(
-            "fn test() { println!(\"test\"); }".to_string(),
+            "A durable personal note".to_string(),
             0,
             1,
-            ChunkKind::Function,
-            "test.rs".to_string(),
+            ChunkKind::Block,
+            "notes.md".to_string(),
         );
-        chunk.context = vec!["File: test.rs".to_string(), "Function: test".to_string()];
-        chunk.signature = Some("fn test()".to_string());
-        chunk.docstring = Some("/// Test function".to_string());
+        chunk.context = vec!["File: notes.md".to_string(), "Section: Ideas".to_string()];
 
-        let text = batch.prepare_text(&chunk);
+        let default_text = BatchEmbedder::prepare_text(&chunk, ModelType::default());
+        let gemma_text = BatchEmbedder::prepare_text(&chunk, ModelType::EmbeddingGemma300MQ4);
 
-        assert!(text.contains("Context: File: test.rs > Function: test"));
-        assert!(text.contains("Signature: fn test()"));
-        assert!(text.contains("Documentation: Test function"));
-        assert!(text.contains("Code:"));
-
-        // Clean up temp cache
-        let _ = std::fs::remove_dir_all(temp_dir);
-        std::env::remove_var("FASTEMBED_CACHE_DIR");
+        assert_eq!(
+            default_text,
+            "Context: File: notes.md > Section: Ideas\nCode:\nA durable personal note"
+        );
+        assert_eq!(
+            gemma_text,
+            "Context: File: notes.md > Section: Ideas\nText:\nA durable personal note"
+        );
     }
 
     fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {

--- a/src/embed/batch.rs
+++ b/src/embed/batch.rs
@@ -103,7 +103,7 @@ impl BatchEmbedder {
                 .embedder
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Embedder mutex poisoned: {}", e))?
-                .embed_batch(texts)?;
+                .embed_documents(texts)?;
 
             // Combine chunks with embeddings
             for (chunk, embedding) in chunk_batch.iter().zip(embeddings) {
@@ -122,7 +122,10 @@ impl BatchEmbedder {
             .embedder
             .lock()
             .map_err(|e| anyhow::anyhow!("Embedder mutex poisoned: {}", e))?
-            .embed_one(&text)?;
+            .embed_documents(vec![text])?
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("No embedding generated"))?;
         Ok(EmbeddedChunk::new(chunk, embedding))
     }
 
@@ -175,7 +178,14 @@ impl BatchEmbedder {
         }
 
         // Add main content
-        parts.push(format!("Code:\n{}", chunk.content));
+        let label = match std::path::Path::new(&chunk.path)
+            .extension()
+            .and_then(|extension| extension.to_str())
+        {
+            Some("md" | "markdown" | "txt") => "Text",
+            _ => "Code",
+        };
+        parts.push(format!("{label}:\n{}", chunk.content));
 
         parts.join("\n")
     }

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -45,6 +45,8 @@ pub enum ModelType {
     MxbaiEmbedLargeV1,
     /// ModernBERT Embed Large - 1024 dimensions, latest architecture
     ModernBertEmbedLarge,
+    /// Quantized EmbeddingGemma 300M - 768 dimensions, multilingual retrieval
+    EmbeddingGemma300MQ4,
 }
 
 impl ModelType {
@@ -70,6 +72,7 @@ impl ModelType {
             Self::MultilingualE5Small => FastEmbedModel::MultilingualE5Small,
             Self::MxbaiEmbedLargeV1 => FastEmbedModel::MxbaiEmbedLargeV1,
             Self::ModernBertEmbedLarge => FastEmbedModel::ModernBertEmbedLarge,
+            Self::EmbeddingGemma300MQ4 => FastEmbedModel::EmbeddingGemma300MQ4,
         }
     }
 
@@ -89,7 +92,8 @@ impl ModelType {
             | Self::NomicEmbedTextV1
             | Self::NomicEmbedTextV15
             | Self::NomicEmbedTextV15Q
-            | Self::JinaEmbeddingsV2BaseCode => 768,
+            | Self::JinaEmbeddingsV2BaseCode
+            | Self::EmbeddingGemma300MQ4 => 768,
             // 1024 dimensions
             Self::BGELargeENV15 | Self::MxbaiEmbedLargeV1 | Self::ModernBertEmbedLarge => 1024,
         }
@@ -113,6 +117,7 @@ impl ModelType {
             Self::MultilingualE5Small => "intfloat/multilingual-e5-small",
             Self::MxbaiEmbedLargeV1 => "mixedbread-ai/mxbai-embed-large-v1",
             Self::ModernBertEmbedLarge => "lightonai/modernbert-embed-large",
+            Self::EmbeddingGemma300MQ4 => "onnx-community/embeddinggemma-300m-ONNX (Q4)",
         }
     }
 
@@ -125,6 +130,7 @@ impl ModelType {
                 | Self::AllMiniLML12V2Q
                 | Self::BGESmallENV15Q
                 | Self::NomicEmbedTextV15Q
+                | Self::EmbeddingGemma300MQ4
         )
     }
 
@@ -147,6 +153,7 @@ impl ModelType {
             Self::MultilingualE5Small => "e5-multilingual",
             Self::MxbaiEmbedLargeV1 => "mxbai-large",
             Self::ModernBertEmbedLarge => "modernbert-large",
+            Self::EmbeddingGemma300MQ4 => "embeddinggemma-q4",
         }
     }
 
@@ -169,6 +176,7 @@ impl ModelType {
             Self::MultilingualE5Small,
             Self::MxbaiEmbedLargeV1,
             Self::ModernBertEmbedLarge,
+            Self::EmbeddingGemma300MQ4,
         ]
     }
 
@@ -204,7 +212,22 @@ impl ModelType {
             "e5-multilingual" | "multilinguale5small" => Some(Self::MultilingualE5Small),
             "mxbai-large" | "mxbaiembedlargev1" => Some(Self::MxbaiEmbedLargeV1),
             "modernbert-large" | "modernbertembedlarge" => Some(Self::ModernBertEmbedLarge),
+            "embeddinggemma-q4" | "embeddinggemma300mq4" => Some(Self::EmbeddingGemma300MQ4),
             _ => None,
+        }
+    }
+
+    pub fn prepare_query(&self, text: &str) -> String {
+        match self {
+            Self::EmbeddingGemma300MQ4 => format!("task: search result | query: {text}"),
+            _ => text.to_string(),
+        }
+    }
+
+    pub fn prepare_document(&self, text: &str) -> String {
+        match self {
+            Self::EmbeddingGemma300MQ4 => format!("title: none | text: {text}"),
+            _ => text.to_string(),
         }
     }
 }
@@ -315,6 +338,27 @@ impl FastEmbedder {
             .ok_or_else(|| anyhow!("No embedding generated"))
     }
 
+    pub fn embed_query(&mut self, text: &str) -> Result<Vec<f32>> {
+        let text = self.model_type.prepare_query(text);
+        self.embed_one(&text)
+    }
+
+    pub fn embed_queries(&mut self, texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
+        let texts = texts
+            .into_iter()
+            .map(|text| self.model_type.prepare_query(&text))
+            .collect();
+        self.embed_batch(texts)
+    }
+
+    pub fn embed_documents(&mut self, texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
+        let texts = texts
+            .into_iter()
+            .map(|text| self.model_type.prepare_document(&text))
+            .collect();
+        self.embed_batch(texts)
+    }
+
     /// Get the dimensionality of embeddings
     pub fn dimensions(&self) -> usize {
         self.model_type.dimensions()
@@ -361,6 +405,7 @@ mod tests {
         assert_eq!(ModelType::BGELargeENV15.dimensions(), 1024);
         assert_eq!(ModelType::MxbaiEmbedLargeV1.dimensions(), 1024);
         assert_eq!(ModelType::ModernBertEmbedLarge.dimensions(), 1024);
+        assert_eq!(ModelType::EmbeddingGemma300MQ4.dimensions(), 768);
     }
 
     #[test]
@@ -386,7 +431,7 @@ mod tests {
     #[test]
     fn test_all_models() {
         let all = ModelType::all();
-        assert_eq!(all.len(), 16);
+        assert_eq!(all.len(), 17);
     }
 
     #[test]
@@ -468,6 +513,10 @@ mod tests {
             ModelType::parse("jina-code"),
             Some(ModelType::JinaEmbeddingsV2BaseCode)
         );
+        assert_eq!(
+            ModelType::parse("embeddinggemma-q4"),
+            Some(ModelType::EmbeddingGemma300MQ4)
+        );
         assert_eq!(ModelType::parse("invalid"), None);
     }
 
@@ -477,6 +526,27 @@ mod tests {
         assert!(ModelType::BGESmallENV15Q.is_quantized());
         assert!(!ModelType::BGESmallENV15.is_quantized());
         assert!(!ModelType::JinaEmbeddingsV2BaseCode.is_quantized());
+        assert!(ModelType::EmbeddingGemma300MQ4.is_quantized());
+    }
+
+    #[test]
+    fn test_embeddinggemma_retrieval_prompts() {
+        let model = ModelType::EmbeddingGemma300MQ4;
+        assert_eq!(
+            model.prepare_query("Was wurde entschieden?"),
+            "task: search result | query: Was wurde entschieden?"
+        );
+        assert_eq!(
+            model.prepare_document("Eine dauerhafte Notiz"),
+            "title: none | text: Eine dauerhafte Notiz"
+        );
+    }
+
+    #[test]
+    fn test_retrieval_prompts_leave_other_models_unchanged() {
+        let model = ModelType::AllMiniLML6V2Q;
+        assert_eq!(model.prepare_query("search text"), "search text");
+        assert_eq!(model.prepare_document("document text"), "document text");
     }
 
     #[test]

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -230,6 +230,32 @@ impl ModelType {
             _ => text.to_string(),
         }
     }
+
+    /// Label prefix for a chunk's main content when building the embedding input.
+    ///
+    /// EmbeddingGemma benefits from distinguishing prose from source code, so
+    /// Markdown and plain-text files are labeled `Text`. Every other model keeps
+    /// the historical `Code` label unconditionally, leaving their embeddings —
+    /// and therefore existing indexes — byte-for-byte unchanged.
+    pub fn content_label(&self, path: &str) -> &'static str {
+        match self {
+            Self::EmbeddingGemma300MQ4 => {
+                match std::path::Path::new(path)
+                    .extension()
+                    .and_then(|extension| extension.to_str())
+                {
+                    Some("md" | "markdown" | "txt") => "Text",
+                    _ => "Code",
+                }
+            }
+            _ => "Code",
+        }
+    }
+
+    /// Whether this model produces larger embeddings than the default model.
+    pub fn is_heavier_than_default(&self) -> bool {
+        self.dimensions() > Self::default().dimensions()
+    }
 }
 
 /// Fast embedding model using fastembed library
@@ -547,6 +573,28 @@ mod tests {
         let model = ModelType::AllMiniLML6V2Q;
         assert_eq!(model.prepare_query("search text"), "search text");
         assert_eq!(model.prepare_document("document text"), "document text");
+    }
+
+    #[test]
+    fn test_content_label_only_distinguishes_prose_for_embeddinggemma() {
+        let gemma = ModelType::EmbeddingGemma300MQ4;
+        assert_eq!(gemma.content_label("notes.md"), "Text");
+        assert_eq!(gemma.content_label("notes.markdown"), "Text");
+        assert_eq!(gemma.content_label("notes.txt"), "Text");
+        assert_eq!(gemma.content_label("src/lib.rs"), "Code");
+
+        let default = ModelType::default();
+        assert_eq!(default.content_label("notes.md"), "Code");
+        assert_eq!(default.content_label("notes.txt"), "Code");
+        assert_eq!(default.content_label("src/lib.rs"), "Code");
+    }
+
+    #[test]
+    fn test_heavier_than_default_tracks_vector_dimensions() {
+        assert!(!ModelType::default().is_heavier_than_default());
+        assert!(!ModelType::MultilingualE5Small.is_heavier_than_default());
+        assert!(ModelType::EmbeddingGemma300MQ4.is_heavier_than_default());
+        assert!(ModelType::ModernBertEmbedLarge.is_heavier_than_default());
     }
 
     #[test]

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -2,6 +2,8 @@ use anyhow::{anyhow, Result};
 use fastembed::{EmbeddingModel as FastEmbedModel, InitOptions, TextEmbedding};
 use ort::execution_providers::CPUExecutionProvider;
 
+use crate::file::Language;
+
 /// Available embedding models
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ModelType {
@@ -182,9 +184,8 @@ impl ModelType {
 
     /// Comma-separated list of all valid model short names.
     ///
-    /// Single source of truth for the "valid models" message shown by the CLI
-    /// (`index add --model`) and the serve `POST /repos` error path, so the two
-    /// can never drift from the set `parse()` actually accepts.
+    /// Single source of truth for the "valid models" messages shown by the CLI
+    /// and the serve API, so they cannot drift from the set `parse()` accepts.
     pub fn valid_short_names() -> String {
         Self::all()
             .iter()
@@ -239,14 +240,10 @@ impl ModelType {
     /// and therefore existing indexes — byte-for-byte unchanged.
     pub fn content_label(&self, path: &str) -> &'static str {
         match self {
-            Self::EmbeddingGemma300MQ4 => {
-                match std::path::Path::new(path)
-                    .extension()
-                    .and_then(|extension| extension.to_str())
-                {
-                    Some("md" | "markdown" | "txt") => "Text",
-                    _ => "Code",
-                }
+            Self::EmbeddingGemma300MQ4
+                if Language::from_path(std::path::Path::new(path)) == Language::Markdown =>
+            {
+                "Text"
             }
             _ => "Code",
         }
@@ -455,12 +452,6 @@ mod tests {
     }
 
     #[test]
-    fn test_all_models() {
-        let all = ModelType::all();
-        assert_eq!(all.len(), 17);
-    }
-
-    #[test]
     fn test_short_name_round_trips_through_parse() {
         // Every model advertised by all() must parse back from its short_name.
         // This guards the C1/M6 fix: the embedding path resolves the model from
@@ -579,6 +570,7 @@ mod tests {
     fn test_content_label_only_distinguishes_prose_for_embeddinggemma() {
         let gemma = ModelType::EmbeddingGemma300MQ4;
         assert_eq!(gemma.content_label("notes.md"), "Text");
+        assert_eq!(gemma.content_label("NOTES.MD"), "Text");
         assert_eq!(gemma.content_label("notes.markdown"), "Text");
         assert_eq!(gemma.content_label("notes.txt"), "Text");
         assert_eq!(gemma.content_label("src/lib.rs"), "Code");

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -172,7 +172,7 @@ impl EmbeddingService {
         let embedding = embedder_arc
             .lock()
             .map_err(|e| anyhow::anyhow!("Embedder mutex poisoned: {}", e))?
-            .embed_one(query)?;
+            .embed_query(query)?;
 
         // Store in cache
         self.query_cache.put(query, embedding.clone());
@@ -210,7 +210,7 @@ impl EmbeddingService {
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Embedder mutex poisoned: {}", e))?;
 
-            let new_embeddings = embedder.embed_batch(queries_to_embed)?;
+            let new_embeddings = embedder.embed_queries(queries_to_embed)?;
 
             // Store in cache and add to results
             for (i, embedding) in new_embeddings.into_iter().enumerate() {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -512,7 +512,18 @@ pub async fn index_quiet(
     global: bool,
     cancel_token: CancellationToken,
 ) -> Result<()> {
-    index_with_options(path, false, force, global, None, true, cancel_token).await
+    index_quiet_with_model(path, force, global, None, cancel_token).await
+}
+
+/// Index a repository quietly while selecting the model for a new index.
+pub async fn index_quiet_with_model(
+    path: Option<PathBuf>,
+    force: bool,
+    global: bool,
+    model: Option<ModelType>,
+    cancel_token: CancellationToken,
+) -> Result<()> {
+    index_with_options(path, false, force, global, model, true, cancel_token).await
 }
 
 /// Internal index function with all options

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -408,6 +408,14 @@ pub fn adapt_rrf_k(query: &str) -> (f64, f64) {
 /// Search the codebase
 pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) -> Result<()> {
     let (db_path, project_path) = get_db_path(path.clone())?;
+    let requested_model = options
+        .model_override
+        .as_deref()
+        .map(|name| {
+            ModelType::parse(name)
+                .ok_or_else(|| anyhow::anyhow!("Unknown embedding model override '{name}'"))
+        })
+        .transpose()?;
 
     if !db_path.exists() {
         if options.create_index {
@@ -417,7 +425,8 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
                 "🚀 No index found, creating one...".bright_cyan()
             ));
             let cancel_token = tokio_util::sync::CancellationToken::new();
-            crate::index::index_quiet(path, false, false, cancel_token).await?;
+            crate::index::index_quiet_with_model(path, false, false, requested_model, cancel_token)
+                .await?;
             crate::output::print_info(format_args!("{}", "✅ Index created successfully!".green()));
         } else {
             println!("{}", "❌ No database found!".red());
@@ -437,21 +446,35 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
 
     // Read model metadata from database FIRST (needed for sync)
     let (model_type, dimensions, primary_language) =
-        if let Some(ref model_name) = options.model_override {
-            // User specified a model - use it (warning: may not match indexed data!)
-            let mt = ModelType::parse(model_name).unwrap_or_else(|| {
-                tracing::warn!(
-                    "Unrecognized model override '{}', falling back to default model",
-                    model_name
-                );
-                ModelType::default()
-            });
-            (mt, mt.dimensions(), None)
-        } else if let Some((model_name, dims, lang)) = read_metadata(&db_path) {
+        if let Some((model_name, dims, lang)) = read_metadata(&db_path) {
             // Use model from metadata
             if let Some(mt) = ModelType::parse(&model_name) {
+                if let Some(requested) = requested_model {
+                    if requested != mt {
+                        anyhow::bail!(
+                            "Index uses embedding model '{}', but '--model {}' was requested. \
+                             Rebuild the index with `codesearch --model {} index {} --force` \
+                             before searching.",
+                            mt.short_name(),
+                            requested.short_name(),
+                            requested.short_name(),
+                            project_path.display()
+                        );
+                    }
+                }
                 (mt, dims, lang)
             } else {
+                if let Some(requested) = requested_model {
+                    anyhow::bail!(
+                        "Index metadata names unknown embedding model '{}', so '--model {}' \
+                         cannot be verified. Rebuild the index with \
+                         `codesearch --model {} index {} --force`.",
+                        model_name,
+                        requested.short_name(),
+                        requested.short_name(),
+                        project_path.display()
+                    );
+                }
                 // Model name not recognized, fall back to default
                 tracing::warn!(
                     "Unrecognized model '{}' in database metadata, falling back to default model",
@@ -463,6 +486,14 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
                 );
                 (ModelType::default(), 384, None)
             }
+        } else if let Some(requested) = requested_model {
+            anyhow::bail!(
+                "Cannot verify '--model {}' because the index metadata is missing or invalid. \
+                 Rebuild the index with `codesearch --model {} index {} --force`.",
+                requested.short_name(),
+                requested.short_name(),
+                project_path.display()
+            );
         } else {
             // No metadata, fall back to default
             (ModelType::default(), 384, None)

--- a/tests/cli_model_errors.rs
+++ b/tests/cli_model_errors.rs
@@ -1,0 +1,84 @@
+use codesearch::ModelType;
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn write_index_markers(project: &Path, model: &str, dimensions: usize) {
+    let db = project.join(".codesearch.db");
+    fs::create_dir_all(db.join("fts")).expect("database directories should be created");
+    fs::write(db.join("data.mdb"), []).expect("LMDB marker should be created");
+    fs::write(
+        db.join("metadata.json"),
+        serde_json::to_vec(&json!({
+            "model_short_name": model,
+            "dimensions": dimensions
+        }))
+        .expect("metadata should serialize"),
+    )
+    .expect("metadata should be written");
+}
+
+#[test]
+fn unknown_model_error_lists_every_supported_model() {
+    let output = Command::new(env!("CARGO_BIN_EXE_codesearch"))
+        .args(["--model", "not-a-model", "search", "query"])
+        .output()
+        .expect("codesearch should start");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+
+    for model in ModelType::all() {
+        assert!(
+            stderr.contains(model.short_name()),
+            "unknown-model error omitted '{}'",
+            model.short_name()
+        );
+    }
+}
+
+#[test]
+fn search_rejects_a_model_that_does_not_match_the_index() {
+    let project = tempfile::tempdir().expect("temporary project should be created");
+    write_index_markers(project.path(), "minilm-l6-q", 384);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_codesearch"))
+        .args(["--model", "embeddinggemma-q4", "search", "query", "--path"])
+        .arg(project.path())
+        .arg("--create-index=false")
+        .output()
+        .expect("codesearch should start");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(stderr.contains("minilm-l6-q"), "{stderr}");
+    assert!(stderr.contains("embeddinggemma-q4"), "{stderr}");
+    assert!(stderr.contains("--force"), "{stderr}");
+}
+
+#[test]
+fn search_rejects_an_override_when_the_index_model_is_unknown() {
+    let project = tempfile::tempdir().expect("temporary project should be created");
+    write_index_markers(project.path(), "future-model", 768);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_codesearch"))
+        .args([
+            "--model",
+            "embeddinggemma-q4",
+            "search",
+            "query",
+            "--sync",
+            "--path",
+        ])
+        .arg(project.path())
+        .arg("--create-index=false")
+        .output()
+        .expect("codesearch should start");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(stderr.contains("future-model"), "{stderr}");
+    assert!(stderr.contains("embeddinggemma-q4"), "{stderr}");
+    assert!(stderr.contains("--force"), "{stderr}");
+}


### PR DESCRIPTION
## What changed

- add the quantized `EmbeddingGemma300MQ4` FastEmbed model under the CLI alias `embeddinggemma-q4`
- apply EmbeddingGemma's recommended query and document prompts through separate embedding paths
- label Markdown and plain-text chunks as `Text:` only for EmbeddingGemma, preserving existing model inputs
- warn for heavier models and reject `--model` values that don't match an existing index
- document model selection and the required full reindex when changing vector spaces

## Why

EmbeddingGemma is a compact multilingual retrieval model for source code, technical documentation, and note collections. It expects distinct query and document prompts, so treating both inputs identically reduces retrieval quality.

## User impact

Users can create an EmbeddingGemma-backed index with:

```bash
codesearch --model embeddinggemma-q4 index /path/to/project --force
```

Existing models and indexes retain their current behavior.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked --lib -- --test-threads=1` (`583 passed`, `12 ignored`)
- 3 CLI regression tests
- Clippy with warnings denied
- local end-to-end Markdown indexing and semantic-search smoke test
