### PR TITLE
fix(build): build.ps1 self-heals core.bare before cargo (no more 'did not expect repo to be bare')

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ Common mistake: a subagent runs `/git pr create` with no explicit `--base`, the 
 
 - **Validation:** `cargo check` and `cargo clippy` for iteration. No `--release` builds — always dev/debug until the very end.
 - **Runtime:** `C:\Users\develterf\.local\bin\` — `codesearch.exe` + `helpers/csharp/scip-csharp.exe`
-- **Build:** `target/release/` — outside repo (via `CARGO_TARGET_DIR`)
+- **Build:** `target/release/` — outside repo (via `CARGO_TARGET_DIR`). `build.ps1` self-heals `core.bare=false` before invoking cargo — this checkout is a bare+working-tree hybrid whose `core.bare` intermittently resets to `true` (VS Code's git integration rewrites `.git/config` on ref changes), which makes cargo abort with `did not expect repo to be bare`. No need to flip it manually before building; `build.ps1` does it.
 - **Deploy:** `..\copy-to-common.ps1` — builds + copies both binaries to `~/.local/bin/`. A running `codesearch.exe` is file-locked on Windows; stop serve before deploying.
 - **Canonical paths:** NEVER call `.canonicalize()` directly. Always use `safe_canonicalize()`.
 - **LMDB rule:** No two `EnvOpenOptions::open()` on same dir in same process. All access via `get_or_open_stores()` → `Arc<SharedStores>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ finalized in place with a date — no renaming/migration step needed.
 
 ## [1.2.1] (unreleased)
 
+### Fixed
+
+- **`build.ps1` now self-heals `core.bare=false` before invoking cargo.** This repo lives at `codesearch.git` as a bare+working-tree hybrid — a full checked-out source tree + `.git/index`, but `core.bare=true` in `.git/config`. `core.bare` intermittently resets to `true` (VS Code's git integration rewrites `.git/config` on ref changes; smoking gun: `github-pr-owner-number` duplicated 7× for `develop`), and when it does, cargo's source fingerprinting aborts every build with `did not expect repo ...\.git to be bare`, breaking `copy-to-common.ps1` → `build.ps1` → `cargo build`. `build.ps1` now forces `core.bare=false` right after `Set-Location`, before any cargo invocation. Idempotent and harmless for a normal (truly non-bare) checkout; non-fatal if git is unreachable.
+
 ## [1.2.0] - 2026-08-03
 
 **TypeScript & Protobuf indexing, remote-TUI auth, cloud + cancellation hardening.** First minor bump since the 1.1.0 federation release: TypeScript joins `find_impact` via SCIP, Protobuf is now a tree-sitter-indexed language, the standalone remote TUI works against authenticated serves, and the embedded serve TUI stops waking scale-to-zero cloud peers — plus a cloud-serve OOM/read-only fix, honest index-cancellation, and a self-cleanup backstop for orphaned index dirs.

--- a/build.ps1
+++ b/build.ps1
@@ -29,6 +29,24 @@ $ErrorActionPreference = "Stop"
 $ScriptDir = $PSScriptRoot
 Set-Location $ScriptDir
 
+# --- Self-heal: force core.bare = false (cargo fingerprint-safe) ---
+# This repo lives at codesearch.git as a bare+working-tree hybrid: full
+# checked-out tree + .git/index, but core.bare intermittently resets to `true`
+# (VS Code's git integration rewrites .git/config on ref changes). When
+# core.bare=true, cargo's source fingerprinting aborts with
+# "did not expect repo ... to be bare", breaking every build. Force it false
+# before invoking cargo. Idempotent and harmless for a normal (truly non-bare)
+# checkout too.
+try {
+    & git -C $ScriptDir config core.bare $false 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  [self-heal] ensured core.bare=false (cargo fingerprint-safe)" -ForegroundColor DarkGray
+    }
+} catch {
+    # Non-fatal — if git isn't reachable or this isn't a git repo, let cargo
+    # run and surface its own error.
+}
+
 # Determine build mode
 $BuildMode = if ($Release) { "release" } else { "debug" }
 


### PR DESCRIPTION
## Summary

`build.ps1` now forces `core.bare=false` before invoking `cargo build`, fixing the recurring `did not expect repo ...\.git to be bare` build failure on this checkout.

## Root cause

This repo lives at `codesearch.git` as a **bare+working-tree hybrid**: it has a full checked-out source tree and a `.git/index`, but `core.bare=true` in `.git/config`. `core.bare` intermittently resets to `true` — VS Code's git integration rewrites `.git/config` on ref changes (smoking gun: `github-pr-owner-number` is duplicated 7× for `develop` in `.git/config`, a known VS Code GitHub-Pull-Requests extension artifact). The flip persists when idle and through fetch/worktree ops.

When `core.bare=true`, cargo's source fingerprinting aborts every build with:

\`\`\`
error: failed to determine package fingerprint for build script \`build.rs\`
Caused by: did not expect repo at '...\.git' to be bare
\`\`\`

This breaks `copy-to-common.ps1` → `build.ps1` → `cargo build`. Manually flipping `git config core.bare false` works and persists through a build; this PR makes `build.ps1` do that flip automatically.

## The fix

Inserted a self-heal block in `build.ps1` right after \`Set-Location $ScriptDir\`, before the build-mode determination:

\`\`\`powershell
try {
    & git -C $ScriptDir config core.bare \$false 2>\$null
    if (\$LASTEXITCODE -eq 0) {
        Write-Host "  [self-heal] ensured core.bare=false (cargo fingerprint-safe)" -ForegroundColor DarkGray
    }
} catch {
    # Non-fatal — if git isn't reachable or this isn't a git repo, let cargo
    # run and surface its own error.
}
\`\`\`

- **Idempotent** — forcing an already-false \`core.bare\` to false is a no-op.
- **Harmless** for a normal (truly non-bare) checkout.
- **Non-fatal** — if git is unreachable or this isn't a git repo, the \`catch\` lets cargo run and surface its own error.

## Validation

- ✅ Simulated the failure: set \`core.bare=true\` in the worktree, ran \`build.ps1\` → self-heal fired (\`[self-heal] ensured core.bare=false\`), \`core.bare\` ended \`False\`, \`cargo build\` succeeded (no bare-repo error).
- ✅ \`cargo fmt --all -- --check\`
- ✅ \`cargo clippy --all-targets -- -D warnings\`
- ✅ \`cargo test --lib --bins\` (555 + 551 passed, 0 failed)
- ✅ PS1 syntax validated via \`[Parser]::ParseFile\` (0 errors).

## Files

- \`build.ps1\` — the self-heal block.
- \`CHANGELOG.md\` — \`### Fixed\` entry under \`[1.2.1] (unreleased)\`.
- \`AGENTS.md\` — concise note in "Notes for OpenCode / agents" that \`build.ps1\` self-heals \`core.bare\` (so agents don't manually flip it).