### PR TITLE
fix: translate MSYS POSIX paths at the path boundary (path-pollution defect)

### DIFF
--- a/src/cache/file_meta.rs
+++ b/src/cache/file_meta.rs
@@ -37,7 +37,75 @@ pub fn strip_unc_prefix(path: PathBuf) -> PathBuf {
     }
 }
 
-/// Canonicalize a path and strip any Windows UNC `\\?\` prefix.
+/// Translate an MSYS / Git Bash POSIX-style drive path (`/c/Users/...`) to
+/// its Windows drive-path equivalent (`C:/Users/...`). Idempotent on every
+/// other input. On non-Windows this is a no-op (a Unix path like `/c/...`
+/// is a legitimate absolute path, not an MSYS-ism).
+///
+/// # Why this exists
+/// When an agent (or any non-MSYS caller — e.g. an MCP client) sends
+/// codesearch a path like `/c/Users/foo`, Rust on Windows interprets the
+/// leading `/` as "rooted on the *current drive*" — i.e. it resolves to
+/// `<current-drive>:\c\Users\foo`, creating junk directories like
+/// `C:\c\Users\...` and silently indexing the wrong project. This is the
+/// path-pollution defect behind the orphan `<repo>-propagate-tmp` indexes:
+/// an agent-supplied POSIX path slipped past `safe_canonicalize` and got
+/// materialised on disk as `C:\c\...`.
+///
+/// # What it matches
+/// A leading `/` followed by a **single ASCII letter** followed by either
+/// `/` or end-of-string. So `/c`, `/c/`, `/c/Users/foo` all match (drive `C`);
+/// `/ab/foo`, `/usr/bin`, `relative/c/x` do **not** match (left untouched).
+///
+/// # What it does not match
+/// Existing Windows paths (`C:\...`, `C:/...`) — the first byte is not `/`,
+/// so they pass through unchanged. Verbatim UNC (`\\?\C:\...`) likewise.
+#[cfg(windows)]
+pub fn translate_msys_path(path: &Path) -> PathBuf {
+    let s = path.to_string_lossy();
+    let b = s.as_bytes();
+    if b.len() >= 2 && b[0] == b'/' {
+        let second = b[1];
+        if second.is_ascii_alphabetic() && (b.len() == 2 || b[2] == b'/') {
+            // `/c/Users/foo` → `C:/Users/foo`. Windows accepts `/` as a path
+            // separator, so we don't need to rewrite subsequent slashes.
+            // Drive letter is upper-cased so `/c/...` and `/C/...` collapse
+            // to the same canonical form before they reach the registry.
+            let drive = (second as char).to_ascii_uppercase();
+            let rest = if b.len() > 2 { &s[2..] } else { "/" };
+            return PathBuf::from(format!("{}:{}", drive, rest));
+        }
+    }
+    path.to_path_buf()
+}
+
+/// Non-Windows: legitimate absolute POSIX path, must not be rewritten.
+/// (See the Windows variant above for the full rationale.)
+#[cfg(not(windows))]
+pub fn translate_msys_path(path: &Path) -> PathBuf {
+    path.to_path_buf()
+}
+
+/// Normalize a raw user-supplied path: translate any MSYS POSIX drive prefix
+/// (`/c/...` → `C:/...`) AND strip any Windows UNC `\\?\` prefix.
+///
+/// Use this as the **fallback** when [`safe_canonicalize`] fails (path
+/// doesn't exist yet, permission denied, etc.) so the registry never stores
+/// a raw path that Windows would later resolve to a polluted
+/// `<drive>:\c\...` location. Both operations are idempotent and no-ops on
+/// non-Windows, so this is safe to call unconditionally.
+///
+/// This helper exists precisely to avoid the per-site discipline trap of
+/// repeating `translate_msys_path(&strip_unc_prefix(path))` at every
+/// fallback site — that pattern was the original defect: `register()` had
+/// it, but `unregister_path()` and `alias_for_path()` did not, breaking
+/// register/unregister symmetry.
+pub fn normalize_user_path(path: &Path) -> PathBuf {
+    strip_unc_prefix(translate_msys_path(path))
+}
+
+/// Canonicalize a path, translate any MSYS POSIX-style prefix first, and
+/// strip any Windows UNC `\\?\` prefix from the result.
 ///
 /// **This is the ONLY approved way to canonicalize paths in codesearch.**
 /// It returns the same error as `Path::canonicalize()` on failure (path does
