### PR TITLE
🔧 ci: skip CodeQL on fork PRs (upload cannot write security-events)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,14 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Skip on fork pull requests: the restricted GITHUB_TOKEN for fork PRs
+    # cannot write `security-events` back to the upstream repo, so the
+    # `github/codeql-action/analyze` upload step fails with
+    # "Resource not accessible by integration". CodeQL still runs on push
+    # events to develop/master (where the token has full write scopes per
+    # the `permissions:` block below), so merged code is still scanned —
+    # this only skips the redundant, upload-failing fork-PR run.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Problem

CodeQL fails on every fork pull request with:
```
##[error]Resource not accessible by integration - https://docs.github.com/rest
```

Root cause: fork PRs run with a **restricted GITHUB_TOKEN** that cannot write `security-events` back to the upstream repo. The workflow's `permissions: security-events: write` block doesn't help — GitHub deliberately uses a separate, reduced-scope token for fork PR runs (security measure to prevent untrusted code from exfiltrating write scopes).

This caused the confusing red X on PR #150 (from @tony-nexartis) even though the analysis itself completed successfully and the post-merge CodeQL run on `develop` passed.

## Fix

Add a job-level `if:` that skips the entire `analyze` job when the pull request's head repo differs from the workflow's repository:

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

## Coverage retained

CodeQL still runs on:
- ✅ **push to develop/master** — post-merge, where the token has full write scopes (this is the run that actually matters for the security tab)
- ✅ **same-repo PRs** — full write token, upload works
- ✅ **weekly schedule** — full write token

Only the redundant fork-PR run (which always failed to upload anyway) is skipped. No scanning coverage is lost.

## Verification

- YAML syntax validated (`python -c "import yaml; yaml.safe_load(...)"`)
- `git diff` is +9 −0 (comment + 1-line `if:` condition)
- Confirmed develop's post-merge CodeQL run #29989526007 was green — the failure was purely the fork-PR pull_request event #29989594411
