### PR TITLE
fix(release): D1 - apply cp-retry pattern to Linux with-csharp step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,11 +100,23 @@ jobs:
           Copy-Item -Recurse helpers-publish\* staging\helpers\csharp\
           Compress-Archive -Path staging\* -DestinationPath ${{ matrix.artifact_csharp }}
 
+      # D1 — same cp-retry pattern as the macOS "Package with-csharp" step (which
+      # broke v1.1.31 under APFS disk pressure, see build-macos job below). The
+      # Linux runner has ~84GB disk and ext4 (no fcopyfile EIO failure mode), so
+      # this isn't fixing an observed failure — it's preventive consistency so
+      # both platforms fail the same transient-copy-error way instead of one
+      # silently hard-failing on the first attempt.
       - name: Package with-csharp (Linux)
         if: runner.os == 'Linux'
         run: |
           mkdir -p staging/helpers/csharp
-          cp target/${{ matrix.target }}/release/codesearch staging/
+          for i in 1 2 3; do
+            if cp target/${{ matrix.target }}/release/codesearch staging/codesearch; then break; fi
+            echo "cp attempt $i/3 failed, retrying in 5s…"
+            df -h /
+            sleep 5
+          done
+          test -f staging/codesearch
           cp -r helpers-publish/* staging/helpers/csharp/
           tar czf ${{ matrix.artifact_csharp }} -C staging .
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Single source of truth for outstanding codesearch work. Items marked 🔒 live i
 
 ### Defensive / low priority
 
-- [ ] **D1: Apply same cp-retry pattern to Linux `with-csharp` step** in `release.yml` (lines 103-109) — same `cp ... staging/` pattern as the macOS step that broke v1.1.31. Linux has 84GB disk + ext4 (no `fcopyfile`), so low risk; preventive consistency only.
+- [x] **D1: Apply same cp-retry pattern to Linux `with-csharp` step** in `release.yml` — the "Package with-csharp (Linux)" step now retries the binary `cp` up to 3x with `df -h` diagnostics on failure and a hard `test -f` check, mirroring the macOS step's C3 pattern. Preventive consistency only (Linux runner has 84GB disk + ext4, no `fcopyfile` EIO failure mode) — no observed Linux failure, just aligning both platforms' failure behavior.
 
 ### Historical context (for C1/C2 above)
 


### PR DESCRIPTION
## Summary
- Mirrors the macOS "Package with-csharp" step's cp-retry pattern (3 attempts + df -h diagnostics + hard test -f check) onto the Linux "Package with-csharp (Linux)" step in `release.yml`.
- Preventive consistency only - no observed Linux failure (84GB disk + ext4, no fcopyfile EIO mode like APFS under pressure that broke v1.1.31's macOS packaging). Just aligns both platforms' failure behavior.

## Test plan
- [x] YAML validated, shell semantics verified against the macOS reference pattern (if-guarded cp doesn't trip errexit, test -f hard-fails on exhaustion)
- [x] Reviewed via reviewer agent - PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)