### PR TITLE
🐛 fix(index): stamp model on serve/git-hook index path (worktree "model: unknown")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`model: unknown` on indexes created via the serve / git-hook path (git worktrees especially).** When a repo was registered through `POST /repos` (the git-hook flow), the vector store was opened first and `ensure_schema_version` pre-created a `metadata.json` containing only `schema_version` — no model fields. The force-reindex path then saw the file already existed and skipped stamping the default model, so the index was left with no `model_short_name`. Every reader reported `model: unknown`, and that sentinel disabled the empty-index live-chunk-count self-heal, making a perfectly good worktree index look empty so agents fell back to grep. The serve/git-hook and incremental-refresh paths now always stamp the resolved model. As part of the fix, the model→metadata stamp (`model_short_name`/`model_name`/`dimensions`) is consolidated into a single `ModelType::write_metadata_fields` source of truth across all five index-creation sites — which also corrects a pre-existing drift where the auto-create-DB path wrote the Debug variant name (e.g. `AllMiniLML6V2Q`) as `model_name` instead of the real model name. Existing worktree indexes need one reindex to pick up the stamped model.
+
 ## [1.1.31] - 2026-07-23
 
 **Security hardening sweep (Aikido) + community bug/dependency fixes.**

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -159,6 +159,30 @@ impl ModelType {
         }
     }
 
