### PR TITLE
docs: release-process accuracy (workflow_dispatch ref + merge-style + version scheme)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
       # pin@v4
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          # Pin ref so workflow_dispatch builds the tagged commit (inputs.version),
+          # not the default branch (master-tip) — otherwise binaries get labeled
+          # with a version they weren't built from (#161-class mismatch).
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.version) || github.ref }}
           persist-credentials: false
 
       - name: Install Rust
@@ -141,6 +145,10 @@ jobs:
       # pin@v4
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          # Pin ref so workflow_dispatch builds the tagged commit (inputs.version),
+          # not the default branch (master-tip) — otherwise binaries get labeled
+          # with a version they weren't built from (#161-class mismatch).
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.version) || github.ref }}
           persist-credentials: false
 
       - name: Install Rust

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md — codesearch (features/remote-mount-selection)
 
-_Last updated: 2026-07-27_
+_Last updated: 2026-07-29_
 
 ## Current state
 
-- **Version:** see `Cargo.toml` (pre-commit hook auto-bumps patch per commit on feature branches).
+- **Version:** `Major.Minor.Patch` (semver). Patch auto-bumps +1 on every PR merged to `develop` (CI via `.github/workflows/bump-develop.yml`); minor bumps manually at release (`scripts/bump-version.sh --type minor`, resets patch→0). Per-commit uniqueness comes from `build.rs`'s `+<commit_count>` suffix. See `RELEASING.md`.
 - **Validation:** `cargo check` for iteration, `cargo clippy -D warnings` for lint, `cargo test --lib --bins` before a branch is considered done. No `--release` builds during the fix loop — build only at the very end.
 - **Deploy:** cloud peer runs the per-vendor federation split (akeneo/vendor-a/bynder/digizuite/inriver/keyshot + custom KB), image built locally via BuildKit `docker buildx --push`, all vendors reindexed and federation validated end-to-end (`project=cloud/<vendor>`).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,7 +33,8 @@ git commit -m "fix: describe the change"
 git push -u origin fix/my-fix
 ```
 
-Create PR → `develop`. **Squash merge.**
+Create PR → `develop`. **Merge commit** (`--merge`) — feature history stays full of
+`Merge pull request #N`, not squash.
 
 ### 2. Develop → master (when requested)
 
@@ -56,10 +57,14 @@ CI (`release.yml`) builds binaries and creates a GitHub Release with auto-genera
 
 ## Rules
 
-- **Version bumps are manual + deliberate** — edit `version` in `Cargo.toml`
-  when it's meaningful (typically when cutting a release branch), then
-  `cargo update --workspace` to sync `Cargo.lock`. There is no per-commit
-  auto-bump; per-commit uniqueness comes from `build.rs`'s `+<commit_count>`.
+- **Version scheme `Major.Minor.Patch`** (semver):
+  - **Patch** auto-bumps +1 on every PR merged to `develop` — CI does this via
+    `.github/workflows/bump-develop.yml` (edits `Cargo.toml` + syncs `Cargo.lock`,
+    no rebuild). No per-commit bump; per-commit uniqueness still comes from
+    `build.rs`'s `+<commit_count>` suffix.
+  - **Minor** bumps manually at release via `scripts/bump-version.sh --type minor`
+    (resets patch→0). **Major** on breaking changes.
 - **No manual CHANGELOG.md edits** — GitHub Releases auto-generate release notes
-- **Squash merge** all PRs to keep history linear
+- **Merge style:** feature→`develop` = **merge commit** (`--merge`); `develop`→`master`
+  release PR = **squash** (one commit per release on master)
 - **Tag format**: `v1.0.X` on master HEAD


### PR DESCRIPTION
Three release/versioning-process accuracy fixes, the follow-ups flagged after #171 (auto patch-bump workflow) shipped.

**1. release.yml — pin checkout ref (functional, ~#161)**
Both `actions/checkout` steps (build + build-macos jobs) had no `ref:`. On `workflow_dispatch` the action checks out the repo default branch (master-tip), but the release job labels the GitHub Release/artifacts with `inputs.version` -> you publish binaries *labeled* as a version they were not built from. Now `ref:` resolves to `refs/tags/<inputs.version>` on dispatch; on tag push `github.ref` is already the tag, unchanged.

**2. RELEASING.md — correct merge style + version scheme**
- Feature->develop is a **merge commit** (`--merge`), NOT squash — the doc said 'Squash merge' (line 36 + line 64). Only develop->master *release* PRs are squash.
- Version-bumps rule rewritten: patch auto-bumps +1 on every PR merged to develop (CI, #171); minor is manual at release (`bump-version.sh --type minor`, resets patch->0). No longer claims 'no auto-bump'.

**3. AGENTS.md — fix stale auto-bump claim**
Line 7 claimed the pre-commit hook auto-bumps patch per commit on feature branches — doubly wrong (hook does `cargo fmt` only; auto-bump is now CI on PR-merge). Rewrote to the actual scheme; bumped the doc date.

**Validation:** release.yml YAML re-parses (yaml.safe_load). No Rust touched -> no cargo needed.

**Out of scope** (separate reconcile): AGENTS.md still lists the two locked items (find_impact routing, TypeScript SCIP) as open in `## Open TODOs` though both are merged (#163, #167). Not touched here.