### PR TITLE
feat: /indexing freshness endpoint + grep-guard wait-and-retry (#54/#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ more PRs land; when the release is actually tagged, the same section is
 finalized in place with a date — no renaming/migration step needed.
 -->
 
+## [1.2.13] (unreleased)
+
+### Added
+
+- **`GET /indexing?path=<absolute path>` — per-repo freshness probe, and grep-guard now waits instead of forcing a grep fallback after a branch switch (todos #54/#55).** Two related fixes shipped together. (1) `codesearch serve` exposes a cheap new endpoint that resolves an absolute filesystem path to its containing registered repo (longest-root-wins, component-boundary match so `/x/alpha` never matches `/x/alpha-x`) and reports `{"covered":bool,"alias":..,"indexing":bool}` — `indexing` is true while that repo has an active (non-stale, lazily-evicted) reindex in flight, which includes the full refresh the file watcher fires on every branch switch. Same auth class as `/status` (open on localhost, bearer-protected on network binds); `/healthz` deliberately stays the only always-unauthenticated endpoint — liveness and freshness are different questions. (2) The Claude Code `grep-guard` hook (both `.ps1` and `.sh`, kept in sync) now probes this endpoint when the serve hub is live: if the target repo is mid-reindex, the deny message becomes a **wait-and-retry instruction** (sleep 15-30s, then re-run the codesearch call) instead of the standard "use codesearch" one — searching a mid-rebuild index returns stale/empty results, which previously pushed the agent into a manual `(approved fallback)` grep on every routine checkout. The probe is skipped silently (standard deny) on serves that predate the endpoint, so hook and server versions mix freely. Additionally fixed in the same hooks: repo resolution now follows the **grep target** (the git root of the path being searched) instead of the hook's cwd — an absolute-path Grep into a different indexed repo previously looked "external" against the cwd's repo root and slipped the guard uncovered.
+
 ## [1.2.11] (unreleased)
 
 ### Fixed

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -30,15 +30,27 @@ Two [Claude Code hooks](https://docs.claude.com/en/docs/claude-code/hooks)
 that make the preference *structural* instead of advisory:
 
 - **`grep-guard`** — a `PreToolUse` hook on `Grep`. Blocks every `Grep`
-  call against an internal repo path *for as long as the codesearch serve hub
-  is reachable*, with a message telling the model exactly how to load and call
-  codesearch instead. Grep is auto-allowed **only** when codesearch is
-  genuinely down: the hook probes the unauthenticated `/healthz` liveness
-  endpoint and lets Grep through only when that probe fails. A low-confidence
-  or empty codesearch *result* is a successful call ("reformulate"), not a dead
-  server, so it does **not** unblock Grep. Grep against paths outside the
-  current repo is never blocked; codesearch doesn't cover arbitrary external
-  paths well, grep is right there.
+  call against an indexed repo *for as long as the codesearch serve hub
+  is reachable*, with a message telling the model exactly how to load and
+  call codesearch instead. The guarded repo is resolved from the **grep
+  target itself** — the git root of the path being searched, not the
+  hook's working directory — so an absolute-path Grep into a different
+  indexed repo is guarded too (a cwd-based check used to let those
+  through). Grep is auto-allowed **only** when codesearch is genuinely
+  down: the hook probes the unauthenticated `/healthz` liveness endpoint
+  and lets Grep through only when that probe fails. A low-confidence or
+  empty codesearch *result* is a successful call ("reformulate"), not a
+  dead server, so it does **not** unblock Grep. One exception: when the
+  target repo is live but **mid-reindex** (the serve watcher's full
+  refresh, e.g. right after a branch switch), the hook denies Grep with a
+  **wait-and-retry** instruction (sleep 15-30s, then re-run the
+  codesearch call) — searching a mid-rebuild index returns stale/empty
+  results and must not degrade into a manual grep approval on every
+  routine checkout. The freshness probe (`GET /indexing?path=<repo
+  root>`) is skipped silently on serves that predate the endpoint, so
+  hook and server versions can be mixed freely. Grep against paths
+  outside any git repo, or against repos codesearch does not cover, is
+  never blocked; grep is right there in those cases.
 
 - **`subagent-preamble`** — a `PreToolUse` hook on `Agent` (the subagent-spawn
   tool). Prepends a short preamble to every subagent prompt explaining that
@@ -48,7 +60,7 @@ that make the preference *structural* instead of advisory:
 
 Both hooks fail open: if they can't parse their input, or codesearch isn't
 running/indexed, they get out of the way and let Grep proceed untouched. They
-never block anything outside the current repo.
+never block targets outside any git repo, or repos codesearch does not cover.
 
 ## Install
 
@@ -113,17 +125,23 @@ points at `hooks/codesearch/`) from `settings.json`, and delete
 
 ## Caveats
 
-- `grep-guard` detects "codesearch is available **for the current repo**" via
-  a local `.codesearch.db` at the git root, or an explicit `CODESEARCH_SERVER`
-  env var for pure remote-serve setups with no local index. It deliberately
-  does **not** treat "a `codesearch` process is running" as sufficient —
-  `codesearch serve` commonly runs as a persistent background hub covering
-  many registered repos (`codesearch index list`), so that process is alive
-  on a dev machine almost all the time regardless of whether the current
-  directory is one of the repos it actually indexes. Checking process
-  presence alone made the hook fire in every directory on the machine,
-  including unindexed ones — this was found and fixed after exactly that
-  false-positive showed up in real use.
+- `grep-guard` resolves the guarded repo from the **grep target**, never
+  from its own cwd: empty/relative paths resolve against the cwd repo
+  (they are relative to it by definition), absolute paths resolve against
+  the git root of the path being searched. Coverage is then detected via
+  a local `.codesearch.db` at that repo's git root, or an explicit
+  `CODESEARCH_SERVER` env var for pure remote-serve setups with no local
+  index. It deliberately does **not** treat "a `codesearch` process is
+  running" as sufficient — `codesearch serve` commonly runs as a
+  persistent background hub covering many registered repos
+  (`codesearch index list`), so that process is alive on a dev machine
+  almost all the time regardless of whether the searched repo is one of
+  the repos it actually indexes. Checking process presence alone made the
+  hook fire in every directory on the machine, including unindexed ones —
+  this was found and fixed after exactly that false-positive showed up in
+  real use. (The older cwd-based resolution had the mirror-image defect:
+  an absolute-path Grep into a *different* indexed repo looked "external"
+  and slipped the guard — also fixed, same release.)
   If your setup connects to a remote `codesearch serve` instance with no
   local `.codesearch.db`, set `CODESEARCH_SERVER` to opt back into
   enforcement for that repo.

--- a/integrations/claude-code/hooks/grep-guard.ps1
+++ b/integrations/claude-code/hooks/grep-guard.ps1
@@ -17,18 +17,26 @@
 # "codesearch is down".
 #
 # Blocks the Grep call when ALL of:
-#   - the search path is internal (empty/relative, or absolute-but-inside the
-#     current git repo), AND
-#   - codesearch covers THIS repo (indexed .codesearch.db at git root, or the
-#     CODESEARCH_SERVER opt-in for remote/hub-only setups), AND
+#   - the search target resolves to a git repo (its OWN root, not the cwd's —
+#     absolute paths into a different repo resolve against THAT repo, todo
+#     #54), AND
+#   - codesearch covers THAT repo (indexed .codesearch.db at its git root, or
+#     the CODESEARCH_SERVER opt-in for remote/hub-only setups), AND
 #   - the codesearch serve hub answers its /healthz liveness probe (it's UP)
 #
 # Passes through (exit 0, no block) when:
-#   - the path is outside the current git repo (codesearch doesn't cover
-#     arbitrary external paths well; grep is the right tool there)
-#   - codesearch does not cover this repo (no local index, no CODESEARCH_SERVER)
+#   - the target is not inside any git repo (external path — grep is the
+#     right tool there)
+#   - codesearch does not cover the target's repo (no local index, no
+#     CODESEARCH_SERVER)
 #   - the codesearch serve hub does not answer /healthz — it's down, so grep
 #     is genuinely all you have
+#
+# When the target repo is covered and LIVE but MID-REINDEX (branch switch
+# full refresh, todo #55), the deny message is a WAIT-AND-RETRY instruction
+# instead of the standard "use codesearch" one — searching a mid-rebuild
+# index returns stale/empty results and must not degrade into a manual grep
+# approval on every routine checkout.
 #
 # Install: see ../README.md (or run ../install.ps1 to wire this up automatically).
 
@@ -52,62 +60,53 @@ $names = @($inp.PSObject.Properties.Name)
 $path  = if ($names -contains 'path') { [string]$inp.path } else { '' }
 
 # ------------------------------------------------------------------
-# 1. Is the path internal to the current repo?
-# ------------------------------------------------------------------
-$isInternal = $true
-if ($path -and $path -ne '.' -and $path -ne './') {
-    $normPath = $path.TrimEnd('/\')
-    # Absolute paths (Windows drive letter, or Git-Bash /c/... style)
-    if ($normPath -match '^([A-Za-z]:[\\/]|/[a-zA-Z]/|//)') {
-        try {
-            $gr = (& git rev-parse --show-toplevel 2>$null)
-            if ($LASTEXITCODE -eq 0 -and $gr) {
-                $gr  = $gr.Trim() -replace '[/\\]', [System.IO.Path]::DirectorySeparatorChar
-                $abs = $normPath   -replace '[/\\]', [System.IO.Path]::DirectorySeparatorChar
-                if (-not $abs.StartsWith($gr, [System.StringComparison]::OrdinalIgnoreCase)) {
-                    $isInternal = $false
-                }
-            }
-        } catch {
-            $isInternal = $false  # can't determine git root -> assume external, allow grep
-        }
-    }
-    # Relative paths ("src/", "../sibling/") stay internal = $true
-}
-
-if (-not $isInternal) { exit 0 }
-
-# ------------------------------------------------------------------
-# 2. Does codesearch COVER this repo? Don't block if it doesn't.
+# 1+2. Resolve the TARGET repo (the repo this Grep is aimed at) and check
+#      codesearch coverage THERE — never in the hook's cwd.
 #
-# NOTE: we deliberately do NOT treat "a codesearch process is running" as
-# sufficient. codesearch commonly runs as a persistent background `serve`
-# hub covering many registered repos (`codesearch index list`) — that
-# process is alive nearly all the time on a dev machine, regardless of
-# whether the CURRENT directory is one of the repos it actually indexes.
-# Using process-presence alone made this hook fire in every directory on
-# the machine, including ones with no index at all. A local `.codesearch.db`
-# at the git root is the precise, fast signal that THIS repo is indexed.
+# History (#54): coverage used to be resolved from the hook's cwd. An
+# absolute-path Grep into a DIFFERENT indexed repo then failed the
+# startswith(cwd-repo-root) test, looked "external", and was allowed even
+# though its target repo was fully covered. The guard now follows the
+# target: empty/relative paths resolve against the cwd repo (they are
+# relative to it by definition), absolute paths resolve against the git
+# root of the path itself.
 # ------------------------------------------------------------------
-function Test-CodesearchCoversRepo {
+$targetRoot = $null
+$normPath   = $path.TrimEnd('/\')
+$isAbsolute = $normPath -match '^([A-Za-z]:[\\/]|/[a-zA-Z]/|//)'
+
+if (-not $path -or $path -eq '.' -or $path -eq './' -or -not $isAbsolute) {
+    # Empty or relative path: resolves against the cwd repo.
     try {
         $gr = (& git rev-parse --show-toplevel 2>$null)
-        if ($LASTEXITCODE -eq 0 -and $gr) {
-            $gr = $gr.Trim()
-            if (Test-Path (Join-Path $gr '.codesearch.db')) { return $true }
-        }
+        if ($LASTEXITCODE -eq 0 -and $gr) { $targetRoot = $gr.Trim() }
     } catch {}
-
-    # Explicit opt-in escape hatch for pure remote-serve setups with no local
-    # .codesearch.db (this repo's index lives only on a remote `codesearch
-    # serve` host). Requires the user to consciously set this env var, so it
-    # can't spuriously fire the way "any process running" did.
-    if ($env:CODESEARCH_SERVER) { return $true }
-
-    return $false
+} else {
+    # Absolute path: find the git root OF THE TARGET (may be a different
+    # repo than the cwd one — that is the whole point of #54).
+    $probe = $normPath
+    if (Test-Path -LiteralPath $probe -PathType Leaf) {
+        $probe = Split-Path -Parent $probe
+    }
+    try {
+        $gr = (& git -C $probe rev-parse --show-toplevel 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $gr) { $targetRoot = $gr.Trim() }
+    } catch {}
 }
 
-if (-not (Test-CodesearchCoversRepo)) { exit 0 }
+# Not inside any git repo (or git unusable) -> external target: grep is right.
+if (-not $targetRoot) { exit 0 }
+
+# Coverage: a local .codesearch.db at the TARGET repo's root is the precise,
+# fast signal that THIS repo is indexed (a running serve hub alone is NOT —
+# it covers many repos and being alive says nothing about this one).
+# CODESEARCH_SERVER stays the explicit opt-in for pure remote-serve setups.
+$covered = $false
+try {
+    if (Test-Path (Join-Path $targetRoot '.codesearch.db')) { $covered = $true }
+} catch {}
+if (-not $covered -and $env:CODESEARCH_SERVER) { $covered = $true }
+if (-not $covered) { exit 0 }
 
 # ------------------------------------------------------------------
 # 3. Is the codesearch serve hub actually UP right now? (Liveness probe.)
@@ -133,10 +132,10 @@ function Get-CodesearchBaseUrl {
 }
 
 function Test-CodesearchLive {
-    $base = Get-CodesearchBaseUrl
+    param([string]$Base)
     try {
         # Short timeout keeps grep latency low; /healthz answers instantly.
-        $null = Invoke-WebRequest -Uri "$base/healthz" -TimeoutSec 2 -UseBasicParsing
+        $null = Invoke-WebRequest -Uri "$Base/healthz" -TimeoutSec 2 -UseBasicParsing
         return $true
     } catch {
         # An HTTP error RESPONSE (4xx/5xx) still proves the server is reachable
@@ -149,7 +148,58 @@ function Test-CodesearchLive {
 }
 
 # codesearch is DOWN -> grep is genuinely all you have, let it through.
-if (-not (Test-CodesearchLive)) { exit 0 }
+$base = Get-CodesearchBaseUrl
+if (-not (Test-CodesearchLive -Base $base)) { exit 0 }
+
+# ------------------------------------------------------------------
+# 3.5 Is the TARGET repo mid-reindex right now? (Freshness probe, #55.)
+#
+# Liveness (/healthz) says the server is UP; it says nothing about index
+# FRESHNESS. Right after a branch switch the serve watcher fires a full
+# refresh, and searches against the mid-rebuild index return stale/empty
+# results — which used to push the agent into a manual grep approval on
+# every routine checkout (the exact "stale after branch switch" report).
+# GET /indexing?path=<repo root> resolves the target to its registered repo
+# and reports an active reindex. When one is in flight, deny with a
+# WAIT-AND-RETRY instruction: the tree did not change, the index is just
+# catching up — waiting beats grepping.
+#
+# Backward compat: an older serve without this endpoint answers 404, the
+# probe is skipped (catch below), and behaviour is exactly the pre-#55 deny.
+# ------------------------------------------------------------------
+try {
+    $enc  = [uri]::EscapeDataString(($targetRoot -replace '\\', '/'))
+    $resp = Invoke-WebRequest -Uri "$base/indexing?path=$enc" -TimeoutSec 2 -UseBasicParsing
+    $fresh = $resp.Content | ConvertFrom-Json
+    if ($fresh.covered -eq $true -and $fresh.indexing -eq $true) {
+        $waitMsg = @"
+codesearch is LIVE, but THIS repo's index is being rebuilt right now (a
+branch switch or file change fired the serve watcher's full refresh).
+Searching immediately would return stale or empty results — that is the
+rebuild in progress, not a miss, and NOT a reason to grep.
+
+WAIT 15-30 seconds (Bash: sleep 20), then RETRY your codesearch call — it
+will answer normally once the rebuild lands. The working tree did not
+change; only the index is catching up, so grep adds nothing here.
+
+If the rebuild still has not landed after ~2 minutes, run your codesearch
+call anyway (a partially fresh index still beats grep) or ask the user how
+to proceed.
+"@
+        $waitOut = @{
+            hookSpecificOutput = @{
+                hookEventName            = 'PreToolUse'
+                permissionDecision       = 'deny'
+                permissionDecisionReason = $waitMsg
+            }
+        }
+        $waitOut | ConvertTo-Json -Depth 10 -Compress
+        exit 0
+    }
+} catch {
+    # 404 (older serve) or probe failure: no freshness signal — fall through
+    # to the standard deny below.
+}
 
 # ------------------------------------------------------------------
 # 4. Block with actionable guidance
@@ -186,7 +236,8 @@ error, you MUST pass project="<repo-alias>" (single repo) or group="<group>"
 available_groups — pick from that list (the alias may differ from the folder
 name).
 
-Grep is always allowed for paths OUTSIDE the current repo.
+Grep is always allowed for targets outside any git repo, and for repos
+codesearch does not cover (no local index, no CODESEARCH_SERVER).
 "@
 
 $out = @{

--- a/integrations/claude-code/hooks/grep-guard.sh
+++ b/integrations/claude-code/hooks/grep-guard.sh
@@ -11,6 +11,13 @@
 # and leaked grep on every low-confidence result. We now probe the
 # unauthenticated /healthz liveness endpoint directly.
 #
+# The target repo is resolved from the GREP TARGET itself (its own git root),
+# never from the hook's cwd — absolute paths into a different repo resolve
+# against THAT repo (#54). When the target repo is covered and LIVE but
+# MID-REINDEX (branch-switch full refresh, #55), the deny is a WAIT-AND-RETRY
+# instruction instead: searching a mid-rebuild index returns stale/empty
+# results and must not degrade into a manual grep approval on every checkout.
+#
 # Install: see ../README.md (or run ../install.sh to wire this up automatically).
 
 set -euo pipefail
@@ -24,48 +31,46 @@ tool=$(echo "$raw" | jq -r '.tool_name // empty')
 path=$(echo "$raw" | jq -r '.tool_input.path // empty')
 
 # ------------------------------------------------------------------
-# 1. Is the path internal to the current repo?
-# ------------------------------------------------------------------
-is_internal=true
-if [ -n "$path" ] && [ "$path" != "." ] && [ "$path" != "./" ]; then
-    case "$path" in
-        /*)
-            git_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-            if [ -n "$git_root" ]; then
-                case "$path" in
-                    "$git_root"*) is_internal=true ;;
-                    *) is_internal=false ;;
-                esac
-            else
-                is_internal=false  # can't determine git root -> assume external, allow grep
-            fi
-            ;;
-        *) is_internal=true ;;  # relative path stays internal
-    esac
-fi
-
-[ "$is_internal" = false ] && exit 0
-
-# ------------------------------------------------------------------
-# 2. Does codesearch COVER this repo? Don't block if it doesn't.
+# 1+2. Resolve the TARGET repo (the repo this Grep is aimed at) and check
+#      codesearch coverage THERE — never in the hook's cwd.
 #
-# NOTE: we deliberately do NOT treat "a codesearch process is running" as
-# sufficient. codesearch commonly runs as a persistent background `serve`
-# hub covering many registered repos (`codesearch index list`) — that
-# process is alive nearly all the time on a dev machine, regardless of
-# whether the CURRENT directory is one of the repos it actually indexes.
-# Using process-presence alone made this hook fire in every directory on
-# the machine, including ones with no index at all. A local `.codesearch.db`
-# at the git root is the precise, fast signal that THIS repo is indexed.
+# History (#54): coverage used to be resolved from the hook's cwd. An
+# absolute-path Grep into a DIFFERENT indexed repo then failed the
+# startswith(cwd-repo-root) test, looked "external", and was allowed even
+# though its target repo was fully covered. The guard now follows the
+# target: empty/relative paths resolve against the cwd repo (they are
+# relative to it by definition), absolute paths resolve against the git
+# root of the path itself.
+#
+# Coverage signal: a local .codesearch.db at the TARGET repo's root (a
+# running serve hub alone is NOT a signal — it covers many repos and being
+# alive says nothing about this one), or the explicit CODESEARCH_SERVER
+# opt-in for pure remote-serve setups.
 # ------------------------------------------------------------------
+target_root=""
+norm="${path%/}"
+norm="${norm%\\}"
+case "$norm" in
+    [A-Za-z]:[\\/]*|/[a-zA-Z]/*|//*)
+        # Absolute path: find the git root OF THE TARGET (may be a different
+        # repo than the cwd one — that is the whole point of #54).
+        probe="$norm"
+        [ -f "$probe" ] && probe="$(dirname "$probe")"
+        target_root=$(git -C "$probe" rev-parse --show-toplevel 2>/dev/null || true)
+        ;;
+    *)
+        # Empty or relative path: resolves against the cwd repo.
+        target_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+        ;;
+esac
+
+# Not inside any git repo (or git unusable) -> external target: grep is right.
+[ -z "$target_root" ] && exit 0
+
 codesearch_covers=false
-git_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-if [ -n "$git_root" ] && [ -d "$git_root/.codesearch.db" ]; then
+if [ -d "$target_root/.codesearch.db" ]; then
     codesearch_covers=true
 elif [ -n "${CODESEARCH_SERVER:-}" ]; then
-    # Explicit opt-in escape hatch for pure remote-serve setups with no local
-    # .codesearch.db. Requires the user to consciously set this env var, so
-    # it can't spuriously fire the way "any process running" did.
     codesearch_covers=true
 fi
 
@@ -106,6 +111,55 @@ if ! curl -sS --max-time 2 "${base}/healthz" >/dev/null 2>&1; then
 fi
 
 # ------------------------------------------------------------------
+# 3.5 Is the TARGET repo mid-reindex right now? (Freshness probe, #55.)
+#
+# Liveness (/healthz) says the server is UP; it says nothing about index
+# FRESHNESS. Right after a branch switch the serve watcher fires a full
+# refresh, and searches against the mid-rebuild index return stale/empty
+# results — which used to push the agent into a manual grep approval on
+# every routine checkout. GET /indexing?path=<repo root> resolves the
+# target to its registered repo and reports an active reindex. When one is
+# in flight, deny with a WAIT-AND-RETRY instruction: the tree did not
+# change, the index is just catching up — waiting beats grepping.
+#
+# Backward compat: an older serve without this endpoint answers 404; the
+# probe is skipped and behaviour is exactly the pre-#55 deny. The ?path=
+# value is percent-encoded (jq @uri) — a repo root containing spaces, +,
+# &, # or non-ASCII would otherwise make the probe fail or answer for the
+# WRONG repo prefix, silently disabling the wait-and-retry path.
+# ------------------------------------------------------------------
+enc=$(printf '%s' "$target_root" | jq -sRr @uri)
+if fresh_json=$(curl -sS --max-time 2 "${base}/indexing?path=${enc}" 2>/dev/null); then
+    covered=$(echo "$fresh_json" | jq -r '.covered // false' 2>/dev/null || echo false)
+    indexing=$(echo "$fresh_json" | jq -r '.indexing // false' 2>/dev/null || echo false)
+    if [ "$covered" = "true" ] && [ "$indexing" = "true" ]; then
+        msg=$(cat <<'EOF'
+codesearch is LIVE, but THIS repo's index is being rebuilt right now (a
+branch switch or file change fired the serve watcher's full refresh).
+Searching immediately would return stale or empty results — that is the
+rebuild in progress, not a miss, and NOT a reason to grep.
+
+WAIT 15-30 seconds (Bash: sleep 20), then RETRY your codesearch call — it
+will answer normally once the rebuild lands. The working tree did not
+change; only the index is catching up, so grep adds nothing here.
+
+If the rebuild still has not landed after ~2 minutes, run your codesearch
+call anyway (a partially fresh index still beats grep) or ask the user how
+to proceed.
+EOF
+)
+        jq -n --arg msg "$msg" '{
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: $msg
+          }
+        }'
+        exit 0
+    fi
+fi
+
+# ------------------------------------------------------------------
 # 4. Block with actionable guidance
 # ------------------------------------------------------------------
 msg=$(cat <<'EOF'
@@ -140,7 +194,8 @@ error, you MUST pass project="<repo-alias>" (single repo) or group="<group>"
 available_groups — pick from that list (the alias may differ from the folder
 name).
 
-Grep is always allowed for paths OUTSIDE the current repo.
+Grep is always allowed for targets outside any git repo, and for repos
+codesearch does not cover (no local index, no CODESEARCH_SERVER).
 EOF
 )
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -349,6 +349,20 @@ pub const MCP_ENDPOINT_PATH: &str = "/mcp";
 /// Returns JSON snapshot of all repo states, sessions, and CPU usage.
 pub const STATUS_PATH: &str = "/status";
 
+/// Indexing-freshness endpoint path served by `codesearch serve`.
+///
+/// Cheap single-question probe for the grep-guard hook (and any caller that
+/// needs to distinguish "no results" from "index mid-rebuild"): takes
+/// `?path=<absolute path>`, resolves the containing registered repo, and
+/// returns `{"covered":bool,"alias":..,"indexing":bool}` — `indexing` is true
+/// while that repo has an active (non-stale) reindex in flight, which
+/// includes the full refresh fired by a branch switch. Same auth class as
+/// [`STATUS_PATH`]: reachable without the admin key on localhost, protected
+/// by `require_auth_for_network` on network binds. `/healthz` remains the
+/// ONLY always-unauthenticated endpoint — liveness and freshness are
+/// different questions and stay on different paths.
+pub const INDEXING_PATH: &str = "/indexing";
+
 /// Remotes endpoint path served by `codesearch serve`.
 ///
 /// Observability companion to [`STATUS_PATH`]: lists the configured federation

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -38,7 +38,7 @@ use crate::constants::{
     ALLOWED_HOSTS_ENV, ALLOWED_ROOTS_ENV, CHUNK_PATH, CSHARP_PREWARM_ENABLED_ENV,
     CSHARP_PREWARM_MAX_SYMBOLS, CSHARP_SCIP_CONCURRENCY_DEFAULT, CSHARP_SCIP_CONCURRENCY_ENV,
     DB_DIR_NAME, DEFAULT_SERVE_PORT, DISABLE_HOST_VALIDATION_ENV, EXPLORE_PATH, FIND_PATH,
-    HEALTHZ_PATH, HEALTH_PATH, LANG_CSHARP, LANG_TYPESCRIPT, MAX_INDEXING_SECS,
+    HEALTHZ_PATH, HEALTH_PATH, INDEXING_PATH, LANG_CSHARP, LANG_TYPESCRIPT, MAX_INDEXING_SECS,
     MAX_INDEXING_SECS_ENV, MCP_ENDPOINT_PATH, PERSIST_DEBOUNCE_SECS, REAPER_INTERVAL_SECS,
     REMOTES_PATH, REPO_IDLE_TIMEOUT_ENV, REPO_IDLE_TIMEOUT_SECS, SEARCH_PATH, SERVE_API_KEY_ENV,
     SERVE_PORT_ENV, STATUS_PATH,
@@ -2922,6 +2922,107 @@ async fn healthz_handler() -> AxumJson<serde_json::Value> {
     AxumJson(json!({ "status": "ok" }))
 }
 
+/// Query parameters for `GET /indexing`.
+#[derive(serde::Deserialize)]
+struct IndexingQuery {
+    /// Absolute filesystem path of the search target (file or directory).
+    path: String,
+}
+
+/// Response body for `GET /indexing`.
+///
+/// `covered=false` means the path is not inside any registered repo — the
+/// caller should treat that as "no freshness signal" and behave exactly as
+/// before this endpoint existed (backwards-compatible for older hooks).
+#[derive(serde::Serialize)]
+struct IndexingResponse {
+    covered: bool,
+    alias: Option<String>,
+    indexing: bool,
+}
+
+/// Component-boundary prefix match: does `target` lie inside `root`?
+///
+/// `/x/xy` must NOT match root `/x` — comparing components (not string
+/// prefixes) makes the boundary exact. On Windows the comparison is
+/// case-insensitive (`repos.json` may record a different case than the
+/// caller's path); on other platforms it is exact.
+fn path_contains(target: &Path, root: &Path) -> bool {
+    let t: Vec<_> = target.components().collect();
+    let r: Vec<_> = root.components().collect();
+    if r.len() > t.len() {
+        return false;
+    }
+    let eq = |a: &std::path::Component<'_>, b: &std::path::Component<'_>| {
+        if a == b {
+            return true;
+        }
+        if cfg!(windows) {
+            a.as_os_str()
+                .to_string_lossy()
+                .eq_ignore_ascii_case(&b.as_os_str().to_string_lossy())
+        } else {
+            false
+        }
+    };
+    r.iter().zip(t.iter()).all(|(a, b)| eq(a, b))
+}
+
+/// Resolve `target` to the registered repo that contains it.
+///
+/// Longest root wins, so nested registered repos (a repo inside another
+/// repo's tree) resolve to the inner one. Returns `None` for paths outside
+/// every registered repo (including relative paths — callers must pass
+/// absolute paths).
+fn containing_repo_alias(
+    repos: &std::collections::HashMap<String, PathBuf>,
+    target: &Path,
+) -> Option<String> {
+    repos
+        .iter()
+        .filter(|(_, root)| path_contains(target, root))
+        .max_by_key(|(_, root)| root.components().count())
+        .map(|(alias, _)| alias.clone())
+}
+
+impl ServeState {
+    /// Freshness for an absolute filesystem path: which registered repo
+    /// contains it (if any), and is that repo mid-reindex right now?
+    ///
+    /// The `is_indexing` side lazily evicts stale markers, so a leaked
+    /// indexing task cannot report "indexing" forever.
+    fn freshness_for_path(&self, target: &str) -> (Option<String>, bool) {
+        let config = match self.config.read() {
+            Ok(c) => c,
+            Err(_) => return (None, false),
+        };
+        match containing_repo_alias(&config.repos, Path::new(target)) {
+            Some(alias) => {
+                let indexing = self.is_indexing(&alias);
+                (Some(alias), indexing)
+            }
+            None => (None, false),
+        }
+    }
+}
+
+/// Indexing-freshness handler: GET /indexing?path=<absolute path>
+///
+/// Lets a caller distinguish "empty result because nothing matches" from
+/// "stale result because the index is mid-rebuild" — the exact distinction
+/// the grep-guard hook needs after a branch switch. See [`INDEXING_PATH`].
+async fn indexing_handler(
+    axum::extract::State(state): axum::extract::State<Arc<ServeState>>,
+    axum::extract::Query(q): axum::extract::Query<IndexingQuery>,
+) -> AxumJson<IndexingResponse> {
+    let (alias, indexing) = state.freshness_for_path(&q.path);
+    AxumJson(IndexingResponse {
+        covered: alias.is_some(),
+        alias,
+        indexing,
+    })
+}
+
 /// Status handler: GET /status
 ///
 /// Returns a JSON snapshot of all repo states, active sessions, and CPU usage.
@@ -4869,6 +4970,10 @@ pub async fn run_serve(
         .route(HEALTH_PATH, axum::routing::get(health_handler))
         .route(HEALTHZ_PATH, axum::routing::get(healthz_handler))
         .route(STATUS_PATH, axum::routing::get(status_handler))
+        // Freshness probe for the grep-guard hook — same auth class as
+        // /status (localhost: open, network bind: bearer key). NOT in the
+        // always-unauthenticated set: /healthz stays the only one of those.
+        .route(INDEXING_PATH, axum::routing::get(indexing_handler))
         // /remotes is a status-like read-only observability endpoint (lists the
         // configured federation peers). It is NOT in require_admin_auth's
         // `is_management` set, so it inherits exactly the same auth policy as

--- a/src/serve/tests.rs
+++ b/src/serve/tests.rs
@@ -1785,3 +1785,164 @@ mod keep_warm_foreign_target_tests {
         );
     }
 }
+
+// ===========================================================================
+// GET /indexing — freshness probe (grep-guard wait-and-retry, todo #55)
+// ===========================================================================
+
+/// Helper: a repos map from (alias, root) pairs.
+fn repos_map(entries: &[(&str, &str)]) -> std::collections::HashMap<String, std::path::PathBuf> {
+    entries
+        .iter()
+        .map(|(a, p)| (a.to_string(), std::path::PathBuf::from(p)))
+        .collect()
+}
+
+#[test]
+fn containing_repo_alias_matches_subdir_but_not_sibling_prefix() {
+    let repos = repos_map(&[("alpha", "/base/alpha"), ("beta", "/base/beta")]);
+
+    // Exact root.
+    assert_eq!(
+        containing_repo_alias(&repos, Path::new("/base/alpha")),
+        Some("alpha".to_string())
+    );
+    // File inside the repo.
+    assert_eq!(
+        containing_repo_alias(&repos, Path::new("/base/alpha/src/main.rs")),
+        Some("alpha".to_string())
+    );
+    // Component boundary: /base/alpha-x is NOT inside /base/alpha.
+    assert_eq!(
+        containing_repo_alias(&repos, Path::new("/base/alpha-x/file.rs")),
+        None,
+        "string-prefix sibling must not match"
+    );
+    // Entirely outside.
+    assert_eq!(containing_repo_alias(&repos, Path::new("/elsewhere")), None);
+}
+
+#[test]
+fn containing_repo_alias_prefers_nested_repo() {
+    // Two registered repos, one nested inside the other's tree: the inner
+    // (longer root) must win so the freshness answer is about the repo the
+    // path actually belongs to.
+    let repos = repos_map(&[("outer", "/base"), ("inner", "/base/inner")]);
+    assert_eq!(
+        containing_repo_alias(&repos, Path::new("/base/inner/src/a.rs")),
+        Some("inner".to_string())
+    );
+    assert_eq!(
+        containing_repo_alias(&repos, Path::new("/base/other/src/b.rs")),
+        Some("outer".to_string())
+    );
+}
+
+#[test]
+fn containing_repo_alias_case_insensitive_only_on_windows() {
+    let repos = repos_map(&[("alpha", "/Base/Alpha")]);
+    let hit = containing_repo_alias(&repos, Path::new("/base/alpha/x.rs"));
+    if cfg!(windows) {
+        assert_eq!(hit, Some("alpha".to_string()));
+    } else {
+        assert_eq!(hit, None, "unix path matching stays case-sensitive");
+    }
+}
+
+#[test]
+fn freshness_for_path_reports_indexing_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo_path = tmp.path().join("repo");
+
+    let mut config = ReposConfig::default();
+    config
+        .register_with_alias(repo_path.clone(), Some("fresh".to_string()))
+        .unwrap();
+
+    let state = Arc::new(ServeState::new(config, None));
+    let target = repo_path.join("src").join("lib.rs");
+
+    // Idle: covered, not indexing.
+    let (alias, indexing) = state.freshness_for_path(&target.to_string_lossy());
+    assert_eq!(alias.as_deref(), Some("fresh"));
+    assert!(!indexing);
+
+    // Mid-reindex (the exact state a branch-switch full refresh puts the
+    // repo in — make_indexing_status_callback inserts around it).
+    state.begin_indexing("fresh");
+    let (_, indexing) = state.freshness_for_path(&target.to_string_lossy());
+    assert!(indexing, "begin_indexing must surface as indexing=true");
+
+    state.end_indexing("fresh");
+    let (_, indexing) = state.freshness_for_path(&target.to_string_lossy());
+    assert!(!indexing);
+
+    // Unknown path: not covered, no crash.
+    let (alias, indexing) = state.freshness_for_path("/definitely/not/registered");
+    assert_eq!(alias, None);
+    assert!(!indexing);
+}
+
+#[tokio::test]
+async fn indexing_route_answers_json() {
+    // Route + handler wiring: a GET with a covered path returns our JSON
+    // (never axum's empty 404), with the covered/indexing fields present.
+    let tmp = tempfile::tempdir().unwrap();
+    let repo_path = tmp.path().join("hooked");
+    std::fs::create_dir(&repo_path).unwrap();
+
+    let mut config = ReposConfig::default();
+    config
+        .register_with_alias(repo_path.clone(), Some("hooked".to_string()))
+        .unwrap();
+
+    let state = Arc::new(ServeState::new(config, None));
+
+    let app = axum::Router::new()
+        .route(
+            crate::constants::INDEXING_PATH,
+            axum::routing::get(indexing_handler),
+        )
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let client = reqwest::Client::new();
+    // Temp paths are safe ASCII; normalise backslashes so the query string is
+    // legal as-is (component matching treats / and \ identically on Windows).
+    let covered = repo_path.to_string_lossy().replace('\\', "/");
+
+    // Covered path.
+    let resp = client
+        .get(format!(
+            "http://{addr}/indexing?path={covered}",
+            addr = addr
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["covered"], serde_json::json!(true));
+    assert_eq!(body["alias"], serde_json::json!("hooked"));
+    assert_eq!(body["indexing"], serde_json::json!(false));
+
+    // Uncovered path.
+    let resp = client
+        .get(format!(
+            "http://{addr}/indexing?path=/nowhere/at/all",
+            addr = addr
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["covered"], serde_json::json!(false));
+    assert_eq!(body["indexing"], serde_json::json!(false));
+}


### PR DESCRIPTION
## What
- **Server:** new `GET /indexing?path=<absolute path>` — resolves the containing registered repo (longest-root-wins, component-boundary match, Windows-only case-insensitivity) and reports `{covered, alias, indexing}`. `indexing=true` while an active (non-stale, lazily-evicted) reindex is in flight — including the branch-switch full refresh. Same auth class as `/status`; `/healthz` stays the only always-unauthenticated endpoint. 5 new tests (matching, nesting, freshness cycle, live route).
- **Hooks (ps1+sh in sync):** coverage now resolves from the GREP TARGET's git root, not the hook cwd — absolute-path Greps into other indexed repos are guarded (#54). When the target repo is live but mid-reindex, deny becomes wait-and-retry (sleep 15-30s, retry codesearch) instead of the standard message (#55) — a mid-rebuild index returning stale/empty results no longer degrades into a manual grep approval. Probe is percent-encoded (sh via jq @uri) and skipped silently on older serves (404 → standard deny), so versions mix freely.
- README caveats updated; CHANGELOG under [1.2.13].

Review: round 1 PASS WITH REMARKS (2 Important: sh URL-escaping, stale README sentence) → fixed + amended → round 2 PASS (scoped).

Refs: develterf_dlwr/todo#54, develterf_dlwr/todo#55