+    /// Stamp this model's identity into a metadata JSON object.
+    ///
+    /// Single source of truth for the three metadata keys (`model_short_name`,
+    /// `model_name`, `dimensions`). Every index-creation path — CLI
+    /// (`index_with_options`), serve/git-hook force-reindex, incremental
+    /// refresh, and `--model` override — writes the model through here so the
+    /// keys and value derivation cannot drift, and so `read_model_metadata`
+    /// never has to fall back to the `unknown` sentinel (which disables the
+    /// empty-index self-heal). Overwrites any existing values for these keys.
+    pub fn write_metadata_fields(&self, obj: &mut serde_json::Map<String, serde_json::Value>) {
+        obj.insert(
+            "model_short_name".to_string(),
+            serde_json::Value::String(self.short_name().to_string()),
+        );
+        obj.insert(
+            "model_name".to_string(),
+            serde_json::Value::String(self.name().to_string()),
+        );
+        obj.insert(
+            "dimensions".to_string(),
+            serde_json::Value::Number(self.dimensions().into()),
+        );
+    }
+
     /// List all available models
     pub fn all() -> &'static [ModelType] {
         &[

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -231,6 +231,7 @@ impl EmbeddingService {
     }
 
     /// Get model information
+    #[allow(dead_code)] // Public info accessor; mirrors model_short_name()
     pub fn model_name(&self) -> &str {
         self.model_type.name()
     }

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -856,18 +856,7 @@ impl IndexManager {
         // — a failed write only affects display/status, not searchability.
         {
             if let Err(e) = crate::vectordb::merge_metadata_atomic(db_path, |obj| {
-                obj.insert(
-                    "model_short_name".to_string(),
-                    serde_json::Value::String(embed_model.short_name().to_string()),
-                );
-                obj.insert(
-                    "model_name".to_string(),
-                    serde_json::Value::String(embed_model.name().to_string()),
-                );
-                obj.insert(
-                    "dimensions".to_string(),
-                    serde_json::Value::Number(embed_model.dimensions().into()),
-                );
+                embed_model.write_metadata_fields(obj);
             }) {
                 warn!("metadata.json model write warning: {}", e);
             }
@@ -924,10 +913,9 @@ impl IndexManager {
 
         // Apply model override if provided (e.g. from `index add --model`)
         if let Some(ref mt) = model_override {
-            preserved_metadata["model_short_name"] =
-                serde_json::Value::String(mt.short_name().to_string());
-            preserved_metadata["model_name"] = serde_json::Value::String(mt.name().to_string());
-            preserved_metadata["dimensions"] = serde_json::Value::Number(mt.dimensions().into());
+            if let Some(obj) = preserved_metadata.as_object_mut() {
+                mt.write_metadata_fields(obj);
+            }
             info!(
                 "📝 Model override applied: {} ({} dims)",
                 mt.short_name(),
@@ -948,12 +936,9 @@ impl IndexManager {
         // override was given (the override block above already populated these).
         if preserved_metadata.get("model_short_name").is_none() {
             let default_model = ModelType::default();
-            preserved_metadata["model_short_name"] =
-                serde_json::Value::String(default_model.short_name().to_string());
-            preserved_metadata["model_name"] =
-                serde_json::Value::String(default_model.name().to_string());
-            preserved_metadata["dimensions"] =
-                serde_json::Value::Number(default_model.dimensions().into());
+            if let Some(obj) = preserved_metadata.as_object_mut() {
+                default_model.write_metadata_fields(obj);
+            }
             info!(
                 "📝 metadata.json had no model_short_name (pre-created by schema-version bootstrap) — stamping default model {} ({} dims)",
                 default_model.short_name(),

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -843,8 +843,35 @@ impl IndexManager {
             elapsed.as_secs_f64()
         );
 
-        // Persist chunk/file counts in metadata.json for status(projects)
+        // Persist the resolved model AND the chunk/file counts in metadata.json.
+        //
+        // Writing the model here (mirroring the CLI `index_with_options` path,
+        // which stamps it unconditionally) unifies the two index-creation paths:
+        // an index built via the serve/git-hook path — which may have started
+        // from a model-less metadata.json pre-created by `ensure_schema_version`
+        // — now always ends up with a resolvable `model_short_name`. This is the
+        // structural half of the "model: unknown" fix: it guarantees the model
+        // is recorded regardless of who created the file, so it can never regress
+        // to `unknown` (which also disables the empty-index fallback). Best-effort
+        // — a failed write only affects display/status, not searchability.
         {
+            if let Err(e) = crate::vectordb::merge_metadata_atomic(db_path, |obj| {
+                obj.insert(
+                    "model_short_name".to_string(),
+                    serde_json::Value::String(embed_model.short_name().to_string()),
+                );
+                obj.insert(
+                    "model_name".to_string(),
+                    serde_json::Value::String(embed_model.name().to_string()),
+                );
+                obj.insert(
+                    "dimensions".to_string(),
+                    serde_json::Value::Number(embed_model.dimensions().into()),
+                );
+            }) {
+                warn!("metadata.json model write warning: {}", e);
+            }
+
             let vs = stores.vector_store.read().await;
             if let Ok(stats) = vs.stats() {
                 super::update_metadata_stats(db_path, stats.total_chunks, stats.total_files);
@@ -905,6 +932,32 @@ impl IndexManager {
                 "📝 Model override applied: {} ({} dims)",
                 mt.short_name(),
                 mt.dimensions()
+            );
+        }
+
+        // If the metadata.json that already exists lacks model fields, stamp the
+        // default model. This is the fix for the "model: unknown" worktree bug:
+        // when a repo is registered via `POST /repos` (the git-hook path), the
+        // store is opened first and `ensure_schema_version` pre-creates a
+        // metadata.json containing only `schema_version`. That defeats the
+        // `else` branch above (which only stamps a default when the whole file is
+        // absent), so without this guard the index is left with no
+        // `model_short_name` — every reader then shows `model: unknown` AND the
+        // live-chunk-count fallback (`live_chunk_count`) bails on that string,
+        // making a perfectly-good index look empty. Only runs when no explicit
+        // override was given (the override block above already populated these).
+        if preserved_metadata.get("model_short_name").is_none() {
+            let default_model = ModelType::default();
+            preserved_metadata["model_short_name"] =
+                serde_json::Value::String(default_model.short_name().to_string());
+            preserved_metadata["model_name"] =
+                serde_json::Value::String(default_model.name().to_string());
+            preserved_metadata["dimensions"] =
+                serde_json::Value::Number(default_model.dimensions().into());
+            info!(
+                "📝 metadata.json had no model_short_name (pre-created by schema-version bootstrap) — stamping default model {} ({} dims)",
+                default_model.short_name(),
+                default_model.dimensions()
             );
         }
         let model_name = preserved_metadata
@@ -2117,6 +2170,59 @@ mod tests {
         assert!(
             result.is_ok(),
             "Should return Ok when no metadata.json exists"
+        );
+    }
+
+    #[tokio::test]
+    async fn force_reindex_stamps_model_when_metadata_has_only_schema_version() {
+        // Regression for the "model: unknown" worktree bug.
+        //
+        // When a repo is registered via `POST /repos` (the git-hook path), the
+        // store is opened FIRST and `ensure_schema_version` pre-creates a
+        // metadata.json containing ONLY `schema_version` — no model fields.
+        // Before the fix, force_reindex's Step 0 saw the file already exists and
+        // skipped the default-model stamp, so the index was left with no
+        // `model_short_name`: every reader then showed `model: unknown` AND the
+        // live-chunk-count fallback bailed on that string, making the index look
+        // empty (agent falls back to grep). This test reproduces that exact
+        // bootstrap state and asserts force_reindex now stamps the default model.
+        let temp = tempdir().unwrap();
+        let codebase_path = temp.path().join("codebase");
+        let db_path = temp.path().join("db");
+        std::fs::create_dir_all(&codebase_path).unwrap();
+        std::fs::create_dir_all(&db_path).unwrap();
+
+        // create_test_stores → VectorStore::new → ensure_schema_version, which
+        // writes the real "schema_version only" metadata.json — the exact bug state.
+        let dims = ModelType::default().dimensions();
+        let stores = create_test_stores(&db_path, dims).await;
+
+        // Precondition: the bootstrap wrote NO model field.
+        let before = std::fs::read_to_string(db_path.join("metadata.json")).unwrap();
+        let before_json: serde_json::Value = serde_json::from_str(&before).unwrap();
+        assert!(
+            before_json.get("model_short_name").is_none(),
+            "precondition: schema-version bootstrap must not write a model, got: {before}"
+        );
+
+        // Empty codebase → perform_incremental_refresh returns before any
+        // embedding, so this exercises Fix A (the Step-0 stamp) without loading
+        // an ONNX model.
+        IndexManager::force_reindex_with_stores(&codebase_path, &db_path, &stores, None)
+            .await
+            .expect("force reindex on empty codebase should succeed");
+
+        let after = std::fs::read_to_string(db_path.join("metadata.json")).unwrap();
+        let after_json: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(
+            after_json.get("model_short_name").and_then(|v| v.as_str()),
+            Some(ModelType::default().short_name()),
+            "metadata.json must have the default model_short_name stamped, got: {after}"
+        );
+        assert_eq!(
+            after_json.get("dimensions").and_then(|v| v.as_u64()),
+            Some(dims as u64),
+            "metadata.json must record the default model's dimensions, got: {after}"
         );
     }
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1003,18 +1003,7 @@ async fn index_with_options(
         // partial chunks we already built are still searchable.
         // Uses read-modify-write so existing stats (total_chunks/total_files) are preserved.
         if let Err(e) = merge_metadata_atomic(&db_path, |obj| {
-            obj.insert(
-                "model_short_name".to_string(),
-                serde_json::Value::String(model_type.short_name().to_string()),
-            );
-            obj.insert(
-                "model_name".to_string(),
-                serde_json::Value::String(model_type.name().to_string()),
-            );
-            obj.insert(
-                "dimensions".to_string(),
-                serde_json::Value::Number(model_type.dimensions().into()),
-            );
+            model_type.write_metadata_fields(obj);
             obj.insert(
                 "indexed_at".to_string(),
                 serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
@@ -1085,11 +1074,6 @@ async fn index_with_options(
 
         return Ok(());
     }
-
-    // Capture model info before dropping the ONNX model
-    let model_short_name = embedding_service.model_short_name().to_string();
-    let model_name = embedding_service.model_name().to_string();
-    let model_dimensions = embedding_service.dimensions();
 
     // Free ONNX model + arena allocator memory before final index operations
     // This releases hundreds of MB of inference buffers
@@ -1172,18 +1156,7 @@ async fn index_with_options(
     // (which writes `partial: true`); readers can always check the field
     // regardless of how indexing completed.
     merge_metadata_atomic(&db_path, |obj| {
-        obj.insert(
-            "model_short_name".to_string(),
-            serde_json::Value::String(model_short_name.to_string()),
-        );
-        obj.insert(
-            "model_name".to_string(),
-            serde_json::Value::String(model_name.to_string()),
-        );
-        obj.insert(
-            "dimensions".to_string(),
-            serde_json::Value::Number(model_dimensions.into()),
-        );
+        model_type.write_metadata_fields(obj);
         obj.insert(
             "indexed_at".to_string(),
             serde_json::Value::String(chrono::Utc::now().to_rfc3339()),

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -8686,23 +8686,14 @@ pub async fn run_mcp_server(
         // Get model info
         let model_type = ModelType::default();
         let model_short_name = model_type.short_name().to_string();
-        let model_name = format!("{:?}", model_type);
         let dimensions = model_type.dimensions();
 
-        // Create minimal metadata.json (atomic read-modify-write, matching format used by build_index)
+        // Create minimal metadata.json (atomic read-modify-write, matching format
+        // used by build_index). Routes through the single-source-of-truth stamp so
+        // model_name matches the other index paths (previously wrote the Debug
+        // variant name here, e.g. "AllMiniLML6V2Q", instead of the model name).
         crate::vectordb::merge_metadata_atomic(&db_path, |obj| {
-            obj.insert(
-                "model_short_name".to_string(),
-                serde_json::Value::String(model_short_name.clone()),
-            );
-            obj.insert(
-                "model_name".to_string(),
-                serde_json::Value::String(model_name),
-            );
-            obj.insert(
-                "dimensions".to_string(),
-                serde_json::Value::Number(dimensions.into()),
-            );
+            model_type.write_metadata_fields(obj);
             obj.insert(
                 "indexed_at".to_string(),
                 serde_json::Value::String(chrono::Utc::now().to_rfc3339()),


### PR DESCRIPTION
## Summary
- Fixes the `model: unknown` bug on indexes created via the serve / git-hook (`POST /repos`) path — git worktrees especially.
- Root cause: `ensure_schema_version` pre-creates `metadata.json` with only `schema_version` (no model fields); force-reindex then saw the file existed and skipped stamping the default model. Readers showed `model: unknown`, and that sentinel disabled the empty-index live-chunk-count self-heal → a good worktree index looked empty and agents fell back to grep.
- Consolidates the model→metadata stamp into a single `ModelType::write_metadata_fields` source of truth across all five index-creation sites, correcting a pre-existing drift (auto-create-DB path wrote the Debug variant name `AllMiniLML6V2Q` as `model_name`).

## Changes
- `src/index/manager.rs` — Fix A (`force_reindex_with_stores`: stamp default model when metadata lacks it) + Fix B (`perform_incremental_refresh_with_stores`: persist resolved model) + regression test.
- `src/embed/embedder.rs` — new `ModelType::write_metadata_fields` helper (single source of truth).
- `src/index/mod.rs` — CLI partial-cancel + final save routed through helper; dead capture block removed.
- `src/mcp/mod.rs` — auto-create-DB stamp routed through helper (drift fixed).
- `src/embed/mod.rs` — `#[allow(dead_code)]` on now-unused `model_name()` accessor.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Testing
- [x] `cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --all-targets -D warnings`
- [x] `cargo test --lib` — 596 passed, 20 ignored (pre-push QC gate)
- [x] New regression test `force_reindex_stamps_model_when_metadata_has_only_schema_version`
- [x] 3 reviewer passes → clean ✅ PASS

## Note
Existing worktree indexes (e.g. `HUSQ.Aprimo-209169`) need one reindex to pick up the stamped model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)