@@ -48,8 +116,13 @@ pub fn strip_unc_prefix(path: PathBuf) -> PathBuf {
 /// `.join()` and `Path::exists()` to fail inconsistently on sub-paths, and
 /// produces diverging HashMap keys when the same directory is accessed with
 /// and without the prefix. `safe_canonicalize` eliminates this class of bug.
+///
+/// It also calls [`translate_msys_path`] *before* canonicalising, so that
+/// caller-supplied POSIX-style paths (`/c/Users/foo`) are routed to
+/// `C:/Users/foo` rather than being materialised as `<drive>:\c\Users\foo`.
 pub fn safe_canonicalize(path: &Path) -> std::io::Result<PathBuf> {
-    path.canonicalize().map(strip_unc_prefix)
+    let translated = translate_msys_path(path);
+    translated.canonicalize().map(strip_unc_prefix)
 }
 
 /// Normalize a file path for consistent HashMap lookups.

--- a/src/cache/file_meta_tests.rs
+++ b/src/cache/file_meta_tests.rs
@@ -158,6 +158,50 @@ fn translate_msys_path_is_noop_on_unix() {
     );
 }
 
+// ── normalize_user_path ─────────────────────────────────────────────────
+//
+// Single helper used by every "safe_canonicalize(...).unwrap_or_else(_)"
+// fallback site (register, unregister_path, alias_for_path, scan_for_remote,
+// resolve_database_with_message, try_delegate_*_to_serve, run_serve). Tests
+// pin both the translate + UNC-strip composition and the contract that
+// makes it safe to call on already-clean paths.
+
+#[cfg(windows)]
+#[test]
+fn normalize_user_path_translates_msys_and_strips_unc() {
+    // MSYS path → translated, no UNC to strip (input is not yet canonical).
+    assert_eq!(
+        normalize_user_path(&PathBuf::from("/c/Users/foo")),
+        PathBuf::from("C:/Users/foo")
+    );
+    // Already-canonical UNC path → UNC stripped, no translate needed
+    // (first byte is `\`, not `/`).
+    assert_eq!(
+        normalize_user_path(&PathBuf::from(r"\\?\C:\Users\foo")),
+        PathBuf::from(r"C:\Users\foo")
+    );
+    // Already-clean Windows path → idempotent.
+    assert_eq!(
+        normalize_user_path(&PathBuf::from(r"C:\Users\foo")),
+        PathBuf::from(r"C:\Users\foo")
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn normalize_user_path_only_strips_unc_on_unix() {
+    // No MSYS translation on Unix; UNC strip is a no-op on a non-Windows
+    // path but the function must still be safe to call.
+    assert_eq!(
+        normalize_user_path(&PathBuf::from("/c/Users/foo")),
+        PathBuf::from("/c/Users/foo")
+    );
+    assert_eq!(
+        normalize_user_path(&PathBuf::from("/home/user")),
+        PathBuf::from("/home/user")
+    );
+}
+
 #[cfg(windows)]
 #[test]
 fn test_normalize_path_windows_forms() {

--- a/src/cache/file_meta_tests.rs
+++ b/src/cache/file_meta_tests.rs
@@ -59,6 +59,105 @@ fn safe_canonicalize_on_nonexistent_path_returns_error() {
     );
 }
 
+// ── translate_msys_path ─────────────────────────────────────────────────
+//
+// Regression guard for the `<repo>-propagate-tmp` path-pollution defect:
+// an agent-supplied POSIX path (`/c/Users/...`) slipped past canonicalize
+// and got materialised on Windows as `<current-drive>:\c\Users\...`, creating
+// junk `C:\c\Users\...` directories. translate_msys_path closes that hole.
+
+#[cfg(windows)]
+#[test]
+fn translate_msys_path_converts_single_letter_drive() {
+    let cases: &[(&str, &str)] = &[
+        // lowercase drive → uppercase
+        ("/c/Users/foo", "C:/Users/foo"),
+        // uppercase drive → unchanged
+        ("/D/data/repo", "D:/data/repo"),
+        // bare drive root
+        ("/c", "C:/"),
+        // drive root with trailing slash
+        ("/c/", "C://"),
+        // deeply nested
+        ("/z/a/b/c/d/e/f", "Z:/a/b/c/d/e/f"),
+    ];
+    for (input, expected) in cases {
+        let got = translate_msys_path(&PathBuf::from(input));
+        assert_eq!(
+            got,
+            PathBuf::from(*expected),
+            "translate_msys_path({:?}): expected {:?}, got {:?}",
+            input,
+            expected,
+            got
+        );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn translate_msys_path_leaves_non_drive_paths_untouched() {
+    // These look like POSIX paths but are NOT single-letter-drive MSYS paths
+    // — they must be left as-is so genuine Unix-isms (/usr, /etc, multi-char)
+    // aren't accidentally rewritten.
+    let cases: &[&str] = &[
+        "/usr/bin/foo",    // multi-char first segment
+        "/ab/foo",         // two-letter drive → not a Windows drive
+        "/home/user",      // multi-char
+        "/1/foo",          // digit, not a letter
+        "/_foo",           // underscore, not a letter
+        "relative/path",   // not absolute
+        "relative/c/path", // relative despite single-letter segment
+        ".",               // bare relative
+        "",                // empty
+    ];
+    for input in cases {
+        let got = translate_msys_path(&PathBuf::from(*input));
+        assert_eq!(
+            got,
+            PathBuf::from(*input),
+            "translate_msys_path({:?}) must be a no-op, got {:?}",
+            input,
+            got
+        );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn translate_msys_path_leaves_existing_windows_paths_untouched() {
+    let cases: &[&str] = &[
+        r"C:\Users\foo",
+        "C:/Users/foo",
+        r"\\?\C:\Users\foo", // UNC verbatim
+        r"D:\",
+    ];
+    for input in cases {
+        let got = translate_msys_path(&PathBuf::from(*input));
+        assert_eq!(
+            got,
+            PathBuf::from(*input),
+            "translate_msys_path must not touch existing Windows paths: {:?} → {:?}",
+            input,
+            got
+        );
+    }
+}
+
+#[cfg(not(windows))]
+#[test]
+fn translate_msys_path_is_noop_on_unix() {
+    // On Unix `/c/Users/foo` is a legitimate absolute path, not an MSYS-ism.
+    assert_eq!(
+        translate_msys_path(&PathBuf::from("/c/Users/foo")),
+        PathBuf::from("/c/Users/foo")
+    );
+    assert_eq!(
+        translate_msys_path(&PathBuf::from("/home/user")),
+        PathBuf::from("/home/user")
+    );
+}
+
 #[cfg(windows)]
 #[test]
 fn test_normalize_path_windows_forms() {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,8 +1,8 @@
 mod file_meta;
 
 pub use file_meta::{
-    normalize_filter_path, normalize_path, normalize_path_str, path_matches_filter,
-    safe_canonicalize, strip_unc_prefix, FileMetaStore,
+    normalize_filter_path, normalize_path, normalize_path_str, normalize_user_path,
+    path_matches_filter, safe_canonicalize, strip_unc_prefix, FileMetaStore,
 };
 
 use moka::sync::Cache;

--- a/src/db_discovery/mod.rs
+++ b/src/db_discovery/mod.rs
@@ -366,8 +366,12 @@ pub fn resolve_database_with_message(
         PathBuf::from(".")
     };
 
-    // Try to canonicalize, but fall back to original path if it fails
-    let canonical_path = safe_canonicalize(&project_path).unwrap_or(project_path.clone());
+    // Try to canonicalize, but fall back to original path if it fails.
+    // normalize_user_path on the fallback translates caller-supplied POSIX
+    // paths (`/c/...` → `C:/...`) even when the path doesn't exist yet
+    // (safe_canonicalize itself already translates before canonicalising).
+    let canonical_path = safe_canonicalize(&project_path)
+        .unwrap_or_else(|_| crate::cache::normalize_user_path(&project_path));
     let db_path = canonical_path.join(".codesearch.db");
     Ok((db_path, canonical_path))
 }

--- a/src/db_discovery/repos.rs
+++ b/src/db_discovery/repos.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::cache::{safe_canonicalize, strip_unc_prefix};
+use crate::cache::{normalize_user_path, safe_canonicalize, strip_unc_prefix};
 use crate::constants::{CONFIG_DIR_NAME, REPOS_CONFIG_FILE};
 
 /// A remote `codesearch serve` peer that can be queried for federation.
@@ -335,10 +335,12 @@ impl ReposConfig {
     }
 
     pub fn register(&mut self, path: PathBuf) -> String {
-        // safe_canonicalize strips \\?\ on success; strip_unc_prefix handles the
-        // fallback so UNC paths never enter the registry even if the path doesn't
-        // exist yet (e.g. a path that will be created during indexing).
-        let canonical = safe_canonicalize(&path).unwrap_or_else(|_| strip_unc_prefix(path));
+        // safe_canonicalize strips \\?\ on success AND translates MSYS POSIX
+        // paths (`/c/...` → `C:/...`); the fallback re-applies both via
+        // normalize_user_path so a not-yet-existing path still enters the
+        // registry as `C:/...` instead of the raw `/c/...` (which Windows
+        // would later resolve to `<drive>:\c\...`, the path-pollution defect).
+        let canonical = safe_canonicalize(&path).unwrap_or_else(|_| normalize_user_path(&path));
 
         if let Some((alias, _)) = self
             .repos
@@ -357,7 +359,7 @@ impl ReposConfig {
     }
 
     pub fn register_with_alias(&mut self, path: PathBuf, alias: Option<String>) -> Result<String> {
-        let canonical = safe_canonicalize(&path).unwrap_or_else(|_| strip_unc_prefix(path));
+        let canonical = safe_canonicalize(&path).unwrap_or_else(|_| normalize_user_path(&path));
 
         if let Some((existing_alias, _)) = self
             .repos
@@ -428,8 +430,12 @@ impl ReposConfig {
     }
 
     pub fn unregister_path(&mut self, path: &Path) -> bool {
-        let canonical =
-            safe_canonicalize(path).unwrap_or_else(|_| strip_unc_prefix(path.to_path_buf()));
+        // normalize_user_path on the fallback keeps register/unregister
+        // symmetry: if `register("/c/Users/foo")` stored `C:\Users\foo`, then
+        // `unregister_path("/c/Users/foo")` must match it even when the dir
+        // no longer exists (canonicalize fails) — see AGENTS.md "structural
+        // fix" rule for the warnings-channel class defect this mirrors.
+        let canonical = safe_canonicalize(path).unwrap_or_else(|_| normalize_user_path(path));
         let to_remove = self
             .repos
             .iter()
@@ -955,8 +961,9 @@ impl ReposConfig {
     }
 
     pub fn alias_for_path(&self, path: &Path) -> Option<String> {
-        let canonical =
-            safe_canonicalize(path).unwrap_or_else(|_| strip_unc_prefix(path.to_path_buf()));
+        // See unregister_path: normalize_user_path on the fallback preserves
+        // lookup symmetry for not-on-disk paths.
+        let canonical = safe_canonicalize(path).unwrap_or_else(|_| normalize_user_path(path));
         self.repos
             .iter()
             .find(|(_, p)| normalize_path_for_compare(p) == normalize_path_for_compare(&canonical))
@@ -1217,7 +1224,10 @@ fn scan_for_remote(dir: &Path, target_remote: &str, depth: usize, out: &mut Vec<
         if git_remote_url(dir).as_deref() == Some(target_remote) {
             // Canonicalize to resolve 8.3 short names on Windows (e.g. RUNNER~1 →
             // runneradmin) so stored and found paths are always in the same form.
-            out.push(safe_canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf()));
+            // normalize_user_path on the fallback is defensive (paths here come
+            // from a filesystem scan, so they are already clean Windows paths,
+            // but the helper is a no-op then).
+            out.push(safe_canonicalize(dir).unwrap_or_else(|_| normalize_user_path(dir)));
         }
         return;
     }

--- a/src/db_discovery/repos_tests.rs
+++ b/src/db_discovery/repos_tests.rs
@@ -130,6 +130,168 @@ fn register_derives_alias_from_directory_name() {
     assert!(cfg.repos.contains_key(&alias));
 }
 
+/// Regression for the `<repo>-propagate-tmp` path-pollution defect.
+///
+/// An agent (or any non-MSYS caller) supplied a POSIX-style path
+/// `/c/Users/.../repo` to `register()`. Before the fix, `safe_canonicalize`
+/// failed (LMDB-style paths that exist on disk did translate, but fresh
+/// not-yet-created paths fell through to `strip_unc_prefix` which is a no-op
+/// on `/c/...`), and Windows then resolved `/c/...` as
+/// `<current-drive>:\c\...`, creating junk `C:\c\Users\...` directories and
+/// silently indexing the wrong project.
+///
+/// After the fix, the POSIX path is translated to `C:/...` (or `D:/...`, etc.)
+/// on the success path AND the fallback path, so the registry entry points
+/// at the real Windows location regardless of whether the dir exists yet.
+#[test]
+#[cfg(windows)]
+fn register_translates_msys_posix_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Construct the Windows path of a temp dir, then express its parent+name
+    // as the MSYS POSIX equivalent (`/c/...`).
+    let win_repo = tmp.path().join("propagate-tmp-repo");
+    std::fs::create_dir(&win_repo).unwrap();
+    let win_str = win_repo.to_string_lossy().replace('\\', "/");
+    // win_str looks like "C:/Users/.../propagate-tmp-repo"
+    let (drive_letter, rest) = win_str.split_at(2); // "C:" + "/Users/..."
+    let drive_letter = drive_letter.chars().next().unwrap();
+    let msys_path = format!(
+        "/{}/{}",
+        drive_letter.to_ascii_lowercase(),
+        rest.trim_start_matches('/')
+    );
+    // msys_path now looks like "/c/Users/.../propagate-tmp-repo"
+
+    let mut cfg = ReposConfig::default();
+    let alias = cfg.register(PathBuf::from(&msys_path));
+
+    // The registered path must be the canonical Windows path, NOT a polluted
+    // `C:\c\Users\...` form. Compare normalized (forward-slash, lower-cased
+    // drive) so the assertion is robust against canonicalize's exact casing.
+    let stored = cfg.repos.get(&alias).expect("alias must be registered");
+    let stored_norm = stored.to_string_lossy().replace('\\', "/").to_lowercase();
+    let expected_norm = win_str.to_lowercase();
+    assert_eq!(
+        stored_norm, expected_norm,
+        "register() must translate MSYS path {:?} to {:?}, got {:?}",
+        msys_path, win_str, stored
+    );
+
+    // And the registered path must actually resolve to the same directory
+    // (i.e. no `C:\c\...` junk was created alongside).
+    assert!(
+        stored.exists(),
+        "registered path must exist (no path pollution): {}",
+        stored.display()
+    );
+}
+
+/// Pins the **non-existing-path** branch — the actual defect site.
+///
+/// The sibling test `register_translates_msys_posix_path` creates the dir on
+/// disk first, so `safe_canonicalize` succeeds on the first call and the
+/// fallback (where the bug lived) never executes. This test deliberately
+/// does NOT create the dir, forcing `safe_canonicalize` to fail and the
+/// `normalize_user_path` fallback to run. If someone "simplifies" the
+/// fallback to `strip_unc_prefix(path)` (the pre-fix code), this test goes
+/// red: stored path would be `/c/...` instead of `C:/...`.
+#[test]
+#[cfg(windows)]
+fn register_translates_msys_posix_path_when_dir_does_not_exist() {
+    let tmp = tempfile::tempdir().unwrap();
+    let win_repo = tmp.path().join("never-created-propagate-tmp");
+    // Deliberately do NOT create_dir — the path must not exist.
+    assert!(!win_repo.exists());
+
+    let win_str = win_repo.to_string_lossy().replace('\\', "/");
+    let (drive_letter, rest) = win_str.split_at(2);
+    let drive_letter = drive_letter.chars().next().unwrap();
+    let msys_path = format!(
+        "/{}/{}",
+        drive_letter.to_ascii_lowercase(),
+        rest.trim_start_matches('/')
+    );
+
+    let mut cfg = ReposConfig::default();
+    let alias = cfg.register(PathBuf::from(&msys_path));
+
+    let stored = cfg.repos.get(&alias).expect("alias must be registered");
+    let stored_norm = stored.to_string_lossy().replace('\\', "/").to_lowercase();
+    assert_eq!(
+        stored_norm,
+        win_str.to_lowercase(),
+        "register() fallback must translate MSYS path {:?} to {:?}, got {:?} — \
+         if this fails, the fallback in register() was reverted to strip_unc_prefix \
+         and the original path-pollution defect is back",
+        msys_path,
+        win_str,
+        stored
+    );
+}
+
+/// Pins **register/unregister symmetry** — the second defect the reviewer
+/// flagged. Before the structural fix, `register("/c/Users/foo")` stored
+/// `C:\Users\foo` but `unregister_path("/c/Users/foo")` compared against the
+/// untranslated `/c/Users/foo` (its fallback used `strip_unc_prefix`, which
+/// is a no-op on `/c/...`) and returned `false`, leaving the entry stuck in
+/// the registry. After the fix, both sides use `normalize_user_path` on the
+/// fallback, so they agree.
+#[test]
+#[cfg(windows)]
+fn unregister_path_matches_msys_posix_form() {
+    let tmp = tempfile::tempdir().unwrap();
+    let win_repo = tmp.path().join("propagate-tmp-unreg");
+    std::fs::create_dir(&win_repo).unwrap();
+    let win_str = win_repo.to_string_lossy().replace('\\', "/");
+    let (drive_letter, rest) = win_str.split_at(2);
+    let drive_letter = drive_letter.chars().next().unwrap();
+    let msys_path = format!(
+        "/{}/{}",
+        drive_letter.to_ascii_lowercase(),
+        rest.trim_start_matches('/')
+    );
+
+    let mut cfg = ReposConfig::default();
+    let alias = cfg.register(PathBuf::from(&msys_path));
+    assert!(cfg.repos.contains_key(&alias));
+
+    // Now delete the dir so unregister_path's safe_canonicalize fails and the
+    // normalize_user_path fallback runs (this is the branch that used to miss).
+    std::fs::remove_dir(&win_repo).unwrap();
+    assert!(!win_repo.exists());
+
+    let removed = cfg.unregister_path(&PathBuf::from(&msys_path));
+    assert!(
+        removed,
+        "unregister_path must match the MSYS form via normalize_user_path fallback"
+    );
+    assert!(
+        !cfg.repos.contains_key(&alias),
+        "alias must be gone after unregister"
+    );
+}
+
+/// On Unix, `/c/Users/...` is a legitimate absolute path (not an MSYS-ism),
+/// so `register()` must store it verbatim. This guards against the Windows
+/// fix accidentally rewriting paths on the wrong platform.
+#[test]
+#[cfg(not(windows))]
+fn register_leaves_unix_path_untouched() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("propagate-tmp-repo");
+    std::fs::create_dir(&repo).unwrap();
+    let path_str = repo.to_string_lossy().to_string();
+
+    let mut cfg = ReposConfig::default();
+    let alias = cfg.register(repo.clone());
+    let stored = cfg.repos.get(&alias).expect("alias must be registered");
+    assert_eq!(
+        stored.to_string_lossy(),
+        path_str,
+        "register() must not rewrite Unix paths"
+    );
+}
+
 #[test]
 #[cfg_attr(
     windows,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -2060,8 +2060,11 @@ async fn try_delegate_reindex_to_serve(
         .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
     // Canonicalize and strip UNC prefix (\\?\) for reliable path operations.
-    let project_path =
-        safe_canonicalize(&raw_project_path).unwrap_or_else(|_| raw_project_path.clone());
+    // normalize_user_path on the fallback handles caller-supplied MSYS POSIX
+    // paths (`/c/...` → `C:/...`) even when canonicalize fails (path doesn't
+    // exist yet) — same defect class as register(), see AGENTS.md.
+    let project_path = safe_canonicalize(&raw_project_path)
+        .unwrap_or_else(|_| crate::cache::normalize_user_path(&raw_project_path));
 
     let config = crate::db_discovery::repos::ReposConfig::load()
         .map_err(|e| format!("cannot load repos.json: {}", e))?;
@@ -2292,8 +2295,10 @@ pub(crate) async fn try_delegate_add_to_serve(
     let raw_project_path = path
         .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-    let project_path =
-        safe_canonicalize(&raw_project_path).unwrap_or_else(|_| raw_project_path.clone());
+    // normalize_user_path on the fallback: caller-supplied MSYS POSIX paths
+    // (`/c/...` → `C:/...`) must not leak to the serve POST body.
+    let project_path = safe_canonicalize(&raw_project_path)
+        .unwrap_or_else(|_| crate::cache::normalize_user_path(&raw_project_path));
 
     // 3. Build request body
     let mut body = serde_json::json!({
@@ -2390,11 +2395,14 @@ pub(crate) async fn try_delegate_rm_to_serve(
     let raw_project_path = path
         .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-    let project_path =
-        safe_canonicalize(&raw_project_path).unwrap_or_else(|_| raw_project_path.clone());
+    // normalize_user_path on the fallback: same defect-class fix as register().
+    let project_path = safe_canonicalize(&raw_project_path)
+        .unwrap_or_else(|_| crate::cache::normalize_user_path(&raw_project_path));
 
     fn normalize_for_cmp(p: &std::path::Path) -> String {
-        let canonical = safe_canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+        // Same translate-on-fallback discipline as the outer call site.
+        let canonical =
+            safe_canonicalize(p).unwrap_or_else(|_| crate::cache::normalize_user_path(p));
         crate::cache::normalize_path(&canonical).to_lowercase()
     }
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -2073,7 +2073,10 @@ async fn try_delegate_reindex_to_serve(
     /// relative components), then normalize via `cache::normalize_path` (strips
     /// Windows UNC prefix, converts backslashes) and lowercases for case-insensitive match.
     fn normalize_for_cmp(p: &std::path::Path) -> String {
-        let canonical = safe_canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+        // Same translate-on-fallback discipline as the outer call site and the
+        // twin closure in try_delegate_rm_to_serve — see stage-1/stage-2.
+        let canonical =
+            safe_canonicalize(p).unwrap_or_else(|_| crate::cache::normalize_user_path(p));
         crate::cache::normalize_path(&canonical).to_lowercase()
     }
 

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -4742,7 +4742,12 @@ pub async fn run_serve(
     // Load repos config (register any --register paths first)
     let mut config = ReposConfig::load().unwrap_or_default();
     for path in &register_paths {
-        let canonical = safe_canonicalize(path).unwrap_or_else(|_| path.clone());
+        // normalize_user_path on the fallback: a `--register /c/Users/...`
+        // invocation must not register a polluted `C:\c\Users\...` path. The
+        // validate_path_within_allowed_roots check below also needs the
+        // canonical form, not the raw MSYS path.
+        let canonical =
+            safe_canonicalize(path).unwrap_or_else(|_| crate::cache::normalize_user_path(path));
 
         // Validate path against allowed roots (if configured)
         if let Err(e) = validate_path_within_allowed_roots(&canonical) {


### PR DESCRIPTION
An agent (or any non-MSYS caller — CLI, MCP client, `--register` flag) supplying a POSIX-style drive path `/c/Users/...` to codesearch on Windows silently produced `<current-drive>:\c\Users\...`, creating junk directories like `C:\c\Users\...` and silently indexing the wrong project. This is the path-pollution defect behind the orphan `<repo>-propagate-tmp` indexes.

## Fix

Two helpers in `src/cache/file_meta.rs`:
- `translate_msys_path(path)` — Windows-only rewrite of `/c/...` → `C:/...`. No-op on Unix.
- `normalize_user_path(path)` — `strip_unc_prefix(translate_msys_path(path))`. Single helper for every `safe_canonicalize(...).unwrap_or_else(_)` fallback site.

`safe_canonicalize` itself now calls `translate_msys_path` before canonicalising.

Applied at 11 production sites across `db_discovery/{repos,mod}.rs`, `index/mod.rs`, `serve/mod.rs`.

Non-repo indexing stays supported — intentionally NO git-repo check added.

## Commits

- stage 1: introduce helpers + fix 6 db_discovery sites + 7 tests
- stage 2: sweep 5 sites in index/mod.rs + serve/mod.rs
- stage 3: fix twin normalize_for_cmp closure missed in stage 2

## Tests

- `translate_msys_path_*` (3 unit, Windows-specific) + noop-on-unix guard
- `normalize_user_path_*` (Windows + Unix variants)
- `register_translates_msys_posix_path` (existing-path branch)
- `register_translates_msys_posix_path_when_dir_does_not_exist` (pins the actual defect site)
- `unregister_path_matches_msys_posix_form` (register/unregister symmetry)
- `register_leaves_unix_path_untouched`

Reviewer positive-control: reverting register() fallback makes the non-existing-path test go red.

cargo check + cargo clippy -D warnings clean.