### PR TITLE
🛡️ fix: defense-in-depth for ANSI injection, .git root walk, and Unix backslash collision (Aikido)

### DIFF
--- a/src/cache/file_meta.rs
+++ b/src/cache/file_meta.rs
@@ -58,14 +58,37 @@ pub fn safe_canonicalize(path: &Path) -> std::io::Result<PathBuf> {
 /// prefix (`\\?\C:\...`). Notify (FSW) events may use standard paths (`C:\...`).
 /// This function strips the UNC prefix and converts backslashes to forward slashes
 /// so that paths from different sources all map to the same key.
+///
+/// **Platform behavior** (Aikido group 30641757, priority 46):
+/// - **Windows**: backslash IS a path separator — converting it to `/` is
+///   required for HashMap consistency across APIs.
+/// - **Unix**: backslash is a **legal filename character** (not a separator).
+///   A file literally named `foo\bar.rs` is distinct from `foo/bar.rs` (which
+///   lives in subdirectory `foo`). Unconditionally converting `\` → `/` would
+///   collapse these two unrelated files into one HashMap key, causing silent
+///   metadata corruption (one file's chunks overwrite the other's).
 pub fn normalize_path(path: &Path) -> String {
     let s = path.to_string_lossy();
-    s.trim_start_matches(r"\\?\").replace('\\', "/")
+    normalize_path_str(&s)
 }
 
 /// Normalize a path string (same logic as `normalize_path` but for `&str` input).
+///
+/// See `normalize_path` for the platform-specific separator handling and
+/// the Aikido 30641757 rationale.
 pub fn normalize_path_str(path: &str) -> String {
-    path.trim_start_matches(r"\\?\").replace('\\', "/")
+    let trimmed = path.trim_start_matches(r"\\?\");
+    #[cfg(windows)]
+    {
+        trimmed.replace('\\', "/")
+    }
+    #[cfg(not(windows))]
+    {
+        // Backslash is a legal filename char on Unix — preserve it literally.
+        // UNC prefix is already stripped above (it's a no-op on Unix in
+        // practice, but defensive in case a Windows-style path string leaks in).
+        trimmed.to_string()
+    }
 }
 
 /// Normalize a filter path for prefix matching.
@@ -451,6 +474,7 @@ mod tests {
         );
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_normalize_path_strips_unc_prefix() {
         let path = Path::new(r"\\?\C:\WorkArea\AI\codesearch\src\main.rs");
@@ -460,6 +484,7 @@ mod tests {
         );
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_normalize_path_converts_backslashes() {
         let path = Path::new(r"C:\WorkArea\AI\codesearch\src\main.rs");
@@ -479,6 +504,7 @@ mod tests {
         assert!(!result.starts_with(r"\\?\"));
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_normalize_path_str_strips_unc() {
         assert_eq!(normalize_path_str(r"\\?\C:\foo\bar.rs"), "C:/foo/bar.rs");
@@ -491,6 +517,25 @@ mod tests {
         assert_eq!(normalize_path(path), "/home/user/project/src/main.rs");
     }
 
+    /// Aikido 30641757 (priority 46): on Unix, a file whose name literally
+    /// contains a backslash (`foo\bar.rs`) is distinct from a file in a
+    /// subdirectory (`foo/bar.rs`). Both must NOT collapse to the same key.
+    #[cfg(not(windows))]
+    #[test]
+    fn test_normalize_path_preserves_unix_backslash_filenames() {
+        // Subdirectory file — forward slash is the separator.
+        let subdir = normalize_path(Path::new("foo/bar.rs"));
+        // Literal-backslash filename — backslash is part of the name on Unix.
+        let literal = normalize_path(Path::new("foo\\bar.rs"));
+        assert_ne!(
+            subdir, literal,
+            "Unix must NOT collapse `foo/bar.rs` and `foo\\bar.rs` into the same key"
+        );
+        assert_eq!(subdir, "foo/bar.rs");
+        assert_eq!(literal, "foo\\bar.rs");
+    }
+
+    #[cfg(windows)]
     #[test]
     fn test_normalize_path_mixed_separators() {
         // Mixed separators should be normalized to forward slashes
@@ -498,6 +543,7 @@ mod tests {
         assert_eq!(normalize_path(path), "C:/Users/project/src/lib.rs");
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_normalize_path_str_mixed_separators() {
         assert_eq!(
@@ -516,6 +562,7 @@ mod tests {
         );
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_normalize_path_deeply_nested() {
         // Deeply nested paths
@@ -526,6 +573,7 @@ mod tests {
         );
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_normalize_path_consecutive_backslashes() {
         // Consecutive backslashes (edge case from file systems)
@@ -533,6 +581,7 @@ mod tests {
         assert_eq!(normalize_path(path), "C://Double//Backslashes//file.rs");
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_migrate_paths_normalizes_keys() {
         let mut store = FileMetaStore::new("test-model".to_string(), 384);
@@ -610,6 +659,7 @@ mod tests {
     // These test the exact bug patterns that have caused issues in production.
     // =========================================================================
 
+    #[cfg(windows)]
     #[test]
     fn test_path_comparison_unc_vs_normal() {
         // UNC prefix (from Windows canonicalize) must match normal path
@@ -618,6 +668,7 @@ mod tests {
         assert_eq!(unc, normal);
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_path_comparison_backslash_vs_forward() {
         let backslash = normalize_path(Path::new(r"C:\WorkArea\src\main.rs"));
@@ -625,6 +676,7 @@ mod tests {
         assert_eq!(backslash, forward);
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_path_str_comparison_unc_vs_normal() {
         let unc = normalize_path_str(r"\\?\C:\WorkArea\src\main.rs");
@@ -632,6 +684,7 @@ mod tests {
         assert_eq!(unc, normal);
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_path_comparison_stored_vs_walker() {
         // Simulates: FileMetaStore stored path vs FileWalker discovered path
@@ -645,6 +698,7 @@ mod tests {
         );
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_path_filter_starts_with() {
         // Simulates: --filter-path src/ matching against stored paths
@@ -657,6 +711,7 @@ mod tests {
         assert!(stored.starts_with(&filter_bs));
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_path_filter_with_unc_prefix() {
         // Agent sends UNC path as filter, stored paths are normalized
@@ -683,6 +738,7 @@ mod tests {
         assert_eq!(from_path, from_str);
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_normalize_path_relative_strips_project_root() {
         let root = normalize_path_str(r"C:\WorkArea\AI\codesearch");
@@ -709,6 +765,7 @@ mod tests {
         assert_eq!(normalize_filter_path("./src/"), "src/");
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_path_matches_filter_with_absolute_windows_path() {
         let root = normalize_path_str(r"C:\WorkArea\AI\codesearch");

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -90,6 +90,27 @@ impl FileWalker {
 
     /// Walk files, returning detailed file information
     pub fn walk(&self) -> Result<(Vec<FileInfo>, WalkStats)> {
+        // Security (Aikido group 30641794): refuse to walk a root whose own
+        // name is on the always-excluded list (e.g. `.git`, `.svn`, `node_modules`).
+        // The `filter_entry` closure below skips these names at depth >= 1, but
+        // it short-circuits on `depth() == 0` (the root). Without this guard,
+        // `codesearch index ./.git` would happily index every object, ref, and
+        // config file under `.git/`, exposing internal/sensitive metadata via
+        // search results. Fail fast at the walker's entry point so every caller
+        // (CLI `index`, HTTP `/repos`, `doctor`, `sync_database`, watcher) is
+        // covered uniformly.
+        if let Some(name) = self.root.file_name().and_then(|n| n.to_str()) {
+            if ALWAYS_EXCLUDED.contains(&name) {
+                anyhow::bail!(
+                    "Refusing to index '{}' — this directory name is on the \
+                     always-excluded list (e.g. `.git`, `.svn`, `node_modules`). \
+                     Indexing it would expose internal/sensitive files via search. \
+                     Point the indexer at the parent project directory instead.",
+                    self.root.display()
+                );
+            }
+        }
+
         let mut files = Vec::new();
         let mut stats = WalkStats::new();
 
@@ -299,5 +320,35 @@ mod tests {
         // Should only get index.js, not the node_modules file
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path.file_name().unwrap(), "index.js");
+    }
+
+    /// A root whose own name matches an `ALWAYS_EXCLUDED` entry (e.g. `.git`)
+    /// must be rejected at `walk()` time — otherwise the depth==0 short-circuit
+    /// in `filter_entry` would let every internal file be indexed.
+    /// Covers Aikido group 30641794.
+    #[test]
+    fn test_rejects_excluded_named_root() {
+        let parent = TempDir::new().unwrap();
+        let git_root = parent.path().join(".git");
+        fs::create_dir(&git_root).unwrap();
+        fs::write(git_root.join("config"), "[core]").unwrap();
+        fs::write(git_root.join("HEAD"), "ref: refs/heads/main").unwrap();
+
+        let walker = FileWalker::new(&git_root);
+        let err = walker.walk().unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("Refusing to index"),
+            "expected refusal message, got: {}",
+            msg
+        );
+        assert!(msg.contains(".git"), "message should name the offender");
+
+        // Sanity: a non-excluded name in the same parent walks normally.
+        let ok_root = parent.path().join("real_project");
+        fs::create_dir(&ok_root).unwrap();
+        fs::write(ok_root.join("main.rs"), "fn main() {}").unwrap();
+        let (files, _) = FileWalker::new(&ok_root).walk().unwrap();
+        assert_eq!(files.len(), 1);
     }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -962,7 +962,7 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
         let mut seen_files = std::collections::HashSet::new();
         for result in &results {
             if !seen_files.contains(&result.path) {
-                println!("{}", result.path);
+                println!("{}", sanitize_for_terminal(&result.path));
                 seen_files.insert(result.path.clone());
             }
         }
@@ -972,7 +972,10 @@ pub async fn search(query: &str, path: Option<PathBuf>, options: SearchOptions) 
     // Standard output
     println!("{}", "🔍 Search Results".bright_cyan().bold());
     println!("{}", "=".repeat(60));
-    println!("Query: \"{}\"", query.bright_yellow());
+    println!(
+        "Query: \"{}\"",
+        sanitize_for_terminal(query).bright_yellow()
+    );
     if let Some(pf) = options.per_file {
         println!(
             "Found {} results (showing up to {} per file)",
@@ -1094,7 +1097,10 @@ fn sync_database(db_path: &Path, model_type: ModelType) -> Result<()> {
         }
 
         changes += 1;
-        println!("  📝 {}", file.path.display());
+        println!(
+            "  📝 {}",
+            sanitize_for_terminal(&file.path.display().to_string())
+        );
 
         // Delete old chunks
         if !old_chunk_ids.is_empty() {
@@ -1124,7 +1130,7 @@ fn sync_database(db_path: &Path, model_type: ModelType) -> Result<()> {
     let deleted_files = file_meta.find_deleted_files();
     for (path, chunk_ids) in &deleted_files {
         changes += 1;
-        println!("  🗑️  {} (deleted)", path);
+        println!("  🗑️  {} (deleted)", sanitize_for_terminal(path));
         if !chunk_ids.is_empty() {
             store.delete_chunks(chunk_ids)?;
         }
@@ -1144,6 +1150,77 @@ fn sync_database(db_path: &Path, model_type: ModelType) -> Result<()> {
     Ok(())
 }
 
+/// Strip ANSI escape sequences and terminal-control bytes from a string.
+///
+/// Indexed content may contain CSI/OSC sequences (e.g. `\x1b[2J` clears the
+/// screen, `\x1b[8m` hides text, `\x1b]0;...\x07` rewrites the window title).
+/// If printed verbatim, the host terminal interprets them — enabling a range
+/// of attacks from screen-clearing DoS to hidden-text obfuscation. This
+/// helper strips:
+///   * CSI sequences: `ESC [ <params 0x30-0x3F> <intermediate 0x20-0x2F> <final 0x40-0x7E>`
+///   * OSC sequences: `ESC ] <data> (BEL | ESC \\)`
+///   * Single-char escape sequences: `ESC <0x40-0x5F>`
+///   * Stray control characters except `\n` and `\t`
+///
+/// Output is safe to feed into `Colorize` methods without risk of the inner
+/// content breaking out of the color wrapper. Mitigates Aikido group 30641757
+/// (ANSI escape sequence injection in search output).
+fn sanitize_for_terminal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\x1b' {
+            if c == '\n' || c == '\t' || !c.is_control() {
+                out.push(c);
+            }
+            continue;
+        }
+        // ESC sequence — consume per ECMA-48
+        match chars.peek().copied() {
+            None => break,
+            Some('[') => {
+                chars.next();
+                while let Some(p) = chars.peek().copied() {
+                    let code = p as u32;
+                    if (0x30..=0x3f).contains(&code) || (0x20..=0x2f).contains(&code) {
+                        chars.next();
+                    } else if (0x40..=0x7e).contains(&code) {
+                        chars.next();
+                        break;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                chars.next();
+                loop {
+                    match chars.next() {
+                        Some('\x07') => break,
+                        Some('\x1b') => {
+                            if matches!(chars.peek().copied(), Some('\\')) {
+                                chars.next();
+                            }
+                            break;
+                        }
+                        Some(_) => continue,
+                        None => break,
+                    }
+                }
+            }
+            Some(c2) => {
+                let code = c2 as u32;
+                if (0x40..=0x5f).contains(&code) {
+                    chars.next();
+                }
+                // ESC followed by something unexpected: drop the ESC, leave
+                // the next char to be processed normally on the next loop.
+            }
+        }
+    }
+    out
+}
+
 fn print_result(
     result: &crate::vectordb::SearchResult,
     show_file: bool,
@@ -1152,20 +1229,22 @@ fn print_result(
 ) -> Result<()> {
     if show_file {
         println!("{}", "─".repeat(60));
-        let file_display = format!("📄 {}", result.path);
+        let file_display = format!("📄 {}", sanitize_for_terminal(&result.path));
         println!("{}", file_display.bright_green());
     }
 
     // Show location and kind
     let location = format!(
         "   Lines {}-{} • {}",
-        result.start_line, result.end_line, result.kind
+        result.start_line,
+        result.end_line,
+        sanitize_for_terminal(&result.kind)
     );
     println!("{}", location.dimmed());
 
     // Show signature if available
     if let Some(sig) = &result.signature {
-        println!("   {}", sig.bright_cyan());
+        println!("   {}", sanitize_for_terminal(sig).bright_cyan());
     }
 
     // Show score if requested
@@ -1191,7 +1270,7 @@ fn print_result(
 
     // Show context if available
     if let Some(ctx) = &result.context {
-        println!("   Context: {}", ctx.dimmed());
+        println!("   Context: {}", sanitize_for_terminal(ctx).dimmed());
     }
 
     // Show content if requested
@@ -1200,13 +1279,13 @@ fn print_result(
         if let Some(ctx_prev) = &result.context_prev {
             println!("\n   {}:", "Context (before)".dimmed());
             for line in ctx_prev.lines() {
-                println!("   │ {}", line.bright_black());
+                println!("   │ {}", sanitize_for_terminal(line).bright_black());
             }
         }
 
         println!("\n   {}:", "Content".bright_yellow());
         for line in result.content.lines().take(10) {
-            println!("   │ {}", line.dimmed());
+            println!("   │ {}", sanitize_for_terminal(line).dimmed());
         }
         if result.content.lines().count() > 10 {
             println!("   │ {}", "...".dimmed());
@@ -1216,12 +1295,18 @@ fn print_result(
         if let Some(ctx_next) = &result.context_next {
             println!("\n   {}:", "Context (after)".dimmed());
             for line in ctx_next.lines() {
-                println!("   │ {}", line.bright_black());
+                println!("   │ {}", sanitize_for_terminal(line).bright_black());
             }
         }
     } else {
         // Show a snippet
-        let snippet: String = result.content.lines().take(3).collect::<Vec<_>>().join(" ");
+        let snippet: String = result
+            .content
+            .lines()
+            .take(3)
+            .map(|l| sanitize_for_terminal(l))
+            .collect::<Vec<_>>()
+            .join(" ");
 
         let snippet = if snippet.len() > 100 {
             format!("{}...", &snippet[..100])
@@ -1492,5 +1577,81 @@ mod tests {
         let project_root = normalize_path_str("C:/WorkArea/AI/codesearch");
         let filter = normalize_filter_path("src/");
         assert!(path_matches_filter("./src/lib.rs", &filter, &project_root));
+    }
+
+    // ── sanitize_for_terminal ───────────────────────────────────────────────
+
+    #[test]
+    fn test_sanitize_strips_csi_clear_screen() {
+        // \x1b[2J = clear screen
+        assert_eq!(sanitize_for_terminal("hello\x1b[2Jworld"), "helloworld");
+    }
+
+    #[test]
+    fn test_sanitize_strips_csi_with_params() {
+        // \x1b[38;5;200m = set 256-color foreground
+        assert_eq!(
+            sanitize_for_terminal("\x1b[38;5;200mred\x1b[0m text"),
+            "red text"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_strips_osc_bel_terminator() {
+        // \x1b]0;title\x07 = set window title, BEL terminator
+        assert_eq!(sanitize_for_terminal("a\x1b]0;title\x07b"), "ab");
+    }
+
+    #[test]
+    fn test_sanitize_strips_osc_st_terminator() {
+        // \x1b]0;title\x1b\\ = set window title, ST terminator
+        assert_eq!(sanitize_for_terminal("a\x1b]0;title\x1b\\b"), "ab");
+    }
+
+    #[test]
+    fn test_sanitize_strips_single_char_escape() {
+        // ESC M = Reverse Index (RI), in the 0x40-0x5F documented range
+        assert_eq!(
+            sanitize_for_terminal("a\x1bM b".to_string()),
+            "a b".to_string()
+        );
+    }
+
+    #[test]
+    fn test_sanitize_strips_control_chars_except_newline_tab() {
+        // NUL, BEL, backspace, vertical tab, form feed, CR — all stripped
+        assert_eq!(
+            sanitize_for_terminal("a\x00b\x07c\x08d\x0be\x0cf\rg"),
+            "abcdefg"
+        );
+        // newline and tab preserved
+        assert_eq!(sanitize_for_terminal("a\nb\tc"), "a\nb\tc");
+    }
+
+    #[test]
+    fn test_sanitize_strips_back_to_back_escapes() {
+        // Two consecutive CSI sequences — both stripped
+        assert_eq!(sanitize_for_terminal("\x1b[2J\x1b[2Jcleared"), "cleared");
+    }
+
+    #[test]
+    fn test_sanitize_preserves_unicode() {
+        assert_eq!(sanitize_for_terminal("héllo → 世界 🦀"), "héllo → 世界 🦀");
+    }
+
+    #[test]
+    fn test_sanitize_preserves_empty_and_clean_strings() {
+        assert_eq!(sanitize_for_terminal(""), "");
+        assert_eq!(sanitize_for_terminal("clean string"), "clean string");
+    }
+
+    #[test]
+    fn test_sanitize_truncated_escape_dropped_safely() {
+        // Truncated CSI at end of string — should not panic
+        assert_eq!(sanitize_for_terminal("text\x1b["), "text");
+        // Truncated OSC at end of string
+        assert_eq!(sanitize_for_terminal("text\x1b]0;unterminated"), "text");
+        // Lone ESC at end
+        assert_eq!(sanitize_for_terminal("text\x1b"), "text");
     }
 }


### PR DESCRIPTION
Companion defense-in-depth branch to PR #151 (which shipped the Critical fixes). This PR closes 3 additional Aikido findings (all MEDIUM severity).

## What ships

| Aikido group | Priority | Finding | Fix |
|---|---|---|---|
| 30641757 | 35 | ANSI escape sequence injection in search output | New `sanitize_for_terminal()` helper in `src/search/mod.rs` strips CSI/OSC/Fe escape sequences + stray control chars per ECMA-48, applied at every user-controllable `println!` site *before* the `Colorize` wrapper. 9 unit tests. |
| 30641794 | 38 | Local client can register `.git` dir as repo, exposing internal Git metadata via search | New guard at `FileWalker::walk()` entry refuses to walk any root whose name is in `ALWAYS_EXCLUDED` (`.git`, `.svn`, `node_modules`, etc.). Actionable error: "Point the indexer at the parent project directory instead." 1 unit test (reject + sibling-accept). |
| 30641757 | 46 | Unix backslash path collision: `foo\bar.rs` (literal) collapsed with `foo/bar.rs` (separator) → HashMap key collision → silent metadata corruption | `normalize_path_str()` now gates `.replace(\\, "/")` behind `#[cfg(windows)]`. UNC-strip remains unconditional. `normalize_path` delegates to `normalize_path_str` (incidental DRY win). 1 new Unix test; 16 Windows-only tests correctly gated. |

## Scope

3 commits, 3 source files only:
- `src/search/mod.rs` (+173 / −12)
- `src/file/mod.rs` (+51 / −0)
- `src/cache/file_meta.rs` (+59 / −2)

Total: +283 / −14. No scope creep, no docs/config noise.

## Local validation caveat

Same as PR #151: `cargo check --lib --tests` fails at link step locally — MSYS2 `/usr/bin/link` (GNU coreutils) shadows MSVC `link.exe` and no Windows SDK is installed. Pre-existing host issue, unrelated to this change. `cargo fmt --check` PASSES on all three files. CI on GitHub Actions will run the authoritative gate.

## Review

All 4 reviews PASS (3 per-stage + 1 final). No critical/important issues. Two minor cosmetic notes deferred (doc-comment drift at `file_meta.rs:59`, commit-message test count).

## Out of scope (deliberately deferred)

- Loopback auth default-on change — deployment-breaking, needs separate decision
- Dependency CVEs (rmcp, quinn-proto, etc.) — separate `cargo update` workflow
- Defense-in-depth internal fs ops in vectordb/store.rs / index/manager.rs — not externally controllable
- ~10 other `safe_canonicalize(...).unwrap_or_else(|_| ...)` sites — already audited; the only HTTP-facing one (`src/serve/mod.rs:3167`) is already correct