### PR TITLE
fix(tests): pre-canonicalize MSYS test fixtures for 8.3 short-name runners

### DIFF
--- a/src/db_discovery/repos_tests.rs
+++ b/src/db_discovery/repos_tests.rs
@@ -147,11 +147,16 @@ fn register_derives_alias_from_directory_name() {
 #[cfg(windows)]
 fn register_translates_msys_posix_path() {
     let tmp = tempfile::tempdir().unwrap();
-    // Construct the Windows path of a temp dir, then express its parent+name
-    // as the MSYS POSIX equivalent (`/c/...`).
     let win_repo = tmp.path().join("propagate-tmp-repo");
     std::fs::create_dir(&win_repo).unwrap();
-    let win_str = win_repo.to_string_lossy().replace('\\', "/");
+    // Pre-canonicalize so 8.3 short names (e.g. `RUNNER~1` on Windows CI)
+    // are resolved to their long form BEFORE we build both the MSYS input
+    // and the expected output. Otherwise `safe_canonicalize` inside
+    // `register()` resolves the short name but our expected value keeps it,
+    // and the equality assertion fails on runners whose temp root sits
+    // under a short-named user folder.
+    let canonical = safe_canonicalize(&win_repo).unwrap();
+    let win_str = canonical.to_string_lossy().replace('\\', "/");
     // win_str looks like "C:/Users/.../propagate-tmp-repo"
     let (drive_letter, rest) = win_str.split_at(2); // "C:" + "/Users/..."
     let drive_letter = drive_letter.chars().next().unwrap();
@@ -242,7 +247,16 @@ fn unregister_path_matches_msys_posix_form() {
     let tmp = tempfile::tempdir().unwrap();
     let win_repo = tmp.path().join("propagate-tmp-unreg");
     std::fs::create_dir(&win_repo).unwrap();
-    let win_str = win_repo.to_string_lossy().replace('\\', "/");
+    // Pre-canonicalize for the same reason as register_translates_msys_posix_path:
+    // we delete the dir later, after which `safe_canonicalize` fails and the
+    // `normalize_user_path` fallback runs WITHOUT short-name resolution. If
+    // we built the MSYS input from the raw short-named path, register() would
+    // store the long form (canonicalized) but unregister()'s fallback would
+    // produce the short form, and the comparison would miss. Building from
+    // the canonical form makes both sides agree regardless of which branch
+    // runs.
+    let canonical = safe_canonicalize(&win_repo).unwrap();
+    let win_str = canonical.to_string_lossy().replace('\\', "/");
     let (drive_letter, rest) = win_str.split_at(2);
     let drive_letter = drive_letter.chars().next().unwrap();
     let msys_path = format!(


### PR DESCRIPTION
Follow-up to PR #196. Two of the MSYS tests failed on Windows CI:

- `db_discovery::repos::tests::register_translates_msys_posix_path`
- `db_discovery::repos::tests::unregister_path_matches_msys_posix_form`

## Root cause

Windows CI runners use a temp root under `C:\Users\RUNNER~1\...` (8.3 short name for `runneradmin`). The tests built the expected path from the raw `tmp.path()` (short-name form) but `safe_canonicalize` inside `register()` resolves 8.3 names to their long form, so the stored path had `runneradmin` while the expected had `RUNNER~1` → string mismatch.

For `unregister_path_matches_msys_posix_form` the same asymmetry hits the fallback branch: after the dir is deleted, `safe_canonicalize` fails and `normalize_user_path` returns the input verbatim (no short-name resolution), so unregister's comparison ran short-form input against long-form stored entry and returned false.

## Fix

Pre-canonicalize the fixture with `safe_canonicalize(&win_repo)` BEFORE building both the MSYS input and the expected value. Both sides then use the long form regardless of which branch (success or fallback) executes.

The non-existing-path sibling test (`register_translates_msys_posix_path_when_dir_does_not_exist`) passed on CI by luck — both sides bypass canonicalize — but its assertion is correct and untouched.

## Validation

Local: all 3 MSYS register/unregister tests green. Pushed through the same pre-push QC gate (577 tests passed).