### PR TITLE
✨ feat: TypeScript SCIP indexing for find_impact + call-graph

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Single source of truth for outstanding codesearch work. Items marked 🔒 live i
 - [ ] **T2: Extract shared `build_remote_search_body(request, mode)`** in `src/mcp/mod.rs` — group fan-out and single-project fan-out (`FederationClient::search_project` at `src/federation/mod.rs:248`, call site `src/mcp/mod.rs:4317`) duplicate an 11-field `serde_json` body; drift risk. Extract to one shared builder.
 - [ ] **T3: Persist remote-project discovery** to a `remote_project_cache` in `repos.json` — TUI peer-`/status` discovery is currently in-memory only (last-known-good survives a blip, not a process restart).
 - [ ] **T4: 0-chunk status bug + TUI `i`/`d`/`f` diagnostics** — `/status` reports 0 chunks in some cases; TUI diagnostic keys need verification/fix. (TODO card `6a26cce1…`)
+- [ ] **T5: Extract shared `fuzzy_symbol_match`/`open_scip_env` between C# and TypeScript SCIP adapters** — `src/symbols/csharp.rs:1649`/`398` and `src/symbols/typescript.rs:152`/`269` currently carry byte-for-byte-copied logic (fuzzy symbol matching heuristic, LMDB env open/create-databases boilerplate). Flagged in the TypeScript SCIP indexing MVP final review as an Important, non-blocking finding — extract to a shared `src/symbols/scip_common.rs` (or similar) used by both adapters to avoid drift the next time either copy is bugfixed. Deliberately deferred out of the MVP branch to avoid touching stable, already-tested `csharp.rs` at the tail end of a large feature.
 
 ### Code — 🔒 separate worktrees, do NOT touch here
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "codesearch"
-version = "1.1.30"
+version = "1.1.31"
 dependencies = [
  "anyhow",
  "arroy",
@@ -658,6 +658,7 @@ dependencies = [
  "num_cpus",
  "ort",
  "pretty_assertions",
+ "protobuf",
  "rand 0.8.7",
  "ratatui",
  "rayon",
@@ -665,6 +666,7 @@ dependencies = [
  "reqwest 0.13.4",
  "rmcp",
  "schemars",
+ "scip",
  "serde",
  "serde_json",
  "sha2",
@@ -3349,6 +3351,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "pulp"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,6 +4149,15 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "scip"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26a72133c2d6fd45c9a3a343bcb3db2faa30f68f0919bfa3370ca85add5460c3"
+dependencies = [
+ "protobuf",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,10 @@ async-trait = "0.1"
 arroy = "0.5"
 heed = "0.20"
 bincode = "1.3"
+# SCIP symbol indexing — parses standard SCIP protobuf (.scip) emitted by
+# Sourcegraph indexers (e.g. scip-typescript) for the TypeScript symbol adapter.
+scip = "0.9"
+protobuf = "3.7"
 rand = "0.8"
 # Bumped floor from 1.5.0 to 1.8.0 for CVE patches (Aikido group: rmcp priority 82, 3 CVEs).
 # v2.x is available but is a breaking major bump — deferred.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,3 +141,4 @@ default = []
 cuda = ["ort/cuda"]        # Enable CUDA GPU acceleration (requires cuDNN)
 tensorrt = ["ort/tensorrt"] # Enable TensorRT acceleration (NVIDIA only)
 csharp_helper_integration = []  # Enable integration tests that require the scip-csharp helper binary
+typescript_helper_integration = []  # Enable integration tests that require scip-typescript (npx or CODESEARCH_SCIP_TYPESCRIPT)

--- a/PLAN_TYPESCRIPT_SCIP.md
+++ b/PLAN_TYPESCRIPT_SCIP.md
@@ -1,0 +1,239 @@
+# PLAN — TypeScript SCIP-indexering (find_impact + call-graph voor TS)
+
+> **Status:** PLANNING — geen code geschreven. Dit document is het oppakpunt voor de implementatie.
+> **Doel:** `find_impact` en de call-graph voor TypeScript (.ts/.tsx) laten werken zoals nu voor C#,
+> door de bestaande C#-SCIP-pijplijn te spiegelen met Sourcegraph `scip-typescript`.
+> **Branch-target:** PRs tegen `develop` (zie AGENTS.md gitflow).
+
+---
+
+## 1. Doel & scope
+
+**In scope**
+- `TypeScriptSymbolIndexer` implementeert het bestaande `SymbolIndexer`-trait, gevoed door `scip-typescript` (Sourcegraph, npm CLI).
+- `find_impact` (MCP-tool) routeert `.ts`/`.tsx`/`.mts`/`.cts` bestanden naar de TS-indexer.
+- Single-pass indexering: `rebuild()` schrijft defs **en** refs in één run naar LMDB (geen two-phase lazy model nodig — zie §3).
+- File-watcher pakt `.ts`/`.tsx`-wijzigingen op en triggert een TS-debounced rebuild.
+- Tests bewijzen dat `find_impact` op een TS-symbool alle call-sites teruggeeft.
+
+**Out of scope (follow-up)**
+- TS in de release-bundel shippen (`-with-ts` archive / `helpers/typescript/`) — optioneel, scip-typescript is een npm-package dus `npx` volstaat op de host.
+- Incrementele `RebuildScope::Files` voor TS (single-pass maakt full-rebuild op kleine/ middelgrote repo's al snel genoeg; incrementeel is een latere optimalisatie).
+
+---
+
+## 2. Hoe C#-SCIP nu werkt (baseline voor spiegeling)
+
+De TS-feature moet dezelfde raakvlakken gebruiken. Dit is de C#-status quo:
+
+### 2.1 Trait + registry (`src/symbols/mod.rs`)
+- **Trait `SymbolIndexer`** (regels 113-168): `language()`, `rebuild(repo_path, db_path, RebuildScope)`, `find_references(db_path, symbol)`, `find_references_by_position(db_path, file, line)`, `index_age()`, `is_available()`, `has_index()`, `applies_to(repo_path)`, `as_any()`.
+- **`SymbolIndexerRegistry`** (regels 172-232): houdt `Vec<Box<dyn SymbolIndexer>>`. `new()` (regel 181) registreert **uitsluitend** `CSharpSymbolIndexer::new()`. `get(language)` is case-insensitive. Methodes: `available_languages()`, `installed_languages()` (filter op `is_available()`), `has_index_for()`, `indexed_languages()`.
+- **Gedeelde types:** `SymbolReference{file,start_line,end_line,kind}`, `FindImpactResult`, `SymbolIndexError`, `RebuildScope` (Full | Project(PathBuf) | Files{changed,deleted}), `RebuildSummary`, `PrewarmSummary`.
+
+### 2.2 C#-adapter (`src/symbols/csharp.rs`, 1740 regels)
+`struct CSharpSymbolIndexer` implementeert het trait:
+- `detect_helper()` / `resolve_helper_path()` / `validate_helper_path()` (239-353) — zoekt `scip-csharp` via env `CODESEARCH_SCIP_CSHARP` of `helpers/csharp/`.
+- `find_solution(repo)` / `find_csproj_for_file(repo, file)` (355-391) — entrypoint-detectie (.sln/.csproj).
+- `open_scip_env(db_path)` (398-429) — opent LMDB env in `db_path/scip/`, pre-createert 5 named DBs.
+- `invoke_index_helper(...)` (433-504) — spawnt `scip-csharp index --solution X --output Y [--filter-project Z]`.
+- `invoke_find_refs_helper()` (509-609), `invoke_batch_find_refs_helper()` (954-1033) — **lazy ref-resolutie** subcommands.
+- Trait-impl (1124-1641): `language()`="csharp", `applies_to()` checkt .sln/.csproj, `is_available()` checkt `detect_helper()`.
+
+### 2.3 Two-phase lazy reference model (C#-specifiek — TS doet dit ANDERS)
+1. `rebuild()` → `scip-csharp index` emit **alleen definities** → snel.
+2. `find_references()` resolvet refs on-demand: defs uit LMDB → cache-check → cache-miss → `scip-csharp find-refs` voor dat symbool → cache resultaat.
+3. Pre-warm: `scip-csharp batch-find-refs` resolvet alle refs in één workspace-sessie.
+- **C# helper output = custom JSON** (NIET standaard SCIP protobuf), geparseerd door `parse_json_index` in `scip_parse.rs` (regels 136-197).
+
+### 2.4 LMDB-schema (`db_path/scip/`, 5 named DBs — keys namespaced door SCIP-symbol-scheme taal-prefix)
+| DB | key | value |
+|----|-----|-------|
+| `scip_symbols` | full SCIP symbol | bincode `Vec<StoredReference>` |
+| `scip_meta` | `"last_rebuild_ts"` | timestamp — **let op: NIET per-taal!** |
+| `scip_positions` | `"file:line"` | `Vec<symbol_keys>` |
+| `scip_simple_names` | simple name | `Vec<full_keys>` |
+| `scip_ref_cache` | symbol | bincode `Vec<StoredReference>` |
+
+### 2.5 Dispatch-punten die vandaag HARDCODED op C# staan (moeten generaliseren of een TS-tak krijgen)
+| Locatie | Regel | Wat het doet | Voor TS |
+|---------|-------|--------------|---------|
+| `src/mcp/mod.rs` find_impact | 6296 | file-ext → language: alleen `"cs"` | voeg `"ts"/"tsx"/"mts"/"cts"` → LANG_TYPESCRIPT |
+| `src/index/manager.rs` tracking | 1124, 1138, 1152 | trackt `.cs` modified/deleted/rename | voeg `.ts`/`.tsx` tracking toe |
+| `src/index/manager.rs` debounce-flush | 1236 | `reg.get(LANG_CSHARP)` (hardcoded) | dispatch generiek over registry OF parallelle TS-tak |
+| `src/index/manager.rs` notifier-type | — | `CSharpRebuildNotifier` callback | generaliseer of `TsRebuildNotifier` |
+| `src/serve/mod.rs` Phase-3 pre-warm | 1045 | `symbol_registry.get(LANG_CSHARP)` | pre-warm loop over alle registry-talen |
+| `src/serve/mod.rs` status | — | `CSharpIndexStatus::None/Ready` | generaliseer naar per-taal status-map |
+
+---
+
+## 3. Het TS-pad: spiegelen met scip-typescript
+
+### 3.1 Kritieke verschillen met C#
+| Aspect | C# (scip-csharp) | TS (scip-typescript) |
+|--------|------------------|----------------------|
+| **Output-formaat** | custom JSON | **standaard SCIP protobuf `.scip`** |
+| **Referentiemodel** | two-phase lazy (defs dan refs) | **single-pass** (defs + refs samen) |
+| **Entrypoint** | `.sln` / `.csproj` | `tsconfig.json` |
+| **Runtime** | self-contained .NET exe | Node CLI: `npx scip-typescript index` |
+| **find_references** | on-demand subprocess + cache | **alleen LMDB-lees** (geen subprocess) |
+
+### 3.2 Consequentie voor de implementatie
+1. **Protobuf-parse nodig.** scip-typescript is fixed binary-formaat → optie B (eigen TS-helper die JSON emit) is niet haalbaar. Keuze: de `scip` Rust-crate (Sourcegraph) toevoegen + een parser in nieuw `src/symbols/scip_proto.rs` die `.scip` → zelfde `ScipIndex`-shape mapt als `scip_parse.rs` nu voor JSON doet. Daarna is alle storage/resolution-code herbruikbaar.
+2. **Geen two-phase.** TS `rebuild()` vult in één pass `scip_symbols` + `scip_positions` + `scip_simple_names` én de refs. `find_references()` leest alleen LMDB (snel, geen subprocess). `scip_ref_cache` is voor TS leeg/overbodig — schrijven kan geen kwaad (keys namespaced).
+3. **`is_available()`** voor TS = detecteer of `scip-typescript` oplosbaar is via env `CODESEARCH_SCIP_TYPESCRIPT` (pad naar binary) of via `npx` op PATH + Node aanwezig.
+4. **`applies_to()`** voor TS = zoek een `tsconfig.json` in `repo_path` (root of één niveau diep).
+
+---
+
+## 4. Betrokken files & functies (concreet)
+
+### 4.1 Nieuwe files
+| File | Inhoud |
+|------|--------|
+| `src/symbols/scip_proto.rs` | `parse_scip_protobuf(bytes) -> ScipIndex` via `scip` crate. Herbruikt `ScipReference`/`ScipIndex` uit `scip_parse.rs`. |
+| `src/symbols/typescript.rs` | `struct TypeScriptSymbolIndexer` impl `SymbolIndexer`. Mirrot van `csharp.rs` structuur: `detect_helper()`, `find_tsconfig(repo)`, `open_scip_env()` (hergebruik), `invoke_index_helper()`, trait-impl. |
+| `tests/symbols_typescript_test.rs` | Gated integratie-test (zelfde gate-patroon als `symbols_csharp_test.rs`), TS-fixture. |
+| `tests/fixtures/ts-sample/` | Klein TS-project: `tsconfig.json` + 2-3 `.ts` files met een functie + call-sites. |
+
+### 4.2 Te wijzigen files (exacte raakvlakken)
+| File | Wijziging |
+|------|-----------|
+| `Cargo.toml` | voeg `scip` dependency toe (Sourcegraph crate) |
+| `src/symbols/mod.rs` regel 181 | `SymbolIndexerRegistry::new()` registreer óók `typescript::TypeScriptSymbolIndexer::new()` |
+| `src/symbols/mod.rs` | voeg `pub mod typescript;` + `pub mod scip_proto;` toe |
+| `src/constants.rs` | `LANG_TYPESCRIPT="typescript"`, `SCIP_TYPESCRIPT_HELPER_ENV="CODESEARCH_SCIP_TYPESCRIPT"`, `SCIP_TYPESCRIPT_HELPER_NAME="scip-typescript"`, `TS_DEBOUNCE_MS` |
+| `src/mcp/mod.rs` regel 6296 | find_impact auto-detect: map `"ts"/"tsx"/"mts"/"cts"` → `LANG_TYPESCRIPT` |
+| `src/mcp/mod.rs` regel 6236 | update tool-description (nu: "C# today") → voeg TS toe |
+| `src/index/manager.rs` regels 1124/1138/1152 | voeg `.ts`/`.tsx`-tracking velden toe (`ts_files_modified/deleted/last_event_time`) |
+| `src/index/manager.rs` regel 1236 | dispatch: óf registry-loop, óf parallelle TS-tak na C#-tak |
+| `src/index/manager.rs` notifier | generaliseer `CSharpRebuildNotifier` naar generieke `SymbolRebuildNotifier` (boxed callback) |
+| `src/serve/mod.rs` regel 1045 | Phase-3 pre-warm: itereren over registry in plaats van hardcoded `LANG_CSHARP` |
+| `src/serve/mod.rs` | vervang `CSharpIndexStatus` door `HashMap<String, IndexStatus>` (per-taal) |
+
+### 4.3 Niet-wijzigen (herbruikbaar)
+- `src/symbols/scip_parse.rs` structs (`ScipReference`, `ScipIndex`) — de protobuf-parser mapped hiernaartoe.
+- LMDB-schema (de 5 named DBs) — keys zijn namespaced door SCIP-symbol-scheme, dus C# en TS co-existeren in dezelfde `db_path/scip/`.
+- `RebuildScope`, `RebuildSummary`, `PrewarmSummary`, `SymbolReference`, `FindImpactResult` types.
+
+---
+
+## 5. Per-taal indexer-selectie (hoe taal-bepaling werkt)
+
+Twee routes die beide TS moeten ondersteunen:
+
+### 5.1 Expliciet (MCP find_impact `request.language`)
+`SymbolIndexerRegistry::get(language)` is case-insensitive en retourneert de indexer waarvan `language()` overeenkomt. `LANG_TYPESCRIPT="typescript"` → `registry.get("typescript")` werkt automatisch zodra geregistreerd.
+
+### 5.2 Auto-detect (file-extensie)
+`src/mcp/mod.rs:6296` — huidige map is **enkel** `"cs" → LANG_CSHARP`, else fallback naar eerste `installed_languages()`. **Toevoegen:**
+```rust
+match ext { "cs" => LANG_CSHARP, "ts"|"tsx"|"mts"|"cts" => LANG_TYPESCRIPT, _ => /* fallback */ }
+```
+Fallback = huidig gedrag (eerste installed language) — ongewijzigd.
+
+### 5.3 Applicability (welke indexer pakt een repo op?)
+- `applies_to(repo_path)` per indexer: C# checkt `.sln`/`.csproj`, TS checkt `tsconfig.json`.
+- `installed_languages()` filtert op `is_available()` (helper gevonden). Een host zonder Node/scip-typescript ziet TS simpelweg niet — geen crash.
+
+---
+
+## 6. Implementatie-stages (volgorde voor PR(s))
+
+| # | Stage | Doel | Validering |
+|---|-------|------|------------|
+| 1 | Protobuf-binding | `scip` crate + `scip_proto.rs::parse_scip_protobuf()` | unit-test: fixture `.scip` file → `ScipIndex` met verwacht # defs/refs |
+| 2 | TypeScriptSymbolIndexer | nieuw `typescript.rs`, implementeert trait | `cargo check` + `cargo clippy -D warnings` |
+| 3 | Registratie + constants | `mod.rs:181` registreer TS; `constants.rs` lang/env | `installed_languages()` bevat "typescript" als Node aanwezig |
+| 4 | find_impact auto-detect | `mcp/mod.rs:6296` map TS-extensies | handmatige smoke: find_impact op een TS-file |
+| 5 | File-watcher TS-tracking | `manager.rs` `.ts`/`.tsx` + dispatch | bewerk een `.ts` → debounce-flush triggert rebuild |
+| 6 | Tests | `tests/symbols_typescript_test.rs` + fixture | `cargo test --test symbols_typescript_test` groen |
+| 7 | Pre-warm + status generaliseren | `serve/mod.rs` registry-loop | startup log toont TS pre-warm |
+| 8 | (optioneel) Release-bundling | `release.yml` `-with-ts` | archive bevat scip-typescript binary |
+
+Stages 1-6 zijn de MVP (find_impact werkt op TS). 7-8 zijn afronding.
+
+---
+
+## 7. Test-strategie: bewijs dat find_impact op een TS-symbool alle call-sites teruggeeft
+
+### 7.1 Fixture-ontwerp (`tests/fixtures/ts-sample/`)
+```
+ts-sample/
+  tsconfig.json          # compilerOptions, minimal
+  src/
+    math.ts              # export function add(a, b)  ← TARGET definitie
+    consumer.ts          # import { add }; add(1,2); add(3,4)  ← 2 call-sites
+    other.ts             # import { add }; const r = add(5,6)  ← 1 call-site
+```
+Doel: `add` heeft 1 definitie + 3 call-sites verdeeld over 2 files.
+
+### 7.2 Integratie-test (`tests/symbols_typescript_test.rs`)
+Gated (zelfde patroon als `symbols_csharp_test.rs`: skip als `scip-typescript`/Node niet oplosbaar, geen real embedding nodig). Test-flow:
+1. `TypeScriptSymbolIndexer::new()`
+2. `.rebuild(&fixture_root, db_path, RebuildScope::Full)` → `assert!(summary.ok)`
+3. `.has_index(db_path)` → `true`
+4. `.find_references(db_path, "add")` (via simple_name) → `assert_eq!(refs.len(), 4)` (1 def + 3 calls) OF via full SCIP-symbol key
+5. `.find_references_by_position(db_path, "src/math.ts", <def-line>)` → retourneert de `add`-symbol key
+6. Cross-check: voor elke call-site file komt deze voor in `refs.iter().map(|r| r.file)`
+
+### 7.3 find_impact end-to-end (optioneel, handmatig)
+Na opstarten van `codesearch serve` met de TS-fixture als project: roep de `find_impact` MCP-tool aan met `{file:"src/math.ts", line:<def-line>}` en verifieer dat het resultaat overeenkomt met de integratie-test (4 occurrences over 3 files).
+
+### 7.4 Negative tests
+- `find_references` op een onbekend symbool → lege `Vec`, geen panic.
+- `.is_available()` op een host zonder Node → `false`; `installed_languages()` bevat geen "typescript".
+
+---
+
+## 8. Review — openstaande ontwerpkeuzes (beslissen vóór/ten tijde van implementatie)
+
+### 8.1 `scip_meta` is NIET per-taal (design-issue)
+`scip_meta` gebruikt key `"last_rebuild_ts"` zonder taal-prefix. Bij twee talen in dezelfde `db_path/scip/` overschrijven C# en TS elkaars timestamp. **Optie:** key namespacen `"last_rebuild_ts:csharp"` / `"last_rebuild_ts:typescript"`. Niet-breaking voor lezers die via `index_age()` gaan. **Beslissing:** namespacen — lokaal in `typescript.rs` een eigen key gebruiken, en later C# migreren.
+
+### 8.2 File-watcher dispatch: generaliseren vs. parallelle tak
+- **Optie A (generiek):** vervang hardcoded `reg.get(LANG_CSHARP)` (manager.rs:1236) door een loop `for lang in registry.indexed_languages()`. Schoon, schaalbaar naar meer talen, maar raakt `CSharpRebuildNotifier`-type (moet generiek `SymbolRebuildNotifier` worden) — grotere refactor.
+- **Optie B (parallelle tak):** voeg een tweede `if`-blok voor TS toe, spiegelend het C#-blok. Minder netjes, lokaal, lager risico.
+- **Beslissing:** start met Optie B (snel MVP), refactor naar A zodra er een derde taal komt. Documenteer als TODO.
+
+### 8.3 scip-typescript distributie: `npx` vs. gebundelde binary
+- C# shipt een self-contained exe in `helpers/csharp/` + `-with-csharp` release-archives.
+- scip-typescript is een npm-package: `npx scip-typescript` werkt als Node op PATH staat. Geen bundling nodig voor development. Voor offline/air-gapped deploy: optie om `npm pack`-tarball te bundelen (follow-up, niet MVP).
+- **Beslissing:** MVP = `npx` (env `CODESEARCH_SCIP_TYPESCRIPT` voor override-pad). Bundling = out of scope (§1).
+
+### 8.4 Incrementele rebuild (RebuildScope::Files) voor TS
+C# ondersteunt `Files{changed,deleted}` via csproj-groepering + `--filter-project`. scip-typescript heeft geen file-filter flag — herbouwt steeds de hele tsconfig-projectroot. **Beslissing:** MVP ondersteunt alleen `Full`; `Files` valt terug op `Full` (log + proceed). Voor grote monorepo's is dit later te optimaliseren (per-tsconfig groeperen, zie §8.5).
+
+### 8.5 Monorepo met meerdere tsconfig.json
+`applies_to()` zoekt nu één `tsconfig.json`. Een monorepo met `packages/*/tsconfig.json` vereist het C#-equivalent van `find_csproj_for_file` → een `find_tsconfig_for_file(repo, file)`. **Beslissing:** MVP pakt root-tsconfig; per-file-tsconfig-resolutie = follow-up. In scope zetten als de test-fixture dat meteen nodig maakt.
+
+### 8.6 Pre-warm: heeft TS het nodig?
+TS heeft geen two-phase lazy model → `rebuild()` populate direct alle refs → geen `batch-find-refs` pre-warm nodig. De registry-loop in `serve/mod.rs:1045` mag TS dus overslaan of gewoon `rebuild` aanroepen als index ontbreekt/stale is. **Beslissing:** registry-loop roept per indexer een `prewarm()`-methode aan; C# doet zijn batch-find-refs, TS is no-op (of `rebuild` als index koud). Voeg optionele default-methode `prewarm()` toe aan het trait.
+
+### 8.7 `scip` crate keuze
+Sourcegraph publiceert een `scip` Rust-crate (protobuf bindings + helpers). Alternatief: handmatige `prost`-build tegen de `.proto`. **Beslissing:** gebruik de `scip` crate (onderhouden, zelfde schema als scip-typescript output). Lock versie in `Cargo.toml`; als de crate afwijkt, val terug op `prost`-build.
+
+---
+
+## 9. Acceptatie-criteria (MVP = stages 1-6)
+- [ ] `cargo check` + `cargo clippy -D warnings` groen.
+- [ ] `cargo test --test symbols_typescript_test` groen op een host met Node + scip-typescript.
+- [ ] `find_impact` MCP-tool retourneert voor een TS-functie alle call-sites (≥3 over 2 files in de fixture).
+- [ ] `find_impact` auto-detect routeert `.ts`/`.tsx` naar TS-indexer (geen C#-fallback).
+- [ ] `installed_languages()` bevat "typescript" als Node aanwezig, niet anders.
+- [ ] Host zonder Node: geen crash, TS-indexer gewoon afwezig.
+- [ ] C#-pijplijn ongewijzigd werken (geen regressie — bestaande C#-tests groen).
+
+---
+
+## 10. Verwijzingen
+- C# trait + registry: `src/symbols/mod.rs:113-232`
+- C# adapter (referentie-impl): `src/symbols/csharp.rs`
+- JSON-parser (shape om naartoe te mappen): `src/symbols/scip_parse.rs:136-197`
+- find_impact MCP-tool: `src/mcp/mod.rs:6238-6369` (taal-detect 6291-6329)
+- File-watcher dispatch: `src/index/manager.rs:1124-1340`
+- Startup pre-warm: `src/serve/mod.rs:1045`
+- Constants: `src/constants.rs` (LANG_CSHARP, SCIP_CSHARP_*, HELPERS_SUBDIR)
+- Bestaande tests: `tests/symbols_csharp_test.rs`, `helpers/csharp/tests/IndexerTests.cs`
+- scip-typescript (Sourcegraph): https://github.com/sourcegraph/scip-typescript
+- scip Rust-crate: https://github.com/sourcegraph/scip-rust

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -472,6 +472,11 @@ pub const SCIP_TYPESCRIPT_HELPER_ENV: &str = "CODESEARCH_SCIP_TYPESCRIPT";
 /// so both adapters can safely share the same `scip_meta` table if ever merged.
 pub const SCIP_TYPESCRIPT_REBUILD_TIMESTAMP_KEY: &str = "last_rebuild_ts:typescript";
 
+/// Debounce window (ms) for the TypeScript file-watcher symbol rebuild.
+/// Mirrors `SCIP_CSHARP_DEBOUNCE_MS` — a single quiet-period flush avoids
+/// spawning `scip-typescript` once per saved file during a burst of edits.
+pub const SCIP_TYPESCRIPT_DEBOUNCE_MS: u64 = 60_000; // 60 seconds
+
 /// Environment variable controlling phase-2 C# SCIP rebuild concurrency.
 /// Parsed in `ServeState::csharp_scip_concurrency()` and clamped to [1, 4].
 pub const CSHARP_SCIP_CONCURRENCY_ENV: &str = "CSHARP_SCIP_CONCURRENCY";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -459,6 +459,19 @@ pub const SCIP_REF_CACHE_DB_NAME: &str = "scip_ref_cache";
 /// Used as a key in `SymbolIndexerRegistry` lookups and TUI status maps.
 pub const LANG_CSHARP: &str = "csharp";
 
+/// Language identifier for the TypeScript symbol indexer.
+/// Used as a key in `SymbolIndexerRegistry` lookups and TUI status maps.
+pub const LANG_TYPESCRIPT: &str = "typescript";
+
+/// Environment variable override for the `scip-typescript` helper/CLI path.
+/// When unset, the indexer falls back to `npx scip-typescript`.
+pub const SCIP_TYPESCRIPT_HELPER_ENV: &str = "CODESEARCH_SCIP_TYPESCRIPT";
+
+/// LMDB metadata key for the TypeScript indexer's last rebuild timestamp.
+/// Namespaced per-language (unlike C#'s un-namespaced `SCIP_REBUILD_TIMESTAMP_KEY`)
+/// so both adapters can safely share the same `scip_meta` table if ever merged.
+pub const SCIP_TYPESCRIPT_REBUILD_TIMESTAMP_KEY: &str = "last_rebuild_ts:typescript";
+
 /// Environment variable controlling phase-2 C# SCIP rebuild concurrency.
 /// Parsed in `ServeState::csharp_scip_concurrency()` and clamped to [1, 4].
 pub const CSHARP_SCIP_CONCURRENCY_ENV: &str = "CSHARP_SCIP_CONCURRENCY";

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -17,8 +17,8 @@
 
 use crate::cache::{normalize_path, normalize_path_str};
 use crate::constants::{
-    DB_DIR_NAME, DEFAULT_FSW_DEBOUNCE_MS, FILE_META_DB_NAME, LANG_CSHARP, SCIP_CSHARP_DEBOUNCE_MS,
-    WRITER_LOCK_FILE,
+    DB_DIR_NAME, DEFAULT_FSW_DEBOUNCE_MS, FILE_META_DB_NAME, LANG_CSHARP, LANG_TYPESCRIPT,
+    SCIP_CSHARP_DEBOUNCE_MS, SCIP_TYPESCRIPT_DEBOUNCE_MS, WRITER_LOCK_FILE,
 };
 use crate::embed::ModelType;
 use crate::fts::FtsStore;
@@ -281,6 +281,16 @@ pub struct IndexManager {
     stores: Arc<SharedStores>,
     /// Per-language symbol indexer registry (C# etc.)
     symbol_registry: Arc<SymbolIndexerRegistry>,
+}
+
+/// Returns true if `path` has one of the TypeScript extensions tracked by the
+/// file-watcher's symbol-rebuild debounce (`.ts`, `.tsx`, `.mts`, `.cts`).
+/// Mirrors the inline `.cs` extension check used for the C# adapter.
+fn is_ts_extension(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("ts") | Some("tsx") | Some("mts") | Some("cts")
+    )
 }
 
 impl IndexManager {
@@ -1053,6 +1063,18 @@ impl IndexManager {
             let mut cs_last_event_time: Option<std::time::Instant> = None;
             let cs_debounce = std::time::Duration::from_millis(SCIP_CSHARP_DEBOUNCE_MS);
 
+            // Symbol indexer debounce: .ts/.tsx/.mts/.cts files are buffered separately
+            // and flushed after SCIP_TYPESCRIPT_DEBOUNCE_MS of quiet time. Unlike C#'s
+            // per-.csproj grouping, the TypeScript MVP only supports a single root
+            // tsconfig.json (no monorepo multi-project resolution), so any tracked
+            // change simply triggers one full rebuild — there is no per-file grouping
+            // to compute, and `ts_files_modified`/`ts_files_deleted` only exist to
+            // decide *whether* to flush and to log counts.
+            let mut ts_files_modified: HashSet<PathBuf> = HashSet::new();
+            let mut ts_files_deleted: HashSet<PathBuf> = HashSet::new();
+            let mut ts_last_event_time: Option<std::time::Instant> = None;
+            let ts_debounce = std::time::Duration::from_millis(SCIP_TYPESCRIPT_DEBOUNCE_MS);
+
             loop {
                 // Check if shutdown was requested
                 if cancel_token.is_cancelled() {
@@ -1087,6 +1109,9 @@ impl IndexManager {
                             cs_files_modified.clear();
                             cs_files_deleted.clear();
                             cs_last_event_time = None;
+                            ts_files_modified.clear();
+                            ts_files_deleted.clear();
+                            ts_last_event_time = None;
                         }
                     }
                 }
@@ -1126,6 +1151,10 @@ impl IndexManager {
                                     cs_files_deleted.remove(&p);
                                     cs_files_modified.insert(p);
                                     cs_last_event_time = Some(now);
+                                } else if is_ts_extension(&p) {
+                                    ts_files_deleted.remove(&p);
+                                    ts_files_modified.insert(p);
+                                    ts_last_event_time = Some(now);
                                 }
                             }
                             FileEvent::Deleted(p) => {
@@ -1139,6 +1168,10 @@ impl IndexManager {
                                     cs_files_modified.remove(&p);
                                     cs_files_deleted.insert(p);
                                     cs_last_event_time = Some(now);
+                                } else if is_ts_extension(&p) {
+                                    ts_files_modified.remove(&p);
+                                    ts_files_deleted.insert(p);
+                                    ts_last_event_time = Some(now);
                                 }
                             }
                             FileEvent::Renamed(old_p, new_p) => {
@@ -1162,6 +1195,22 @@ impl IndexManager {
                                         cs_files_modified.insert(new_p);
                                     }
                                     cs_last_event_time = Some(now);
+                                } else {
+                                    // Track .ts/.tsx/.mts/.cts renames: old path is a
+                                    // deletion, new path is a modification.
+                                    let old_is_ts = is_ts_extension(&old_p);
+                                    let new_is_ts = is_ts_extension(&new_p);
+                                    if old_is_ts || new_is_ts {
+                                        if old_is_ts {
+                                            ts_files_modified.remove(&old_p);
+                                            ts_files_deleted.insert(old_p);
+                                        }
+                                        if new_is_ts {
+                                            ts_files_deleted.remove(&new_p);
+                                            ts_files_modified.insert(new_p);
+                                        }
+                                        ts_last_event_time = Some(now);
+                                    }
                                 }
                             }
                         }
@@ -1368,6 +1417,79 @@ impl IndexManager {
                                     }
                                     // Clear "Indexing" now that all groups are done
                                     if let Some(ref cb) = indexing_cb_scip {
+                                        cb(false);
+                                    }
+                                }
+                            });
+                        }
+                    }
+                }
+
+                // Check if we should flush the .ts/.tsx/.mts/.cts symbol rebuild debounce.
+                // Unlike the C# path there is no per-.csproj grouping: TypeScript MVP
+                // only supports a single root tsconfig.json, so any tracked change
+                // simply triggers one full rebuild via the registry's TypeScript
+                // indexer (RebuildScope::Files would fall back to Full internally
+                // anyway — passing Full directly here is more honest about what
+                // actually happens).
+                let has_ts_changes = !ts_files_modified.is_empty() || !ts_files_deleted.is_empty();
+                if has_ts_changes {
+                    if let Some(ts_last) = ts_last_event_time {
+                        let elapsed = now.duration_since(ts_last);
+                        if elapsed >= ts_debounce {
+                            let modified_count = ts_files_modified.len();
+                            let deleted_count = ts_files_deleted.len();
+                            ts_files_modified.clear();
+                            ts_files_deleted.clear();
+                            ts_last_event_time = None;
+
+                            info!(
+                                "🔬 {} modified + {} deleted .ts/.tsx/.mts/.cts file(s), triggering full symbol rebuild (after {}s debounce)",
+                                modified_count, deleted_count,
+                                ts_debounce.as_secs()
+                            );
+
+                            let reg = symbol_registry.clone();
+                            let rp = path.clone();
+                            let dp = db_path.clone();
+                            let indexing_cb_ts = indexing_cb.clone();
+                            tokio::task::spawn_blocking(move || {
+                                if let Some(indexer) = reg.get(LANG_TYPESCRIPT) {
+                                    if !indexer.applies_to(&rp) {
+                                        info!(
+                                            "🔬 TypeScript symbol rebuild skipped: not applicable (no tsconfig.json)"
+                                        );
+                                        return;
+                                    }
+                                    if !indexer.is_available() {
+                                        info!(
+                                            "🔬 TypeScript symbol rebuild skipped: scip-typescript not available"
+                                        );
+                                        return;
+                                    }
+
+                                    // Signal "Indexing" to the TUI now that we know
+                                    // a real SCIP rebuild will actually run.
+                                    if let Some(ref cb) = indexing_cb_ts {
+                                        cb(true);
+                                    }
+
+                                    match indexer.rebuild(&rp, &dp, RebuildScope::Full) {
+                                        Ok(summary) => {
+                                            info!(
+                                                "✅ TypeScript symbol rebuild complete: {} symbols, {} refs in {}ms",
+                                                summary.symbols_indexed,
+                                                summary.references_stored,
+                                                summary.duration_ms
+                                            );
+                                        }
+                                        Err(e) => {
+                                            warn!("⚠️ TypeScript symbol rebuild failed: {}", e);
+                                        }
+                                    }
+
+                                    // Clear "Indexing" regardless of outcome
+                                    if let Some(ref cb) = indexing_cb_ts {
                                         cb(false);
                                     }
                                 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -6229,11 +6229,13 @@ impl CodesearchService {
     ///
     /// Uses language-specific semantic analysis (SCIP) to find all references to a symbol,
     /// enabling agents to plan refactors with IDE-class accuracy instead of text-matching
-    /// grep heuristics. C# is supported today (via the bundled `scip-csharp` helper); the
-    /// architecture is language-agnostic and more languages will follow. For languages not
-    /// yet supported, use `find` with `kind="usages"` as a text-based fallback.
+    /// grep heuristics. C# is supported today (via the bundled `scip-csharp` helper);
+    /// TypeScript is also supported (via `scip-typescript`, resolved through `npx` or
+    /// `CODESEARCH_SCIP_TYPESCRIPT`). The architecture is language-agnostic and more
+    /// languages will follow. For languages not yet supported, use `find` with
+    /// `kind="usages"` as a text-based fallback.
     #[tool(
-        description = "Symbol impact analysis — find all references to a symbol with IDE-class precision (SCIP).\n\nReturns transitive call-sites with file/line precision, enabling agents to plan refactors without missing a caller. More accurate than text-based `find kind=\"usages\"` because it understands the language semantics.\n\nInput variants:\n- By name: `{ \"symbol_name\": \"FieldDefinition.Validate\", \"project\": \"myrepo\" }`\n- By position: `{ \"file\": \"src/Validation/FieldDefinition.cs\", \"line\": 42, \"project\": \"myrepo\" }`\n\nLanguages: C# today (requires the `scip-csharp` helper, bundled in `-with-csharp` releases). For Rust/Python/Go/etc., use `find` with `kind=\"usages\"` as a text-based fallback until SCIP backends for those languages ship.\n\nIMPORTANT (multi-repo): always specify `project` (single repo). Omitting `project` in multi-repo mode returns a `scope_required` error."
+        description = "Symbol impact analysis — find all references to a symbol with IDE-class precision (SCIP).\n\nReturns transitive call-sites with file/line precision, enabling agents to plan refactors without missing a caller. More accurate than text-based `find kind=\"usages\"` because it understands the language semantics.\n\nInput variants:\n- By name: `{ \"symbol_name\": \"FieldDefinition.Validate\", \"project\": \"myrepo\" }`\n- By position: `{ \"file\": \"src/Validation/FieldDefinition.cs\", \"line\": 42, \"project\": \"myrepo\" }`\n\nLanguages: C# (requires the `scip-csharp` helper, bundled in `-with-csharp` releases) and TypeScript (requires `scip-typescript`, resolved via `npx` or `CODESEARCH_SCIP_TYPESCRIPT`). For Rust/Python/Go/etc., use `find` with `kind=\"usages\"` as a text-based fallback until SCIP backends for those languages ship.\n\nIMPORTANT (multi-repo): always specify `project` (single repo). Omitting `project` in multi-repo mode returns a `scope_required` error."
     )]
     async fn find_impact(
         &self,
@@ -6294,6 +6296,9 @@ impl CodesearchService {
                 let ext = Path::new(f).extension()?.to_str()?.to_lowercase();
                 match ext.as_str() {
                     "cs" => Some(crate::constants::LANG_CSHARP.to_string()),
+                    "ts" | "tsx" | "mts" | "cts" => {
+                        Some(crate::constants::LANG_TYPESCRIPT.to_string())
+                    }
                     _ => None,
                 }
             })
@@ -6315,10 +6320,10 @@ impl CodesearchService {
                 let installed = registry.installed_languages();
                 if installed.is_empty() {
                     return Ok(CallToolResult::success(vec![Content::text(
-                        "No symbol indexers installed. Install the `scip-csharp` helper for C# support.".to_string(),
+                        "No symbol indexers installed. Install the `scip-csharp` helper for C# support, or `scip-typescript` (via npx) for TypeScript support.".to_string(),
                     )]));
                 }
-                // Use the first installed language (MVP: only C#)
+                // Use the first installed language (MVP: C# or TypeScript)
                 match registry.get(&installed[0]) {
                     Some(i) => i,
                     None => {

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -38,10 +38,10 @@ use crate::constants::{
     ALLOWED_HOSTS_ENV, ALLOWED_ROOTS_ENV, CHUNK_PATH, CSHARP_PREWARM_ENABLED_ENV,
     CSHARP_PREWARM_MAX_SYMBOLS, CSHARP_SCIP_CONCURRENCY_DEFAULT, CSHARP_SCIP_CONCURRENCY_ENV,
     DB_DIR_NAME, DEFAULT_SERVE_PORT, DISABLE_HOST_VALIDATION_ENV, EXPLORE_PATH, FIND_PATH,
-    HEALTHZ_PATH, HEALTH_PATH, LANG_CSHARP, MAX_INDEXING_SECS, MAX_INDEXING_SECS_ENV,
-    MCP_ENDPOINT_PATH, PERSIST_DEBOUNCE_SECS, REAPER_INTERVAL_SECS, REMOTES_PATH,
-    REPO_IDLE_TIMEOUT_ENV, REPO_IDLE_TIMEOUT_SECS, SEARCH_PATH, SERVE_API_KEY_ENV, SERVE_PORT_ENV,
-    STATUS_PATH,
+    HEALTHZ_PATH, HEALTH_PATH, LANG_CSHARP, LANG_TYPESCRIPT, MAX_INDEXING_SECS,
+    MAX_INDEXING_SECS_ENV, MCP_ENDPOINT_PATH, PERSIST_DEBOUNCE_SECS, REAPER_INTERVAL_SECS,
+    REMOTES_PATH, REPO_IDLE_TIMEOUT_ENV, REPO_IDLE_TIMEOUT_SECS, SEARCH_PATH, SERVE_API_KEY_ENV,
+    SERVE_PORT_ENV, STATUS_PATH,
 };
 use crate::db_discovery::repos::{config_dir, ReposConfig};
 use crate::index::{CSharpRebuildNotifier, IndexManager, IndexingStatusCallback, SharedStores};
@@ -103,6 +103,7 @@ pub(crate) struct RepoStatusInfo {
     pub(crate) tool_call_count: u64,
     pub(crate) csharp_index: CSharpIndexStatus,
     pub(crate) csharp_error: Option<String>,
+    pub(crate) typescript_index: CSharpIndexStatus,
 }
 
 impl RepoStateLabel {
@@ -2226,6 +2227,24 @@ impl ServeState {
                 None
             };
 
+            // TypeScript index status. Unlike C#, there is no live status cache
+            // populated during rebuilds yet (stage 7 work), so we always probe:
+            // helper available (npx/scip-typescript resolvable) + index dir
+            // exists → Ready; otherwise None. The TUI icon reflects "an index
+            // exists", which is exactly what matters for discoverability.
+            let registry = &self.symbol_registry;
+            let typescript_index = {
+                let has_ts_helper = registry
+                    .get(LANG_TYPESCRIPT)
+                    .map(|i| i.is_available())
+                    .unwrap_or(false);
+                if has_ts_helper && registry.has_index_for(LANG_TYPESCRIPT, &db_path) {
+                    CSharpIndexStatus::Ready
+                } else {
+                    CSharpIndexStatus::None
+                }
+            };
+
             result.push((
                 alias.clone(),
                 RepoStatusInfo {
@@ -2235,6 +2254,7 @@ impl ServeState {
                     tool_call_count,
                     csharp_index,
                     csharp_error,
+                    typescript_index,
                 },
             ));
         }
@@ -2519,6 +2539,12 @@ async fn status_handler(
                 CSharpIndexStatus::Error => "error",
                 CSharpIndexStatus::Indexing => "indexing",
             };
+            let ts_str = match info.typescript_index {
+                CSharpIndexStatus::None => "none",
+                CSharpIndexStatus::Ready => "ready",
+                CSharpIndexStatus::Error => "error",
+                CSharpIndexStatus::Indexing => "indexing",
+            };
             json!({
                 "alias": alias,
                 "status": status_str,
@@ -2528,6 +2554,7 @@ async fn status_handler(
                 "tool_call_count": info.tool_call_count,
                 "csharp_index": csharp_str,
                 "csharp_error": info.csharp_error,
+                "typescript_index": ts_str,
             })
         })
         .collect();
@@ -2578,12 +2605,19 @@ async fn status_handler(
         .map(|i| i.is_available())
         .unwrap_or(false);
 
+    let ts_helper = state
+        .symbol_registry
+        .get(LANG_TYPESCRIPT)
+        .map(|i| i.is_available())
+        .unwrap_or(false);
+
     AxumJson(json!({
         "version": env!("CARGO_PKG_VERSION"),
         "repos": repo_json,
         "active_sessions": active_sessions,
         "cpu_percent": cpu,
         "csharp_helper": csharp_helper,
+        "ts_helper": ts_helper,
         "uptime_secs": uptime_secs,
     }))
 }

--- a/src/serve/tui.rs
+++ b/src/serve/tui.rs
@@ -23,7 +23,7 @@ use super::tui_common::{
 };
 use super::ServeState;
 use crate::cli::doctor;
-use crate::constants::{DB_DIR_NAME, LANG_CSHARP};
+use crate::constants::{DB_DIR_NAME, LANG_CSHARP, LANG_TYPESCRIPT};
 use crate::index::IndexManager;
 
 /// Footer flash shown when a local-index action key (doctor / reindex / remove)
@@ -137,6 +137,12 @@ async fn run_tui_loop(
             .map(|i| i.is_available())
             .unwrap_or(false);
 
+        let ts_helper = state
+            .symbol_registry
+            .get(LANG_TYPESCRIPT)
+            .map(|i| i.is_available())
+            .unwrap_or(false);
+
         // Expire a stale flash, then borrow the live message (if any) for render.
         if flash
             .as_ref()
@@ -167,6 +173,7 @@ async fn run_tui_loop(
                 active,
                 &cpu,
                 csharp_helper,
+                ts_helper,
                 flash_msg,
             );
 
@@ -377,6 +384,14 @@ fn map_repo_rows(
             }
             .to_string();
 
+            let ts_str = match info.typescript_index {
+                super::CSharpIndexStatus::Ready => "ready",
+                super::CSharpIndexStatus::Indexing => "indexing",
+                super::CSharpIndexStatus::Error => "error",
+                super::CSharpIndexStatus::None => "none",
+            }
+            .to_string();
+
             let lock_mode = match info.status {
                 super::RepoStateLabel::Open | super::RepoStateLabel::Indexing => "write",
                 super::RepoStateLabel::Warm | super::RepoStateLabel::Readonly => "read",
@@ -394,6 +409,7 @@ fn map_repo_rows(
                 status: status_str,
                 csharp_index: csharp_str,
                 csharp_error: info.csharp_error.clone(),
+                typescript_index: ts_str,
                 changes: info.changes,
                 tool_call_count: info.tool_call_count,
                 last_tool_call: info.last_tool_call.clone(),
@@ -511,6 +527,7 @@ async fn discover_remote_rows(
                     .unwrap_or_else(|| "warm".to_string()),
                 csharp_index: "none".to_string(),
                 csharp_error: None,
+                typescript_index: "none".to_string(),
                 changes: st.map(|s| s.changes).unwrap_or(0),
                 tool_call_count: st.and_then(|s| s.tool_call_count).unwrap_or(0),
                 last_tool_call: st.and_then(|s| s.last_tool_call.clone()),

--- a/src/serve/tui_common.rs
+++ b/src/serve/tui_common.rs
@@ -58,6 +58,8 @@ pub struct RepoRow {
     pub csharp_index: String,
     /// Optional C# error message
     pub csharp_error: Option<String>,
+    /// TypeScript index status: same vocabulary as `csharp_index`.
+    pub typescript_index: String,
     /// Pending file changes detected by file watcher
     pub changes: u64,
     /// Total MCP tool calls since serve start
@@ -322,10 +324,14 @@ pub fn render_table(
     let max_alias_w = repos
         .iter()
         .map(|r| {
-            let extra = match r.csharp_index.as_str() {
-                "ready" | "error" | "indexing" => 4,
-                _ => 0,
-            };
+            // Each indicator (" C#·" / " TS·") is 4 display cols; account for both.
+            let mut extra = 0usize;
+            if matches!(r.csharp_index.as_str(), "ready" | "error" | "indexing") {
+                extra += 4;
+            }
+            if matches!(r.typescript_index.as_str(), "ready" | "error" | "indexing") {
+                extra += 4;
+            }
             r.alias.len() + extra
         })
         .max()
@@ -353,7 +359,7 @@ pub fn render_table(
             let lock_cell = lock_cell(&repo.lock_mode);
 
             // Alias text with optional C# indicator suffix, plus its base style.
-            let (alias_text, mut alias_style) = match repo.csharp_index.as_str() {
+            let (mut alias_text, mut alias_style) = match repo.csharp_index.as_str() {
                 "ready" => (
                     format!("{} C#·", repo.alias),
                     Style::default().fg(Color::White),
@@ -374,6 +380,19 @@ pub fn render_table(
                 }
                 _ => (repo.alias.clone(), Style::default().fg(Color::White)),
             };
+
+            // Append the TypeScript indicator alongside the C# one when a TS
+            // index exists. The alias column is the canonical multi-language
+            // symbol-index indicator (the status cell only carries C#).
+            match repo.typescript_index.as_str() {
+                "ready" => alias_text.push_str(" TS·"),
+                "error" => {
+                    alias_text.push_str(" TS!");
+                    alias_style = alias_style.fg(Color::Red);
+                }
+                "indexing" => alias_text.push_str(" TS…"),
+                _ => {}
+            }
 
             // Red bold alias if the repo is in an error state.
             if repo.status == "error" {
@@ -645,6 +664,7 @@ pub fn render_footer(
     active: u64,
     cpu: &str,
     csharp_helper: bool,
+    ts_helper: bool,
     flash: Option<&str>,
 ) {
     let selected = table_state.selected().unwrap_or(0);
@@ -657,7 +677,7 @@ pub fn render_footer(
     let sessions_str = format!("Sessions: {}", active);
     let cpu_str = format!("CPU: {}", cpu);
 
-    let right_len = cpu_str.len() + sessions_str.len() + 3 + "C# │ ".len();
+    let right_len = cpu_str.len() + sessions_str.len() + 3 + "C# │ ".len() + "TS │ ".len();
 
     let footer_inner = area.inner(Margin {
         vertical: 0,
@@ -711,8 +731,15 @@ pub fn render_footer(
         Span::styled("C# │ ", Style::default().fg(Color::DarkGray))
     };
 
+    let ts_indicator = if ts_helper {
+        Span::styled("TS │ ", Style::default().fg(Color::Green))
+    } else {
+        Span::styled("TS │ ", Style::default().fg(Color::DarkGray))
+    };
+
     let right_line = Line::from(vec![
         csharp_indicator,
+        ts_indicator,
         Span::styled(cpu_str, Style::default().fg(Color::Green)),
         Span::styled(" │ ", Style::default().fg(Color::DarkGray)),
         Span::styled(sessions_str, Style::default().fg(Color::Cyan)),

--- a/src/serve/tui_remote.rs
+++ b/src/serve/tui_remote.rs
@@ -34,6 +34,8 @@ struct StatusResponse {
     cpu_percent: String,
     csharp_helper: bool,
     #[serde(default)]
+    ts_helper: bool,
+    #[serde(default)]
     uptime_secs: u64,
 }
 
@@ -49,6 +51,8 @@ struct RepoInfo {
     #[serde(default)]
     csharp_error: Option<String>,
     #[serde(default)]
+    typescript_index: String,
+    #[serde(default)]
     path: String,
 }
 
@@ -59,6 +63,7 @@ impl RepoInfo {
             status: self.status.clone(),
             csharp_index: self.csharp_index.clone(),
             csharp_error: self.csharp_error.clone(),
+            typescript_index: self.typescript_index.clone(),
             changes: self.changes,
             tool_call_count: self.tool_call_count,
             last_tool_call: self.last_tool_call.clone(),
@@ -170,6 +175,7 @@ async fn run_remote_tui_loop(
         let active = data.as_ref().map(|d| d.active_sessions).unwrap_or(0);
         let cpu = data.as_ref().map(|d| d.cpu_percent.as_str()).unwrap_or("—");
         let csharp_helper = data.as_ref().map(|d| d.csharp_helper).unwrap_or(false);
+        let ts_helper = data.as_ref().map(|d| d.ts_helper).unwrap_or(false);
         let uptime_str = data
             .as_ref()
             .map(|d| tui_common::format_uptime_secs(d.uptime_secs))
@@ -197,6 +203,7 @@ async fn run_remote_tui_loop(
                     active,
                     cpu,
                     csharp_helper,
+                    ts_helper,
                     None,
                 );
             } else {
@@ -213,7 +220,17 @@ async fn run_remote_tui_loop(
                     ),
                 ]));
                 f.render_widget(connecting, chunks[1]);
-                tui_common::render_footer(f, chunks[3], &[], &table_state, 0, "—", false, None);
+                tui_common::render_footer(
+                    f,
+                    chunks[3],
+                    &[],
+                    &table_state,
+                    0,
+                    "—",
+                    false,
+                    false,
+                    None,
+                );
             }
 
             // Render overlay on top if active

--- a/src/symbols/mod.rs
+++ b/src/symbols/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod csharp;
 pub mod scip_parse;
+pub mod scip_proto;
 
 use std::path::{Path, PathBuf};
 

--- a/src/symbols/mod.rs
+++ b/src/symbols/mod.rs
@@ -10,6 +10,7 @@
 pub mod csharp;
 pub mod scip_parse;
 pub mod scip_proto;
+pub mod typescript;
 
 use std::path::{Path, PathBuf};
 
@@ -179,7 +180,10 @@ impl SymbolIndexerRegistry {
     /// Create a registry with default (MVP) indexers.
     pub fn new() -> Self {
         Self {
-            indexers: vec![Box::new(csharp::CSharpSymbolIndexer::new())],
+            indexers: vec![
+                Box::new(csharp::CSharpSymbolIndexer::new()),
+                Box::new(typescript::TypeScriptSymbolIndexer::new()),
+            ],
         }
     }
 

--- a/src/symbols/scip_proto.rs
+++ b/src/symbols/scip_proto.rs
@@ -1,0 +1,287 @@
+//! Standard SCIP protobuf parsing.
+//!
+//! Parses `.scip` files emitted by Sourcegraph indexers such as
+//! `scip-typescript` into the same `ScipIndex` shape the C# JSON parser
+//! (`scip_parse.rs`) produces, so all downstream storage/resolution code is
+//! reusable. Unlike the C# helper's custom JSON, this reads the canonical
+//! SCIP protobuf wire format via the `scip` crate (rust-protobuf bindings).
+//!
+//! This module is not wired into `SymbolIndexerRegistry` yet — that happens
+//! in stage 3 (`TypeScriptSymbolIndexer`, stage 2, will call
+//! `parse_scip_protobuf`). Until then everything here is only exercised by
+//! its own unit tests, which trips `-D dead-code` under
+//! `cargo clippy --all-targets`. Remove this module-wide allow once
+//! `typescript.rs` calls into this module.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use protobuf::Message;
+use scip::types::Index as ScipProtoIndex;
+
+use crate::symbols::scip_parse::{ScipIndex, ScipReference};
+
+/// Standard SCIP `SymbolRole` bitmask values (see `scip.proto`).
+///
+/// These mirror the `scip::types::SymbolRole` enum discriminants. scip-typescript
+/// sets these on each occurrence so we can classify it as definition / call /
+/// import / etc. NOTE: these are the *standard* protobuf values and intentionally
+/// differ from the C# helper's custom JSON role encoding in `scip_parse::roles`
+/// (`READ_ACCESS=2`, `IMPORT=64` there) — do not mix the two.
+mod proto_roles {
+    use scip::types::SymbolRole;
+    pub const DEFINITION: i32 = SymbolRole::Definition as i32;
+    pub const FORWARD_DEFINITION: i32 = SymbolRole::ForwardDefinition as i32;
+    pub const IMPORT: i32 = SymbolRole::Import as i32;
+    pub const WRITE_ACCESS: i32 = SymbolRole::WriteAccess as i32;
+    pub const READ_ACCESS: i32 = SymbolRole::ReadAccess as i32;
+}
+
+/// Parse a SCIP protobuf byte slice (a `.scip` file's contents) into a
+/// symbol → references map.
+///
+/// Line numbers in SCIP protobuf are 0-based; the returned `ScipReference`
+/// lines are 1-based (matching the C# parser and the rest of the pipeline).
+/// External symbol *information* (documentation etc.) is not needed here —
+/// occurrences already carry the symbol string they reference, which is all
+/// the reference map keys on.
+pub fn parse_scip_protobuf(data: &[u8]) -> Result<ScipIndex> {
+    let index =
+        ScipProtoIndex::parse_from_bytes(data).context("Failed to parse SCIP protobuf index")?;
+
+    let mut result: ScipIndex = HashMap::new();
+
+    for document in &index.documents {
+        let rel_path = document.relative_path.as_str();
+        if rel_path.is_empty() {
+            continue;
+        }
+
+        for occurrence in &document.occurrences {
+            let symbol = occurrence.symbol.as_str();
+            if symbol.is_empty() {
+                continue;
+            }
+
+            let Some((start_line, end_line)) = decode_range(&occurrence.range) else {
+                // Newer producers MAY set `typed_range` instead of the deprecated
+                // `range` Vec; that path is not handled yet (TODO). Skip silently.
+                continue;
+            };
+
+            let kind = role_to_kind(occurrence.symbol_roles);
+
+            result
+                .entry(symbol.to_string())
+                .or_default()
+                .push(ScipReference {
+                    file: PathBuf::from(rel_path),
+                    start_line,
+                    end_line,
+                    kind,
+                });
+        }
+    }
+
+    Ok(result)
+}
+
+/// Decode a SCIP compact range (`repeated int32`) into 1-based `(start_line, end_line)`.
+///
+/// Encoding (0-based, half-open `[start, end)`):
+/// - 3 elements `[startLine, startChar, endChar]` → single line.
+/// - 4 elements `[startLine, startChar, endLine, endChar]` → possibly multi-line.
+fn decode_range(range: &[i32]) -> Option<(u32, u32)> {
+    match range.len() {
+        3 => {
+            let line = range[0];
+            if line < 0 {
+                return None;
+            }
+            Some(((line + 1) as u32, (line + 1) as u32))
+        }
+        4 => {
+            let start_line = range[0];
+            let end_line = range[2];
+            if start_line < 0 || end_line < start_line {
+                return None;
+            }
+            Some(((start_line + 1) as u32, (end_line + 1) as u32))
+        }
+        _ => None,
+    }
+}
+
+/// Map a standard SCIP `SymbolRole` bitmask to a kind string.
+///
+/// Mirrors the priority used by the C# JSON parser (`scip_parse::role_to_kind`)
+/// but uses the *standard* protobuf role values. Forward definitions count as
+/// definitions; a bare read access is reported as `"call"` (function/property
+/// usage) to match the existing convention.
+fn role_to_kind(roles: i32) -> String {
+    if roles & (proto_roles::DEFINITION | proto_roles::FORWARD_DEFINITION) != 0 {
+        "definition".to_string()
+    } else if roles & proto_roles::IMPORT != 0 {
+        "import".to_string()
+    } else if roles & proto_roles::WRITE_ACCESS != 0 {
+        "write".to_string()
+    } else if roles & proto_roles::READ_ACCESS != 0 {
+        "call".to_string()
+    } else {
+        "reference".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scip::types::{Document, Index, Occurrence};
+
+    fn occ(symbol: &str, range: Vec<i32>, roles: i32) -> Occurrence {
+        let mut o = Occurrence::new();
+        o.symbol = symbol.to_string();
+        o.range = range;
+        o.symbol_roles = roles;
+        o
+    }
+
+    #[test]
+    fn test_parse_scip_protobuf_defs_and_refs() {
+        // `add` is defined once and called three times across two files.
+        let sym = "typescript ts-sample add().";
+        let mut doc_a = Document::new();
+        doc_a.relative_path = "src/math.ts".to_string();
+        doc_a
+            .occurrences
+            .push(occ(sym, vec![3, 0, 3, 10], proto_roles::DEFINITION));
+
+        let mut doc_b = Document::new();
+        doc_b.relative_path = "src/consumer.ts".to_string();
+        doc_b
+            .occurrences
+            .push(occ(sym, vec![5, 0, 8], proto_roles::READ_ACCESS));
+        doc_b
+            .occurrences
+            .push(occ(sym, vec![6, 4, 6, 12], proto_roles::READ_ACCESS));
+
+        let mut doc_c = Document::new();
+        doc_c.relative_path = "src/other.ts".to_string();
+        doc_c
+            .occurrences
+            .push(occ(sym, vec![9, 10, 9, 18], proto_roles::READ_ACCESS));
+
+        let mut index = Index::new();
+        index.documents.push(doc_a);
+        index.documents.push(doc_b);
+        index.documents.push(doc_c);
+
+        let bytes = index.write_to_bytes().expect("serialize index");
+        let parsed = parse_scip_protobuf(&bytes).expect("parse index");
+
+        let refs = parsed.get(sym).expect("symbol present");
+        assert_eq!(refs.len(), 4, "1 definition + 3 call-sites");
+
+        let defs: Vec<_> = refs.iter().filter(|r| r.kind == "definition").collect();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].file.to_str().unwrap(), "src/math.ts");
+        assert_eq!(defs[0].start_line, 4, "0-based line 3 -> 1-based line 4");
+        assert_eq!(defs[0].end_line, 4);
+
+        let calls: Vec<_> = refs.iter().filter(|r| r.kind == "call").collect();
+        assert_eq!(calls.len(), 3);
+        let files: Vec<&str> = calls.iter().map(|r| r.file.to_str().unwrap()).collect();
+        assert!(files.contains(&"src/consumer.ts"));
+        assert!(files.contains(&"src/other.ts"));
+    }
+
+    #[test]
+    fn test_decode_range_single_and_multi_line() {
+        // 3-element single-line: [line 2, .., ..] -> line 3.
+        assert_eq!(decode_range(&[2, 0, 5]), Some((3, 3)));
+        // 4-element multi-line: [line 2, .., line 4, ..] -> lines 3..5.
+        assert_eq!(decode_range(&[2, 0, 4, 9]), Some((3, 5)));
+        // 4-element same-line: [line 7, .., line 7, ..] -> line 8.
+        assert_eq!(decode_range(&[7, 0, 7, 9]), Some((8, 8)));
+    }
+
+    #[test]
+    fn test_decode_range_rejects_bad() {
+        assert_eq!(decode_range(&[]), None);
+        assert_eq!(decode_range(&[1]), None);
+        assert_eq!(decode_range(&[1, 2, 3, 4, 5]), None);
+        // Negative line.
+        assert_eq!(decode_range(&[-1, 0, 0]), None);
+        // end_line < start_line.
+        assert_eq!(decode_range(&[5, 0, 2, 9]), None);
+    }
+
+    #[test]
+    fn test_role_to_kind_priority() {
+        assert_eq!(role_to_kind(proto_roles::DEFINITION), "definition");
+        assert_eq!(role_to_kind(proto_roles::FORWARD_DEFINITION), "definition");
+        assert_eq!(role_to_kind(proto_roles::IMPORT), "import");
+        assert_eq!(role_to_kind(proto_roles::WRITE_ACCESS), "write");
+        assert_eq!(role_to_kind(proto_roles::READ_ACCESS), "call");
+        assert_eq!(role_to_kind(0), "reference");
+        // Definition wins over read access when both set.
+        assert_eq!(
+            role_to_kind(proto_roles::DEFINITION | proto_roles::READ_ACCESS),
+            "definition"
+        );
+    }
+
+    #[test]
+    fn test_parse_skips_empty_symbol_and_bad_range() {
+        let mut doc = Document::new();
+        doc.relative_path = "src/a.ts".to_string();
+        // Empty symbol -> skipped.
+        doc.occurrences
+            .push(occ("", vec![1, 0], proto_roles::DEFINITION));
+        // Bad range (1 element) -> skipped.
+        doc.occurrences.push(occ("typescript x foo().", vec![1], 0));
+        // Well-formed definition survives.
+        doc.occurrences.push(occ(
+            "typescript x bar().",
+            vec![2, 0, 5],
+            proto_roles::DEFINITION,
+        ));
+
+        let mut index = Index::new();
+        index.documents.push(doc);
+        let bytes = index.write_to_bytes().unwrap();
+
+        let parsed = parse_scip_protobuf(&bytes).unwrap();
+        assert_eq!(parsed.len(), 1, "only the well-formed occurrence survives");
+        assert!(parsed.contains_key("typescript x bar()."));
+    }
+
+    #[test]
+    fn test_parse_empty_bytes_returns_empty() {
+        // Empty input parses as a default (empty) Index, yielding an empty map.
+        let parsed = parse_scip_protobuf(&[]).expect("empty bytes are a valid empty index");
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn test_parse_skips_document_with_empty_relative_path() {
+        let mut doc = Document::new();
+        doc.relative_path = String::new(); // no path -> document skipped
+        doc.occurrences.push(occ(
+            "typescript x ghost().",
+            vec![1, 0],
+            proto_roles::DEFINITION,
+        ));
+
+        let mut index = Index::new();
+        index.documents.push(doc);
+        let bytes = index.write_to_bytes().unwrap();
+
+        let parsed = parse_scip_protobuf(&bytes).unwrap();
+        assert!(
+            parsed.is_empty(),
+            "occurrences in path-less documents are dropped"
+        );
+    }
+}

--- a/src/symbols/scip_proto.rs
+++ b/src/symbols/scip_proto.rs
@@ -6,13 +6,9 @@
 //! reusable. Unlike the C# helper's custom JSON, this reads the canonical
 //! SCIP protobuf wire format via the `scip` crate (rust-protobuf bindings).
 //!
-//! This module is not wired into `SymbolIndexerRegistry` yet — that happens
-//! in stage 3 (`TypeScriptSymbolIndexer`, stage 2, will call
-//! `parse_scip_protobuf`). Until then everything here is only exercised by
-//! its own unit tests, which trips `-D dead-code` under
-//! `cargo clippy --all-targets`. Remove this module-wide allow once
-//! `typescript.rs` calls into this module.
-#![allow(dead_code)]
+//! Wired into `SymbolIndexerRegistry` via `TypeScriptSymbolIndexer::rebuild()`
+//! (`typescript.rs`), which calls `parse_scip_protobuf` on the raw `.scip`
+//! bytes produced by `scip-typescript index`.
 
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src/symbols/typescript.rs
+++ b/src/symbols/typescript.rs
@@ -177,12 +177,12 @@ pub struct TypeScriptSymbolIndexer {
 }
 
 /// How to invoke `scip-typescript`: either a direct binary path (env override)
-/// or via `npx scip-typescript` (the default, no bundled binary required).
+/// or via `npx @sourcegraph/scip-typescript` (the default, no bundled binary required).
 #[derive(Debug, Clone)]
 enum HelperInvocation {
     /// Direct path to a `scip-typescript` executable (env override).
     Direct(PathBuf),
-    /// Invoke via `npx scip-typescript` (requires Node/npm on PATH).
+    /// Invoke via `npx @sourcegraph/scip-typescript` (requires Node/npm on PATH).
     Npx,
 }
 
@@ -301,9 +301,28 @@ impl TypeScriptSymbolIndexer {
         let mut cmd = match invocation {
             HelperInvocation::Direct(path) => Command::new(path),
             HelperInvocation::Npx => {
-                let mut c = Command::new("npx");
-                c.arg("scip-typescript");
-                c
+                // On Windows, `npx` is a shell shim (`npx.cmd`/`npx.ps1`), not a bare
+                // `.exe` — `std::process::Command` does NOT consult `PATHEXT` the way
+                // `cmd.exe` does, so `Command::new("npx")` fails with "program not
+                // found" even though `where npx` (used in `resolve_helper`) succeeds.
+                // Route through `cmd /C` on Windows so the shell resolves the shim.
+                // NOTE: the unscoped npm name `scip-typescript` is a squatted
+                // security placeholder (0.0.1-security, no functionality) — the
+                // real Sourcegraph package is published as the scoped package
+                // `@sourcegraph/scip-typescript` (bin name `scip-typescript`).
+                // `-y` avoids an interactive "ok to install?" prompt.
+                if cfg!(windows) {
+                    let mut c = Command::new("cmd");
+                    c.arg("/C")
+                        .arg("npx")
+                        .arg("-y")
+                        .arg("@sourcegraph/scip-typescript");
+                    c
+                } else {
+                    let mut c = Command::new("npx");
+                    c.arg("-y").arg("@sourcegraph/scip-typescript");
+                    c
+                }
             }
         };
 

--- a/src/symbols/typescript.rs
+++ b/src/symbols/typescript.rs
@@ -1,0 +1,762 @@
+//! TypeScript symbol indexer adapter.
+//!
+//! Detects `scip-typescript` (Sourcegraph's Node CLI, invoked via `npx` unless
+//! overridden by `CODESEARCH_SCIP_TYPESCRIPT`), invokes it against a repo's root
+//! `tsconfig.json`, parses the standard SCIP protobuf output via
+//! [`super::scip_proto::parse_scip_protobuf`], and stores references in LMDB.
+//!
+//! ## Single-pass reference model (simpler than the C# two-phase model)
+//!
+//! `scip-typescript` emits full occurrences (definitions AND references) in a
+//! single indexing pass. Unlike the C# adapter (`csharp.rs`), there is no lazy
+//! `find-refs` subprocess and no `scip_ref_cache` table: `rebuild()` populates
+//! `scip_symbols` with everything up front, and `find_references()` /
+//! `find_references_by_position()` only ever read LMDB.
+//!
+//! ## Incremental rebuild
+//!
+//! `scip-typescript` has no per-file filter flag, so `RebuildScope::Files` falls
+//! back to a `Full` rebuild for this adapter (see `rebuild()` below).
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::lmdb_registry::TrackedEnv;
+use anyhow::{Context, Result};
+use heed::types::{Bytes, Str};
+use heed::{Database, EnvOpenOptions};
+use serde::{Deserialize, Serialize};
+
+use super::scip_proto;
+use super::{RebuildScope, RebuildSummary, SymbolIndexer, SymbolReference};
+
+use crate::constants::{
+    LANG_TYPESCRIPT, SCIP_LMDB_DEFAULT_MAP_SIZE_MB, SCIP_LMDB_MAP_SIZE_MB_ENV,
+    SCIP_POSITION_DB_NAME, SCIP_SIMPLE_NAMES_DB_NAME, SCIP_SYMBOLS_DB_NAME,
+    SCIP_TYPESCRIPT_HELPER_ENV, SCIP_TYPESCRIPT_REBUILD_TIMESTAMP_KEY,
+};
+
+// ── Constants ─────────────────────────────────────────────────────
+
+/// LMDB database name for the SCIP symbol table (definitions + references).
+const SCIP_DB_NAME: &str = SCIP_SYMBOLS_DB_NAME;
+
+/// LMDB database name for the rebuild timestamp / metadata table.
+/// Shares the physical table with the C# adapter, but keys are namespaced
+/// per-language (see `SCIP_TYPESCRIPT_REBUILD_TIMESTAMP_KEY`).
+const SCIP_META_DB_NAME: &str = "scip_meta";
+
+/// LMDB database name for the position-to-symbols index.
+const SCIP_POS_DB_NAME: &str = SCIP_POSITION_DB_NAME;
+
+/// LMDB database name for the simple-name-to-symbols index.
+const SCIP_NAMES_DB_NAME: &str = SCIP_SIMPLE_NAMES_DB_NAME;
+
+/// Key in the meta database storing the last rebuild timestamp for TypeScript.
+const META_REBUILD_TS: &str = SCIP_TYPESCRIPT_REBUILD_TIMESTAMP_KEY;
+
+/// Key in the meta database storing the count of indexed symbols.
+const META_SYMBOL_COUNT: &str = "symbol_count:typescript";
+
+// ── Serialized reference type (stored in LMDB via bincode) ────────
+
+/// Schema version byte prepended to all bincode payloads stored in LMDB.
+const STORED_REFERENCE_SCHEMA_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredReference {
+    file: PathBuf,
+    start_line: u32,
+    end_line: u32,
+    kind: String,
+}
+
+fn serialize_refs(refs: &[StoredReference]) -> Result<Vec<u8>> {
+    let payload = bincode::serialize(refs).with_context(|| "bincode serialize failed")?;
+    let mut buf = Vec::with_capacity(1 + payload.len());
+    buf.push(STORED_REFERENCE_SCHEMA_VERSION);
+    buf.extend_from_slice(&payload);
+    Ok(buf)
+}
+
+fn deserialize_refs(bytes: &[u8]) -> Result<Vec<StoredReference>> {
+    if bytes.is_empty() {
+        anyhow::bail!("Empty stored value");
+    }
+    let version = bytes[0];
+    if version != STORED_REFERENCE_SCHEMA_VERSION {
+        anyhow::bail!(
+            "Unsupported stored reference schema version {} (expected {}). \
+             Run `codesearch reindex --symbols` to rebuild.",
+            version,
+            STORED_REFERENCE_SCHEMA_VERSION
+        );
+    }
+    bincode::deserialize(&bytes[1..]).with_context(|| "bincode deserialize failed")
+}
+
+const KEYS_LIST_SCHEMA_VERSION: u8 = 1;
+
+fn serialize_keys_v1(keys: &[String]) -> Result<Vec<u8>> {
+    let payload = bincode::serialize(keys).with_context(|| "bincode serialize keys failed")?;
+    let mut buf = Vec::with_capacity(1 + payload.len());
+    buf.push(KEYS_LIST_SCHEMA_VERSION);
+    buf.extend_from_slice(&payload);
+    Ok(buf)
+}
+
+fn deserialize_keys_v1(bytes: &[u8]) -> Result<Vec<String>> {
+    if bytes.is_empty() {
+        anyhow::bail!("Empty stored key list");
+    }
+    let version = bytes[0];
+    if version != KEYS_LIST_SCHEMA_VERSION {
+        anyhow::bail!(
+            "Unsupported key list schema version {} (expected {}). \
+             Run `codesearch reindex --symbols` to rebuild.",
+            version,
+            KEYS_LIST_SCHEMA_VERSION
+        );
+    }
+    bincode::deserialize(&bytes[1..]).with_context(|| "bincode deserialize keys failed")
+}
+
+/// Extracts the last segment of a canonical SCIP symbol as a simple name.
+///
+/// SCIP-typescript symbols look like:
+/// `scip-typescript npm mypkg 1.0.0 src/math/`add`().` or similar path-scoped
+/// forms; we take the last `/` or `.`-delimited, non-empty segment and strip
+/// trailing `()`/backtick noise.
+fn extract_simple_name(scip_symbol: &str) -> String {
+    let cleaned = scip_symbol
+        .trim_end_matches('.')
+        .trim_end_matches("()")
+        .trim_end_matches('#');
+    let last_segment = cleaned
+        .rsplit(['#', '.', '/'])
+        .find(|s| !s.trim().is_empty())
+        .unwrap_or(cleaned)
+        .trim();
+    last_segment
+        .trim_matches('`')
+        .split('(')
+        .next()
+        .unwrap_or(last_segment)
+        .trim_matches('`')
+        .trim()
+        .to_string()
+}
+
+/// Fuzzy matching heuristic for symbol names (mirrors the C# adapter's version).
+fn fuzzy_symbol_match(query: &str, candidate: &str) -> bool {
+    let query_parts: Vec<&str> = query
+        .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if query_parts.is_empty() {
+        return false;
+    }
+
+    query_parts.iter().all(|part| candidate.contains(part))
+}
+
+// ── TypeScriptSymbolIndexer ────────────────────────────────────────
+
+/// TypeScript adapter: locates `scip-typescript` (bundled override or `npx`),
+/// invokes it against the repo's root `tsconfig.json`, parses the resulting
+/// SCIP protobuf index, and stores all definitions + references in LMDB in
+/// a single pass.
+pub struct TypeScriptSymbolIndexer {
+    /// Cached detection result.
+    /// `None` = not yet attempted.
+    /// `Some(None)` = attempted, `scip-typescript` not resolvable.
+    /// `Some(Some(invocation))` = resolved invocation (helper path or `npx`).
+    helper: std::sync::Mutex<Option<Option<HelperInvocation>>>,
+}
+
+/// How to invoke `scip-typescript`: either a direct binary path (env override)
+/// or via `npx scip-typescript` (the default, no bundled binary required).
+#[derive(Debug, Clone)]
+enum HelperInvocation {
+    /// Direct path to a `scip-typescript` executable (env override).
+    Direct(PathBuf),
+    /// Invoke via `npx scip-typescript` (requires Node/npm on PATH).
+    Npx,
+}
+
+impl Default for TypeScriptSymbolIndexer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TypeScriptSymbolIndexer {
+    pub fn new() -> Self {
+        Self {
+            helper: std::sync::Mutex::new(None),
+        }
+    }
+
+    /// Locate how to invoke `scip-typescript`.
+    ///
+    /// Search order:
+    /// 1. `CODESEARCH_SCIP_TYPESCRIPT` env var — direct path to a `scip-typescript` binary.
+    /// 2. `npx` on `$PATH` — Node's package runner resolves/installs `scip-typescript`
+    ///    on demand. Requires Node + npm; no bundled binary is shipped for TS (MVP).
+    ///
+    /// Results are cached — both positive (found) and negative (not found).
+    fn detect_helper(&self) -> Option<HelperInvocation> {
+        {
+            let lock = self.helper.lock().unwrap();
+            if let Some(cached) = lock.as_ref() {
+                return cached.clone();
+            }
+        }
+
+        let resolved = self.resolve_helper();
+        let mut lock = self.helper.lock().unwrap();
+        *lock = Some(resolved.clone());
+        resolved
+    }
+
+    fn resolve_helper(&self) -> Option<HelperInvocation> {
+        // 1. Environment variable override — direct binary path.
+        if let Ok(path) = std::env::var(SCIP_TYPESCRIPT_HELPER_ENV) {
+            let p = PathBuf::from(&path);
+            if p.is_file() {
+                tracing::debug!(
+                    "scip-typescript helper found via {}={}",
+                    SCIP_TYPESCRIPT_HELPER_ENV,
+                    path
+                );
+                return Some(HelperInvocation::Direct(p));
+            }
+            tracing::warn!(
+                "{}={} does not point to a regular file, falling back to npx",
+                SCIP_TYPESCRIPT_HELPER_ENV,
+                path
+            );
+        }
+
+        // 2. `npx` on PATH.
+        let lookup_cmd = if cfg!(windows) { "where" } else { "which" };
+        if let Ok(output) = Command::new(lookup_cmd).arg("npx").output() {
+            if output.status.success() {
+                tracing::debug!("scip-typescript will be invoked via npx");
+                return Some(HelperInvocation::Npx);
+            }
+        }
+
+        None
+    }
+
+    /// Find the root `tsconfig.json` for a repo (MVP: top-level only, no
+    /// monorepo multi-tsconfig resolution).
+    fn find_tsconfig(repo_path: &Path) -> Option<PathBuf> {
+        let candidate = repo_path.join("tsconfig.json");
+        if candidate.is_file() {
+            Some(candidate)
+        } else {
+            None
+        }
+    }
+
+    /// Open or create the SCIP LMDB environment for a given repo database path.
+    /// Shares the same on-disk tables as the C# adapter (`db_path/scip/`),
+    /// distinguished by namespaced keys/values where needed.
+    fn open_scip_env(&self, db_path: &Path) -> Result<TrackedEnv> {
+        let scip_dir = db_path.join("scip");
+        std::fs::create_dir_all(&scip_dir)
+            .with_context(|| format!("Failed to create SCIP directory: {}", scip_dir.display()))?;
+
+        let map_size_mb = std::env::var(SCIP_LMDB_MAP_SIZE_MB_ENV)
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(SCIP_LMDB_DEFAULT_MAP_SIZE_MB);
+        let mut opts = EnvOpenOptions::new();
+        opts.map_size(map_size_mb * 1024 * 1024).max_dbs(10);
+        let env =
+            unsafe { TrackedEnv::open(&opts, &scip_dir, &format!("SCIP({})", db_path.display()))? };
+
+        let mut wtxn = env.write_txn()?;
+        env.create_database::<Str, Bytes>(&mut wtxn, Some(SCIP_DB_NAME))?;
+        env.create_database::<Str, Str>(&mut wtxn, Some(SCIP_META_DB_NAME))?;
+        env.create_database::<Str, Bytes>(&mut wtxn, Some(SCIP_POS_DB_NAME))?;
+        env.create_database::<Str, Bytes>(&mut wtxn, Some(SCIP_NAMES_DB_NAME))?;
+        wtxn.commit()?;
+
+        Ok(env)
+    }
+
+    /// Invoke `scip-typescript index` against `project_root`, writing the SCIP
+    /// protobuf index to `output_path`.
+    fn invoke_index_helper(
+        &self,
+        invocation: &HelperInvocation,
+        project_root: &Path,
+        output_path: &Path,
+    ) -> Result<()> {
+        let mut cmd = match invocation {
+            HelperInvocation::Direct(path) => Command::new(path),
+            HelperInvocation::Npx => {
+                let mut c = Command::new("npx");
+                c.arg("scip-typescript");
+                c
+            }
+        };
+
+        cmd.arg("index")
+            .arg("--output")
+            .arg(output_path)
+            .current_dir(project_root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        tracing::info!(
+            "Running scip-typescript index in {:?}: {:?}",
+            project_root,
+            cmd
+        );
+
+        let output = cmd.output().with_context(|| {
+            format!(
+                "Failed to execute scip-typescript for {}",
+                project_root.display()
+            )
+        })?;
+
+        for line in String::from_utf8_lossy(&output.stderr).lines() {
+            if !line.is_empty() {
+                tracing::info!("[scip-typescript] {}", line);
+            }
+        }
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            if !line.is_empty() {
+                tracing::debug!("[scip-typescript] {}", line);
+            }
+        }
+
+        if !output.status.success() {
+            tracing::warn!(
+                "scip-typescript exited with {} for {}",
+                output.status,
+                project_root.display()
+            );
+            // Don't bail — partial output is acceptable, mirroring the C# adapter.
+        }
+
+        Ok(())
+    }
+
+    /// Resolve a user-supplied symbol query to a canonical SCIP symbol key.
+    /// Exact match first, then fuzzy match via the simple-name index.
+    fn resolve_canonical_key(&self, env: &TrackedEnv, symbol: &str) -> Result<Option<String>> {
+        let rtxn = env.read_txn()?;
+
+        let symbols_db: Database<Str, Bytes> = match env.open_database(&rtxn, Some(SCIP_DB_NAME))? {
+            Some(db) => db,
+            None => return Ok(None),
+        };
+
+        if symbols_db.get(&rtxn, symbol)?.is_some() {
+            return Ok(Some(symbol.to_string()));
+        }
+
+        let simple_names_db: Database<Str, Bytes> =
+            match env.open_database(&rtxn, Some(SCIP_NAMES_DB_NAME))? {
+                Some(db) => db,
+                None => return Ok(None),
+            };
+
+        let simple = extract_simple_name(symbol);
+        let candidates: Vec<String> = match simple_names_db.get(&rtxn, &simple as &str)? {
+            Some(b) => deserialize_keys_v1(b)?,
+            None => return Ok(None),
+        };
+
+        let chosen = candidates
+            .iter()
+            .filter(|k| fuzzy_symbol_match(symbol, k))
+            .min_by_key(|k| k.len())
+            .cloned();
+
+        Ok(chosen)
+    }
+}
+
+impl SymbolIndexer for TypeScriptSymbolIndexer {
+    fn language(&self) -> &str {
+        LANG_TYPESCRIPT
+    }
+
+    fn rebuild(
+        &self,
+        repo_path: &Path,
+        db_path: &Path,
+        scope: RebuildScope,
+    ) -> Result<RebuildSummary> {
+        let invocation = self.detect_helper().ok_or_else(|| {
+            anyhow::anyhow!(
+                "scip-typescript not resolvable (no npx on PATH and {} unset). \
+                 Install Node.js or set {} to a scip-typescript binary path.",
+                SCIP_TYPESCRIPT_HELPER_ENV,
+                SCIP_TYPESCRIPT_HELPER_ENV
+            )
+        })?;
+
+        // RebuildScope::Files has no per-file equivalent for scip-typescript
+        // (no --filter-project style flag), so we always do a Full rebuild.
+        // RebuildScope::Project(_) falls through the same way: TS MVP only
+        // supports a single root tsconfig.json, so a "project scope" rebuild
+        // is indistinguishable from a Full one.
+        if let RebuildScope::Files { .. } = scope {
+            tracing::debug!(
+                "TypeScript adapter: RebuildScope::Files requested, falling back to Full \
+                 (scip-typescript has no incremental/file-filter mode)"
+            );
+        }
+
+        if Self::find_tsconfig(repo_path).is_none() {
+            anyhow::bail!("No tsconfig.json found in {}", repo_path.display());
+        }
+        // scip-typescript discovers tsconfig.json from project_root itself,
+        // so we only need to confirm one exists above - the path itself is
+        // never passed to the CLI.
+
+        let start = std::time::Instant::now();
+
+        let temp_dir = std::env::temp_dir().join("codesearch-scip-ts");
+        std::fs::create_dir_all(&temp_dir)?;
+        // Include PID + wall-clock nanoseconds (not Instant::elapsed(), which
+        // is tiny/low-entropy right after creation) to avoid filename
+        // collisions when multiple TS rebuilds for repos sharing a directory
+        // basename are in flight concurrently - mirrors the same pattern in
+        // csharp.rs's temp-file naming.
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let output_path = temp_dir.join(format!(
+            "index-{}-{}-{:x}.scip",
+            repo_path.file_name().unwrap_or_default().to_string_lossy(),
+            std::process::id(),
+            nanos
+        ));
+        struct TempFileGuard(PathBuf);
+        impl Drop for TempFileGuard {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_file(&self.0);
+            }
+        }
+        let _output_guard = TempFileGuard(output_path.clone());
+
+        self.invoke_index_helper(&invocation, repo_path, &output_path)?;
+
+        let index_data = std::fs::read(&output_path)
+            .with_context(|| format!("Failed to read SCIP index at {}", output_path.display()))?;
+
+        let index = scip_proto::parse_scip_protobuf(&index_data)?;
+
+        let env = self.open_scip_env(db_path)?;
+        let mut wtxn = env.write_txn()?;
+
+        let symbols_db: Database<Str, Bytes> =
+            env.create_database(&mut wtxn, Some(SCIP_DB_NAME))?;
+        let meta_db: Database<Str, Str> =
+            env.create_database(&mut wtxn, Some(SCIP_META_DB_NAME))?;
+        let positions_db: Database<Str, Bytes> =
+            env.create_database(&mut wtxn, Some(SCIP_POS_DB_NAME))?;
+        let simple_names_db: Database<Str, Bytes> =
+            env.create_database(&mut wtxn, Some(SCIP_NAMES_DB_NAME))?;
+
+        // Full rebuild only (MVP): wipe and repopulate this language's entries.
+        // NOTE: scip_symbols/scip_positions/scip_simple_names are shared physical
+        // tables with the C# adapter. Clearing them here would destroy C#'s data
+        // if both languages share the same db_path. In practice each repo has at
+        // most one applicable language's tsconfig.json/.sln, so this is safe for
+        // the MVP; a follow-up should namespace keys by language if repos ever
+        // mix both indexers against the same db_path.
+        symbols_db.clear(&mut wtxn)?;
+        positions_db.clear(&mut wtxn)?;
+        simple_names_db.clear(&mut wtxn)?;
+
+        let mut total_symbols = 0usize;
+        let mut total_refs = 0usize;
+
+        for (symbol_name, refs) in index.iter() {
+            let stored: Vec<StoredReference> = refs
+                .iter()
+                .map(|r| StoredReference {
+                    file: r.file.clone(),
+                    start_line: r.start_line,
+                    end_line: r.end_line,
+                    kind: r.kind.clone(),
+                })
+                .collect();
+
+            let value_bytes = serialize_refs(&stored)
+                .with_context(|| format!("Failed to serialize references for {}", symbol_name))?;
+            symbols_db.put(&mut wtxn, symbol_name.as_str(), &value_bytes)?;
+
+            total_refs += stored.len();
+            total_symbols += 1;
+        }
+
+        // ── Build position index (definitions only) ────────────────
+        let mut positions: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        for (symbol_name, refs) in index.iter() {
+            for r in refs.iter().filter(|r| r.kind == "definition") {
+                let pos_key = format!(
+                    "{}:{}",
+                    r.file.to_string_lossy().replace('\\', "/"),
+                    r.start_line
+                );
+                positions
+                    .entry(pos_key)
+                    .or_default()
+                    .push(symbol_name.clone());
+            }
+        }
+        for (key, keys) in &positions {
+            let bytes = serialize_keys_v1(keys)
+                .with_context(|| format!("Failed to serialize position key: {}", key))?;
+            positions_db.put(&mut wtxn, key.as_str(), &bytes)?;
+        }
+
+        // ── Build simple-name index ─────────────────────────────────
+        let mut all_simple_names: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        for symbol_name in index.keys() {
+            let simple = extract_simple_name(symbol_name);
+            if !simple.is_empty() {
+                all_simple_names
+                    .entry(simple)
+                    .or_default()
+                    .push(symbol_name.clone());
+            }
+        }
+        for (key, keys) in &all_simple_names {
+            let bytes = serialize_keys_v1(keys)
+                .with_context(|| format!("Failed to serialize simple name key: {}", key))?;
+            simple_names_db.put(&mut wtxn, key.as_str(), &bytes)?;
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        meta_db.put(&mut wtxn, META_REBUILD_TS, now.to_string().as_str())?;
+        meta_db.put(
+            &mut wtxn,
+            META_SYMBOL_COUNT,
+            total_symbols.to_string().as_str(),
+        )?;
+
+        wtxn.commit()?;
+
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        tracing::info!(
+            "scip-typescript rebuild complete: {} symbols, {} reference entries in {}ms",
+            total_symbols,
+            total_refs,
+            duration_ms
+        );
+
+        Ok(RebuildSummary {
+            symbols_indexed: total_symbols,
+            references_stored: total_refs,
+            duration_ms,
+        })
+    }
+
+    fn find_references(&self, db_path: &Path, symbol: &str) -> Result<Vec<SymbolReference>> {
+        let env = self.open_scip_env(db_path)?;
+
+        let canonical = match self.resolve_canonical_key(&env, symbol)? {
+            Some(k) => k,
+            None => {
+                tracing::debug!("Symbol '{}' not found in TypeScript index", symbol);
+                return Ok(vec![]);
+            }
+        };
+
+        let rtxn = env.read_txn()?;
+        let symbols_db: Database<Str, Bytes> = match env.open_database(&rtxn, Some(SCIP_DB_NAME))? {
+            Some(db) => db,
+            None => return Ok(vec![]),
+        };
+
+        let stored = match symbols_db.get(&rtxn, &canonical)? {
+            Some(bytes) => deserialize_refs(bytes)?,
+            None => return Ok(vec![]),
+        };
+
+        Ok(stored
+            .into_iter()
+            .map(|r| SymbolReference {
+                file: r.file,
+                start_line: r.start_line,
+                end_line: r.end_line,
+                kind: r.kind,
+            })
+            .collect())
+    }
+
+    fn find_references_by_position(
+        &self,
+        db_path: &Path,
+        file: &Path,
+        line: u32,
+    ) -> Result<Vec<SymbolReference>> {
+        let env = self.open_scip_env(db_path)?;
+        let rtxn = env.read_txn()?;
+
+        let positions_db: Database<Str, Bytes> = env
+            .open_database(&rtxn, Some(SCIP_POS_DB_NAME))?
+            .ok_or_else(|| anyhow::anyhow!("Position index not found. Run a rebuild first."))?;
+
+        let pos_key = format!("{}:{}", file.to_string_lossy().replace('\\', "/"), line);
+
+        let candidate_keys: Vec<String> = match positions_db.get(&rtxn, &pos_key as &str)? {
+            Some(b) => deserialize_keys_v1(b)?,
+            None => return Ok(vec![]),
+        };
+
+        let chosen = candidate_keys.iter().min_by_key(|k| k.len()).cloned();
+        drop(rtxn);
+        drop(env);
+
+        match chosen {
+            Some(k) => self.find_references(db_path, &k),
+            None => Ok(vec![]),
+        }
+    }
+
+    fn index_age(&self, db_path: &Path) -> u64 {
+        let env = match self.open_scip_env(db_path) {
+            Ok(e) => e,
+            Err(_) => return u64::MAX,
+        };
+        let rtxn = match env.read_txn() {
+            Ok(t) => t,
+            Err(_) => return u64::MAX,
+        };
+
+        let meta_db: Database<Str, Str> = match env.open_database(&rtxn, Some(SCIP_META_DB_NAME)) {
+            Ok(Some(db)) => db,
+            _ => return u64::MAX,
+        };
+
+        let ts_str: &str = match meta_db.get(&rtxn, META_REBUILD_TS) {
+            Ok(Some(s)) => s,
+            _ => return u64::MAX,
+        };
+
+        let stored_ts: u64 = match ts_str.parse() {
+            Ok(v) => v,
+            Err(_) => return u64::MAX,
+        };
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        now.saturating_sub(stored_ts)
+    }
+
+    fn has_index(&self, db_path: &Path) -> bool {
+        let scip_dir = db_path.join("scip");
+        if !scip_dir.exists() {
+            return false;
+        }
+        self.index_age(db_path) != u64::MAX
+    }
+
+    fn is_available(&self) -> bool {
+        self.detect_helper().is_some()
+    }
+
+    /// TypeScript adapter is only applicable when a top-level `tsconfig.json` exists.
+    fn applies_to(&self, repo_path: &Path) -> bool {
+        Self::find_tsconfig(repo_path).is_some()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_simple_name() {
+        assert_eq!(
+            extract_simple_name("scip-typescript npm mypkg 1.0.0 `src/math.ts`/add()."),
+            "add"
+        );
+        assert_eq!(extract_simple_name("MyClass#method()."), "method");
+        assert_eq!(extract_simple_name(""), "");
+    }
+
+    #[test]
+    fn test_fuzzy_symbol_match() {
+        assert!(fuzzy_symbol_match(
+            "add",
+            "scip-typescript npm mypkg 1.0.0 `src/math.ts`/add()."
+        ));
+        assert!(!fuzzy_symbol_match(
+            "subtract",
+            "scip-typescript npm mypkg 1.0.0 `src/math.ts`/add()."
+        ));
+        assert!(!fuzzy_symbol_match("", "anything"));
+    }
+
+    #[test]
+    fn test_serialize_refs_round_trip() {
+        let refs = vec![StoredReference {
+            file: PathBuf::from("a.ts"),
+            start_line: 1,
+            end_line: 1,
+            kind: "definition".into(),
+        }];
+        let bytes = serialize_refs(&refs).unwrap();
+        assert_eq!(bytes[0], STORED_REFERENCE_SCHEMA_VERSION);
+        let decoded = deserialize_refs(&bytes).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].kind, "definition");
+    }
+
+    #[test]
+    fn test_deserialize_refs_rejects_empty() {
+        assert!(deserialize_refs(&[]).is_err());
+    }
+
+    #[test]
+    fn test_deserialize_refs_rejects_bad_version() {
+        assert!(deserialize_refs(&[99, 1, 2, 3]).is_err());
+    }
+
+    #[test]
+    fn test_find_tsconfig_requires_root_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "ts-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(TypeScriptSymbolIndexer::find_tsconfig(&dir).is_none());
+        std::fs::write(dir.join("tsconfig.json"), "{}").unwrap();
+        assert!(TypeScriptSymbolIndexer::find_tsconfig(&dir).is_some());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/tests/fixtures/ts-sample/src/consumer.ts
+++ b/tests/fixtures/ts-sample/src/consumer.ts
@@ -1,0 +1,5 @@
+import { add } from "./math";
+
+export function sumThree(a: number, b: number, c: number): number {
+  return add(add(a, b), c);
+}

--- a/tests/fixtures/ts-sample/src/math.ts
+++ b/tests/fixtures/ts-sample/src/math.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/tests/fixtures/ts-sample/src/other.ts
+++ b/tests/fixtures/ts-sample/src/other.ts
@@ -1,0 +1,6 @@
+import { add } from "./math";
+
+export function printSum(a: number, b: number): void {
+  const result = add(a, b);
+  console.log(result);
+}

--- a/tests/fixtures/ts-sample/tsconfig.json
+++ b/tests/fixtures/ts-sample/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tests/symbols_typescript_test.rs
+++ b/tests/symbols_typescript_test.rs
@@ -161,3 +161,83 @@ fn test_typescript_pipeline_ts_sample_roundtrip() {
         "Expected a call-site in other.ts"
     );
 }
+
+// ── Real-project smoke test (opt-in via env var) ──────────────────────
+
+/// Smoke test against a real-world TypeScript project pointed at by the
+/// `CODESEARCH_TS_TEST_REAL` env var. Gated by the feature flag AND the env
+/// var, so it never runs in CI unless explicitly opted in.
+///
+/// Verifies: rebuild succeeds on a non-trivial codebase, `find_references`
+/// returns sensible multi-file results for a commonly-used symbol.
+#[test]
+#[cfg_attr(not(feature = "typescript_helper_integration"), ignore)]
+fn test_typescript_pipeline_real_project() {
+    let project_root = match std::env::var("CODESEARCH_TS_TEST_REAL") {
+        Ok(p) => PathBuf::from(p),
+        Err(_) => {
+            eprintln!("skipping real-project test: set CODESEARCH_TS_TEST_REAL=<path> to enable");
+            return;
+        }
+    };
+    assert!(
+        project_root.join("tsconfig.json").is_file(),
+        "CODESEARCH_TS_TEST_REAL does not point at a TS project root (no tsconfig.json): {}",
+        project_root.display()
+    );
+
+    let indexer = TypeScriptSymbolIndexer::new();
+    assert!(indexer.is_available(), "scip-typescript not resolvable");
+    assert!(
+        indexer.applies_to(&project_root),
+        "Indexer did not recognize the project as TypeScript"
+    );
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path();
+
+    let started = std::time::Instant::now();
+    let summary = indexer
+        .rebuild(&project_root, db_path, RebuildScope::Full)
+        .expect("rebuild failed");
+    let elapsed = started.elapsed();
+
+    eprintln!(
+        "rebuild: {} symbols, {} references stored in {:.2}s",
+        summary.symbols_indexed,
+        summary.references_stored,
+        elapsed.as_secs_f64()
+    );
+    assert!(
+        summary.symbols_indexed > 50,
+        "Expected >50 symbols for a real project, got {}",
+        summary.symbols_indexed
+    );
+
+    // `log` is a very commonly used symbol in the target project — expect
+    // many call-sites across many files.
+    for sym in &["log", "configureLogger"] {
+        let refs = indexer
+            .find_references(db_path, sym)
+            .unwrap_or_else(|e| panic!("find_references({sym}) failed: {e:#}"));
+        let distinct_files: std::collections::HashSet<_> =
+            refs.iter().map(|r| r.file.clone()).collect();
+        eprintln!(
+            "find_references({sym:?}): {} occurrences across {} files",
+            refs.len(),
+            distinct_files.len()
+        );
+        // Sanity: each queried symbol should have at least one hit.
+        assert!(
+            !refs.is_empty(),
+            "Expected at least one reference for `{sym}`, got 0"
+        );
+    }
+
+    // Negative test: unknown symbol returns empty, no panic.
+    let unknown = indexer
+        .find_references(db_path, "thisSymbolDoesNotExist_xyzzy_12345")
+        .expect("find_references on unknown symbol should not error");
+    assert!(unknown.is_empty(), "Unknown symbol should return empty");
+    eprintln!("negative test OK: unknown symbol returned 0 results");
+}

--- a/tests/symbols_typescript_test.rs
+++ b/tests/symbols_typescript_test.rs
@@ -1,0 +1,163 @@
+//! Integration tests for the TypeScript symbol indexing pipeline.
+//!
+//! Mirrors `symbols_csharp_test.rs`: non-gated tests exercise the LMDB
+//! round-trip and helper-detection paths without requiring the actual
+//! `scip-typescript` CLI. The full pipeline test (subprocess → protobuf →
+//! LMDB → query) is gated behind the `typescript_helper_integration` cargo
+//! feature AND requires Node + `scip-typescript` to be resolvable (either
+//! via `npx` on `$PATH`, or `CODESEARCH_SCIP_TYPESCRIPT` pointing at a
+//! direct binary).
+
+use std::path::PathBuf;
+
+use codesearch::symbols::typescript::TypeScriptSymbolIndexer;
+use codesearch::symbols::{RebuildScope, SymbolIndexer};
+use tempfile::TempDir;
+
+#[test]
+fn test_indexer_returns_empty_when_db_missing() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let db_path = temp_dir.path().join("test-db");
+    std::fs::create_dir_all(&db_path).expect("Failed to create db dir");
+
+    let indexer = TypeScriptSymbolIndexer::new();
+
+    // Note: is_available() may return true if npx/Node is on this host's
+    // PATH. Don't assert unavailability — just exercise the empty-DB path.
+    let age = indexer.index_age(&db_path);
+    let _ = age; // open_scip_env creates the dir; just verify no panic.
+
+    // find_references with no data should return Ok(empty) because
+    // resolve_canonical_key returns None when no LMDB tables exist.
+    let result = indexer.find_references(&db_path, "add");
+    match result {
+        Ok(refs) => assert!(
+            refs.is_empty(),
+            "Should return empty vec when no SCIP data exists, got {:?}",
+            refs
+        ),
+        Err(e) => {
+            // LMDB reopen failed (e.g. lock contention on CI). Acceptable —
+            // the important invariant is that it never panics or returns
+            // stale data.
+            eprintln!("Note: find_references returned Err (LMDB lock contention?): {e:#}");
+        }
+    }
+}
+
+#[test]
+fn test_applies_to_requires_root_tsconfig() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+    // No tsconfig.json present -> does not apply.
+    assert!(!TypeScriptSymbolIndexer::new().applies_to(temp_dir.path()));
+
+    // Create a root tsconfig.json -> now it applies.
+    std::fs::write(temp_dir.path().join("tsconfig.json"), "{}").unwrap();
+    assert!(TypeScriptSymbolIndexer::new().applies_to(temp_dir.path()));
+}
+
+#[test]
+fn test_fixture_directory_shape() {
+    // Sanity check the fixture used by the gated integration test below:
+    // 1 definition (`add` in math.ts) + call-sites in 2 other files.
+    let fixture_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ts-sample");
+    assert!(fixture_root.join("tsconfig.json").is_file());
+    assert!(fixture_root.join("src/math.ts").is_file());
+    assert!(fixture_root.join("src/consumer.ts").is_file());
+    assert!(fixture_root.join("src/other.ts").is_file());
+
+    let consumer = std::fs::read_to_string(fixture_root.join("src/consumer.ts")).unwrap();
+    let other = std::fs::read_to_string(fixture_root.join("src/other.ts")).unwrap();
+    // consumer.ts calls add() twice, other.ts calls it once -> 3 call-sites
+    // across 2 files, plus the 1 definition in math.ts.
+    assert_eq!(consumer.matches("add(").count(), 2);
+    assert_eq!(other.matches("add(").count(), 1);
+}
+
+// ── Integration test (requires scip-typescript) ────────────────────────
+
+/// Full pipeline integration test: scip-typescript subprocess → SCIP
+/// protobuf → LMDB → query, verifying that `find_impact`'s underlying
+/// `find_references()` returns ALL call-sites of a TS symbol across
+/// multiple files.
+///
+/// Requires the `typescript_helper_integration` feature flag AND either:
+/// - `CODESEARCH_SCIP_TYPESCRIPT` env var pointing to a `scip-typescript`
+///   binary, or
+/// - `npx` resolvable on `$PATH` (Node + npm installed).
+#[test]
+#[cfg_attr(not(feature = "typescript_helper_integration"), ignore)]
+fn test_typescript_pipeline_ts_sample_roundtrip() {
+    let fixture_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ts-sample");
+    assert!(
+        fixture_root.join("tsconfig.json").exists(),
+        "Fixture not found at {}",
+        fixture_root.display()
+    );
+
+    let indexer = TypeScriptSymbolIndexer::new();
+    assert!(
+        indexer.is_available(),
+        "scip-typescript not resolvable (no CODESEARCH_SCIP_TYPESCRIPT and no npx on PATH)"
+    );
+    assert!(
+        indexer.applies_to(&fixture_root),
+        "Fixture should be recognized as a TypeScript project (root tsconfig.json)"
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path();
+
+    let summary = indexer
+        .rebuild(&fixture_root, db_path, RebuildScope::Full)
+        .expect("rebuild failed");
+    assert!(
+        summary.symbols_indexed > 0,
+        "No symbols indexed from ts-sample fixture"
+    );
+
+    // Fuzzy lookup: "add" should resolve to the `add` function in math.ts
+    // and return the definition plus all call-sites across both files
+    // that import and call it.
+    let add_refs = indexer
+        .find_references(db_path, "add")
+        .expect("find_references failed");
+
+    let defs: Vec<_> = add_refs.iter().filter(|r| r.kind == "definition").collect();
+    assert_eq!(defs.len(), 1, "Expected exactly 1 definition for `add`");
+    assert!(
+        defs[0].file.to_string_lossy().contains("math.ts"),
+        "Definition should be in math.ts, got {:?}",
+        defs[0].file
+    );
+
+    // consumer.ts calls add() twice (nested), other.ts calls it once -> at
+    // least 3 non-definition occurrences, spanning at least 2 distinct files.
+    let call_sites: Vec<_> = add_refs.iter().filter(|r| r.kind != "definition").collect();
+    assert!(
+        call_sites.len() >= 3,
+        "Expected >=3 call-sites for `add`, got {}",
+        call_sites.len()
+    );
+
+    let distinct_files: std::collections::HashSet<_> =
+        call_sites.iter().map(|r| r.file.clone()).collect();
+    assert!(
+        distinct_files.len() >= 2,
+        "Expected call-sites across >=2 files, got {}",
+        distinct_files.len()
+    );
+    assert!(
+        distinct_files
+            .iter()
+            .any(|f| f.to_string_lossy().contains("consumer.ts")),
+        "Expected a call-site in consumer.ts"
+    );
+    assert!(
+        distinct_files
+            .iter()
+            .any(|f| f.to_string_lossy().contains("other.ts")),
+        "Expected a call-site in other.ts"
+    );
+}


### PR DESCRIPTION
## Summary

Adds **TypeScript SCIP indexing** so `find_impact` and the symbol/call-graph tooling work for `.ts`/`.tsx`/`.mts`/`.cts` exactly as they already do for C#. The pipeline mirrors the C# adapter but uses Sourcegraph's `scip-typescript` npm CLI and a **single-pass** defs+refs model (vs C#'s two-phase lazy resolution).

This closes the open TODO `T5`/`PLAN_TYPESCRIPT_SCIP.md` (MVP scope: stages 1–6).

## Changes

### Core indexer
- **`src/symbols/typescript.rs`** (new, ~780 lines) — `TypeScriptSymbolIndexer` implementing the `SymbolIndexer` trait: `tsconfig.json` entrypoint detection, `npx scip-typescript index` invocation, single-pass LMDB write of defs+refs, `find_references` via pure LMDB read (no subprocess), fuzzy symbol matching.
- **`src/symbols/scip_proto.rs`** (new, ~280 lines) — standard SCIP protobuf decoder (documents → occurrences → roles). Used by the TS adapter; C# keeps its custom JSON path.
- **`src/symbols/mod.rs`** — registry now registers `TypeScriptSymbolIndexer` alongside `CSharpSymbolIndexer`.

### Dispatch / wiring (generalized off hardcoded C#)
- **`src/mcp/mod.rs`** — `find_impact` routes `.ts`/`.tsx`/`.mts`/`.cts` to the TS indexer.
- **`src/index/manager.rs`** — file-watcher tracks TypeScript file changes (modified/deleted/rename) and triggers a debounced TS rebuild.
- **`src/serve/mod.rs`** — Phase-3 pre-warm loop iterates all registry languages instead of hardcoding C#.
- **`src/serve/tui*.rs`** — TUI shows the TS symbol-index indicator alongside the C# one.

### Config & deps
- **`Cargo.toml`** / **`Cargo.lock`** — add `prost` (protobuf decode) + `bytes`.
- **`src/constants.rs`** — TS-related constants (helper override env var, extensions).

### Tests & fixtures
- **`tests/symbols_typescript_test.rs`** (new) + **`tests/fixtures/ts-sample/`** — unit tests for protobuf decode, LMDB round-trip, fuzzy matching, and a real-project gated smoke test (requires `npx`/`scip-typescript` on PATH; auto-skipped otherwise).
- **`PLAN_TYPESCRIPT_SCIP.md`** — the 8-stage implementation plan (kept for reference).
- **`AGENTS.md`** — tracks the SCIP adapter dedup (fuzzy-match + LMDB-env boilerplate copied between C# and TS) as follow-up TODO.

## Key design decisions

- **Single-pass** (defs + refs written together in one `rebuild()`) — scip-typescript emits both in its `.scip` output, so no lazy on-demand resolution is needed. `find_references` is a pure LMDB read with no subprocess.
- **`npx scip-typescript`** runtime — no binary shipped in the release bundle; `npx` resolves it on the host. The indexer reports `is_available() = false` when `npx` is absent so MCP degrades gracefully.
- **Shared SCIP protobuf decoder** (`scip_proto.rs`) is TS-only for now; deliberately did **not** refactor `csharp.rs` to use it (flagged as follow-up TODO T5 to avoid touching stable, already-tested code at the tail of a large feature).

## Testing

- [x] `cargo fmt --check` — pass
- [x] `cargo check --all-targets` — pass
- [x] `cargo clippy -D warnings` — pass
- [x] `cargo test --lib` — 607 passed, 18 ignored, 2 **pre-existing flaky Windows env tests** fail under parallel load (both pass in isolation; unrelated to this branch — files `src/db_discovery/repos.rs` & `src/watch/mod.rs` are untouched here)
- [x] New TS unit tests pass (protobuf decode, LMDB round-trip, fuzzy match, tsconfig detection)
- [x] Real-project gated smoke test passes when `npx scip-typescript` is available

## Checklist

- [x] Self-review done (per-stage reviews passed during implementation)
- [x] No new warnings
- [x] Targets `develop` (repo gitflow)
