### PR TITLE
🐛 fix: raise RLIMIT_NOFILE at serve startup — fd exhaustion silently wedges accept()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,7 @@ dependencies = [
  "hf-hub 0.3.2",
  "ignore",
  "indicatif 0.17.11",
+ "libc",
  "moka",
  "ndarray 0.16.1",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,9 @@ schemars = { version = "1.1.0", features = ["derive"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 sysinfo = { version = "0.38.4", default-features = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 tempfile = "3.13"

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -3735,6 +3735,110 @@ pub async fn run_tui_standalone(serve_url: String) -> Result<()> {
 /// Run the MCP serve mode.
 ///
 /// This is the entry point called from CLI when `codesearch serve` is invoked.
+/// Extra fds reserved for everything that is not a repo store:
+/// listener + accepted sockets, SSE sessions, log files, embedding
+/// model files, federation clients.
+#[cfg(unix)]
+const FD_HEADROOM: u64 = 256;
+
+/// Rough per-repo fd demand: LMDB env + tantivy FTS segments +
+/// file-watcher handles. Measured ~15-17 fds per warm repo on macOS;
+/// 20 leaves margin for segment churn.
+#[cfg(unix)]
+const FDS_PER_REPO_ESTIMATE: u64 = 20;
+
+/// Raise the soft `RLIMIT_NOFILE` to the hard limit before opening
+/// repo stores or binding the listener.
+///
+/// serve's fd demand scales with registered repo count (LMDB +
+/// tantivy + watcher handles per repo — ~1000 fds at 60 repos).
+/// Under process supervisors the default soft limit is often 256
+/// (macOS launchd agents, some systemd/docker configs). Once the
+/// process saturates that limit, `accept(2)` fails with `EMFILE` and
+/// the axum accept loop retries silently — the daemon looks alive to
+/// its supervisor while every new connection is refused or reset.
+/// Raising soft → hard at startup is standard daemon practice
+/// (nginx, envoy, postgres all do it) and turns a silent wedge into
+/// an explicit, logged operator decision.
+///
+/// Never fails the startup: on error we log and continue with the
+/// inherited limit, then warn if it looks too small for the
+/// registered repo count.
+#[cfg(unix)]
+fn raise_fd_limit(repo_count: usize) {
+    // SAFETY: getrlimit/setrlimit with a locally owned rlimit struct.
+    unsafe {
+        let mut lim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut lim) != 0 {
+            warn!(
+                "Could not read RLIMIT_NOFILE ({}); continuing with inherited limit",
+                std::io::Error::last_os_error()
+            );
+            return;
+        }
+        let before = lim.rlim_cur;
+        if lim.rlim_cur < lim.rlim_max {
+            // On macOS the kernel caps the effective per-process limit
+            // at kern.maxfilesperproc even when rlim_max is RLIM_INFINITY;
+            // clamp so setrlimit does not fail with EINVAL.
+            #[cfg(target_os = "macos")]
+            let target = {
+                let mut maxfiles: libc::c_int = 0;
+                let mut size = std::mem::size_of::<libc::c_int>();
+                let name = std::ffi::CString::new("kern.maxfilesperproc").unwrap();
+                if libc::sysctlbyname(
+                    name.as_ptr(),
+                    &mut maxfiles as *mut _ as *mut libc::c_void,
+                    &mut size,
+                    std::ptr::null_mut(),
+                    0,
+                ) == 0
+                {
+                    lim.rlim_max.min(maxfiles as libc::rlim_t)
+                } else {
+                    lim.rlim_max
+                }
+            };
+            #[cfg(not(target_os = "macos"))]
+            let target = lim.rlim_max;
+
+            if target > lim.rlim_cur {
+                lim.rlim_cur = target;
+                if libc::setrlimit(libc::RLIMIT_NOFILE, &lim) != 0 {
+                    warn!(
+                        "Could not raise RLIMIT_NOFILE {} → {} ({}); continuing with inherited limit",
+                        before,
+                        target,
+                        std::io::Error::last_os_error()
+                    );
+                    lim.rlim_cur = before;
+                } else {
+                    info!("Raised RLIMIT_NOFILE soft limit {} → {}", before, target);
+                }
+            }
+        }
+
+        let estimated = (repo_count as u64) * FDS_PER_REPO_ESTIMATE + FD_HEADROOM;
+        // rlim_t width is platform-dependent (u64 on macOS/Linux glibc,
+        // but not guaranteed everywhere) — keep the explicit widening.
+        #[allow(clippy::unnecessary_cast)]
+        let soft = lim.rlim_cur as u64;
+        if soft < estimated {
+            warn!(
+                "⚠️  RLIMIT_NOFILE soft limit is {} but {} registered repos need an estimated {} fds \
+                 (LMDB + FTS + watcher handles per repo). When the limit is exhausted, accept(2) fails \
+                 with EMFILE and serve stops answering connections WITHOUT crashing. Raise the limit for \
+                 this process (launchd: SoftResourceLimits.NumberOfFiles; systemd: LimitNOFILE; \
+                 shell: ulimit -n) or reduce the number of registered repos.",
+                soft, repo_count, estimated
+            );
+        }
+    }
+}
+
 pub async fn run_serve(
     host: Option<String>,
     port: Option<u16>,
@@ -3806,6 +3910,12 @@ pub async fn run_serve(
             warn!("Failed to save auto-discovered repos: {}", e);
         }
     }
+
+    // Raise the fd soft limit BEFORE opening any repo store or binding
+    // the listener — fd demand scales with repo count and a 256-fd
+    // supervisor default wedges accept(2) silently (EMFILE).
+    #[cfg(unix)]
+    raise_fd_limit(config.repos.len());
 
     let serve_state = Arc::new(ServeState::new(config, None));
 


### PR DESCRIPTION
## The bug

`codesearch serve`'s file-descriptor demand scales with registered repo count — each warm repo holds an LMDB env + tantivy FTS segment handles + file-watcher handles (≈ 15–20 fds measured on macOS). Under process supervisors the default soft `RLIMIT_NOFILE` is often **256** (macOS launchd agents, some systemd/docker configs). Once repo warmup saturates that limit:

- tantivy logs `Too many open files` (errno 24) **warnings**, and
- `accept(2)` fails with `EMFILE`; axum 0.7's accept loop sleeps and retries **silently** — the daemon looks alive to its supervisor (KeepAlive sees a healthy pid) while every new connection is refused or reset. No ERROR log, no exit. A silent wedge.

## How we hit it

Production workspace with **60 registered repos** (~1000 fds needed) running serve as a macOS LaunchAgent: serve answered MCP handshakes for ~15s after every start (until warmup consumed the fd budget), then reset every connection while the process stayed 'healthy' — deterministic across restarts. Diagnosis artifacts: errno-24 lines in `serve.log`, `sample` showing all threads idle-parked with the listener effectively dead, process fd table saturated at exactly 255/256 under a `ulimit -n 256` repro.

## The fix

At `run_serve` startup, before any store open or listener bind (unix only, no-op elsewhere):

1. **Raise the soft `RLIMIT_NOFILE` to the hard limit** — standard daemon practice (nginx/envoy/postgres all do it). On macOS the target is clamped to `kern.maxfilesperproc` so `setrlimit` cannot fail with `EINVAL`. Failures are non-fatal and logged.
2. Log the raise at INFO: `Raised RLIMIT_NOFILE soft limit 256 → 61440`.
3. If the effective limit still looks too small for the registered repo count (`repos × 20 + 256` headroom), emit a **loud actionable WARN** naming the supervisor knobs (launchd `SoftResourceLimits.NumberOfFiles`, systemd `LimitNOFILE`, `ulimit -n`) — so the failure mode becomes an explicit operator decision instead of a silent wedge.

Adds `libc` as a direct `cfg(unix)` dependency (already in the tree transitively).

## Verification

- **At-scale repro:** `ulimit -n 256` + 60 registered repos — unpatched serve saturates at 255/256 fds (EMFILE in logs; wedges under launchd); patched serve logs the raise, runs at ~300 fds, and answers MCP handshakes indefinitely under the same conditions.
- `cargo clippy --lib --bins -- -D warnings` clean.
- `cargo test --lib --bins` green (579 + 575 pass, 13 ignored — same as develop).

## Possible follow-up (not in this PR)

Even with the raise, a truly exhausted process still wedges silently because axum swallows accept errors. A custom accept loop (or a periodic fd-headroom check) that logs at ERROR when `accept` hits `EMFILE`/`ENFILE` would make the residual case loud too. Happy to take a stab if you want it.