### PR TITLE
ci: auto bump patch version on PR-merge to develop

### DIFF
--- a/.github/workflows/bump-develop.yml
+++ b/.github/workflows/bump-develop.yml
@@ -1,0 +1,103 @@
+name: Bump develop version
+
+# Auto patch-bump — the "Incr" component of the Major.Minor.Incr scheme:
+#   - Incr (patch) += 1 here, automatically, on EVERY PR merge to develop.
+#   - Minor bumps deliberately at release time: run
+#     `scripts/bump-version.sh --type minor` on the release branch BEFORE
+#     tagging (the tag commit must carry the new Cargo.toml version, so minor
+#     can't be a tag-push-triggered automation). Patch resets to 0 on minor.
+#   - Major on breaking changes (manual `--type major`).
+#
+# The bot pushes the bump commit back to develop. A push made with GITHUB_TOKEN
+# does NOT re-trigger workflows (prevents loops), so this also will not kick off
+# ci.yml's `on: push: branches: [develop]` for the bump commit — the merged PR's
+# own CI already validated the code.
+#
+# ⚠️ ONE-TIME SETUP REQUIRED — the "block develop" ruleset (id 15793147) enforces
+# a pull_request rule (1 review + code-owner review) on refs/heads/develop, and
+# the default GITHUB_TOKEN is NOT in its bypass list (only RepositoryRole id 5).
+# So a GITHUB_TOKEN push to develop is REJECTED. The push step below therefore
+# authenticates with a PAT whose actor CAN bypass (you, the repo owner/admin):
+#   1. Create a fine-grained PAT: scope = this repo only, permission
+#      Contents = Read and write. Owner = you (admin → bypasses the rule).
+#   2. Add it as a repository Actions secret named CI_PAT.
+#   3. (Alternative to a PAT) install a GitHub App with Contents:write, add the
+#      App to the ruleset bypass list, and mint its token via
+#      actions/create-github-app-token instead of the secret below.
+# Until CI_PAT exists, every run fails fast at checkout (empty token).
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  contents: write
+
+# Serialize concurrent merges so each one gets its own bump. cancel-in-progress:
+# false → a queued run waits, then re-reads a fresh develop (already carrying the
+# previous bump) before bumping again. So N rapid merges → N patch bumps.
+concurrency:
+  group: bump-develop
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    # Only when the PR was actually merged (closed-without-merge is a no-op).
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        # pin@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: develop
+          # CI_PAT (not GITHUB_TOKEN): only a token whose actor can bypass
+          # the "block develop" ruleset may push to develop. See SETUP note above.
+          # Passing `token:` also persists those creds so `git push` below works.
+          token: ${{ secrets.CI_PAT }}
+
+      - name: Compute next patch version
+        id: ver
+        run: |
+          set -euo pipefail
+          CURRENT=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          NEW="$MAJOR.$MINOR.$((PATCH + 1))"
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          echo "::notice::Bump $CURRENT -> $NEW"
+
+      - name: Bump version in Cargo.toml + Cargo.lock
+        env:
+          CURRENT: ${{ steps.ver.outputs.current }}
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          set -euo pipefail
+          # Cargo.toml — the package version line (mirrors scripts/bump-version.sh).
+          sed -i "0,/^version = \"$CURRENT\"/s//version = \"$NEW\"/" Cargo.toml
+          # Cargo.lock — sync ONLY the codesearch package's version line, via a
+          # targeted range (its `name =` -> next `version =`). Never touches
+          # dependency versions (unlike `cargo update --workspace`, which would
+          # opportunistically bump transitive deps as a side effect).
+          sed -i "/^name = \"codesearch\"/,/^version = /{ s/^version = \"$CURRENT\"/version = \"$NEW\"/ }" Cargo.lock
+          # Hard-verify both files now carry the new version before committing.
+          grep -m1 "^version = \"$NEW\"" Cargo.toml >/dev/null
+          grep -A1 '^name = "codesearch"$' Cargo.lock | grep -m1 "^version = \"$NEW\"" >/dev/null
+
+      - name: Commit & push bump
+        env:
+          NEW: ${{ steps.ver.outputs.new }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          # No-op guard (e.g. a re-merge that already left develop at NEW).
+          if git diff --cached --quiet; then
+            echo "No version change to commit (already at $NEW)."
+            exit 0
+          fi
+          git commit -m "chore: bump version to $NEW (auto, PR #$PR merged to develop)"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,13 @@
 .DS_Store
 Thumbs.db
 
-# Ignore all hidden folders at any level (except .githooks)
+# Ignore all hidden folders at any level (except .githooks and .github)
 .*/ 
 **/.*/ 
 !.githooks/
 !**/.githooks/
+!.github/
+!**/.github/
 
 # Project specific
 /data/


### PR DESCRIPTION
## What

Adds `.github/workflows/bump-develop.yml`: when a PR is **closed+merged into `develop`**, automatically bumps the **patch** component (`Major.Minor.Incr` → `Incr += 1`) in `Cargo.toml` **and** the matching `codesearch` package entry in `Cargo.lock`, then pushes the commit as `github-actions[bot]`.

## Versioning scheme implemented

| Event | Bump |
|---|---|
| commit / push / PR create | nothing |
| **PR merge → develop** | `Incr` (patch) +1 (auto, this workflow) |
| **Release** | `Minor` +1, `Incr` → 0 (manual: `scripts/bump-version.sh --type minor`, on the release branch **before** the tag) |
| Breaking change | `Major` (manual) |

Release flow unchanged: minor-bump → PR `develop`→`master` → tag master → `release.yml` builds from the tag.

## Why a PAT (`CI_PAT`), not `GITHUB_TOKEN`

The **"block develop" ruleset** (pull_request review required) blocks the default `GITHUB_TOKEN` (separate bot identity, no bypass role). A fine-grained PAT owned by the bypass-eligible repo owner authenticates **as** the owner, so it inherits the bypass and can push the bump commit.

**Setup (repo owner, do NOT paste tokens into chat/PRs):**
1. Create a fine-grained PAT: resource owner `flupkede`, repository access = All repositories (or this repo), permission **Contents: Read and write**.
2. Add it as an Actions secret named **`CI_PAT`** (Settings → Secrets → Actions).

`concurrency` serializes the bump job, so N rapid merges produce N sequential bumps (never a lost update).

## Also fixes `.gitignore`

The blanket `.*\/` rule was silently ignoring `.github/` (only `.githooks/` was exempted), so **any new file under `.github/`** (e.g. this workflow) could not be `git add`-ed. Adds the matching `!.github/` exception — same pattern as the existing `.githooks/` exemption. This was a latent footgun for all future workflow/config additions.

## Validation

- QC gate (mirrors CI) passed: `cargo fmt --check`, `cargo check`, `cargo clippy`, `cargo test --lib` (**609 passed; 0 failed**).
- Sed logic proven on temp copies of real `Cargo.toml` + `Cargo.lock`: `1.1.31 → 1.1.32` on exactly the `codesearch` version line (Cargo.toml L3 + Cargo.lock L632); **0** of the other 618 version lines touched; verify-greps pass.
- YAML valid (`yaml.safe_load`).

## Not bundled (separate follow-ups)

- `release.yml` `workflow_dispatch` checkout has no `ref:` → manual dispatch builds master-tip but labels the Release with the typed version (mismatch). Likely related to #161.
- `RELEASING.md` says "Squash merge all PRs" / "Create PR → develop. Squash merge." — **wrong**: feature→develop uses merge commits; only `develop`→`master` release PRs are squash. AGENTS.md is correct.
- AGENTS.md stale claim "pre-commit hook auto-bumps patch per commit" — false (hook does `cargo fmt` only).