### PR TITLE
fix: retry transient 502/503/504 from federated peers (todo #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ more PRs land; when the release is actually tagged, the same section is
 finalized in place with a date — no renaming/migration step needed.
 -->
 
+## [1.2.14] (unreleased)
+
+### Fixed
+
+- **A scale-to-zero cold start on a federated peer surfaced as a raw, undiagnosable error instead of a retry (todo #58).** `get_chunk`/`search` against a remote peer that answered 503 (non-JSON body — an Azure Container App waking from idle) failed immediately with `remote /chunk returned non-JSON body (http=503 Service Unavailable)`, giving the caller no way to tell a transient cold start apart from a broken mirror. Observed consequence: an agent abandoned a verification that was one retry away from succeeding, and read "503" as "mirror down" — pushing toward fallbacks that cannot work. Both federation read paths now retry transient statuses (502/503/504) a bounded number of times (3 attempts, 3s/8s backoff — [`REMOTE_PEER_RETRY_ATTEMPTS`] in `src/constants.rs`, test-overridable via `CODESEARCH_REMOTE_RETRY_BACKOFF_MS`) inside the already-active tool call, which is not a poll: the "never contact a federated peer on a cadence" design constraint is untouched. Most cold starts never reach the caller. If the peer is still transient-failing after the retries, the message names the likely cause and the remedy (`remote /chunk did not respond in time (http=503 after 2 retries) — likely a cold start on a scale-to-zero host; retry the same call in ~30s`) so "temporarily unavailable" stays distinguishable from "misconfigured/auth failed". Non-transient statuses (4xx, the peer's own 5xx tool errors) are NOT retried — a real answer fails identically on retry, just slower. Transport errors are not retried either (the per-request timeout already spent the budget). Four tests pin it: 503→200 get_chunk succeeds after exactly 3 attempts, persistent 503 carries the cold-start hint + retry count and stops at the configured attempts, a 500 is answered after exactly 1 request (no retry), and search gets the same treatment (it shared the identical pre-fix code shape).
+
 ## [1.2.13] (unreleased)
 
 ### Added

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -508,6 +508,31 @@ pub const MAX_INDEXING_SECS: u64 = 30 * 60; // 30 minutes
 /// Environment variable to override the maximum indexing duration.
 pub const MAX_INDEXING_SECS_ENV: &str = "CODESEARCH_MAX_INDEXING_SECS";
 
+/// Total number of attempts (initial request + retries) the federation client
+/// makes against a remote peer that answers with a transient HTTP status
+/// (502/503/504). Federated peers commonly run on scale-to-zero hosts (Azure
+/// Container Apps): the first request after an idle period can hit a cold
+/// start and surface as a 503 even though the peer is perfectly healthy. A
+/// short bounded retry inside the active tool call absorbs most cold starts
+/// before the caller ever sees them. This is NOT a poll: retries only happen
+/// while a user-initiated tool call is already in flight against that peer
+/// (the "never contact a federated peer on a cadence" rule in AGENTS.md is
+/// about timers, and stays intact).
+pub const REMOTE_PEER_RETRY_ATTEMPTS: u32 = 3;
+
+/// Backoff (milliseconds) between federation retry attempts, one entry per
+/// retry (so `REMOTE_PEER_RETRY_ATTEMPTS - 1` entries; the last entry is
+/// reused if there are ever more retries than entries). Short by design —
+/// the retry exists to catch a peer that is already warming, not to outwait
+/// a long deployment. If the peer is still transient-failing after the last
+/// attempt, the error message tells the caller to retry the same call in
+/// ~30s instead of blocking the tool call longer.
+pub const REMOTE_PEER_RETRY_BACKOFF_MS: &[u64] = &[3000, 8000];
+
+/// Environment variable overriding every federation retry backoff with a
+/// single millisecond value (test hook so retry tests don't sleep for real).
+pub const REMOTE_PEER_RETRY_BACKOFF_ENV: &str = "CODESEARCH_REMOTE_RETRY_BACKOFF_MS";
+
 /// Cooperative join window (seconds) for `await_index_task` and
 /// `await_fsw_shutdown`: how long a background indexing / file-watcher task
 /// is given to observe its `CancellationToken` and exit on its own before it

--- a/src/db_discovery/repos.rs
+++ b/src/db_discovery/repos.rs
@@ -330,7 +330,9 @@ impl ReposConfig {
             let escape = std::env::var("CODESEARCH_TEST_ALLOW_GLOBAL_SAVE").is_ok();
             if !override_set && !escape {
                 panic!(
-                    "ReposConfig::save() under cargo test would write the real global                      repos.json. Set CODESEARCH_REPOS_CONFIG to a temp path first (or set                      CODESEARCH_TEST_ALLOW_GLOBAL_SAVE if this is genuinely intended)."
+                    "ReposConfig::save() under cargo test would write the real global \
+                     repos.json. Set CODESEARCH_REPOS_CONFIG to a temp path first (or set \
+                     CODESEARCH_TEST_ALLOW_GLOBAL_SAVE if this is genuinely intended)."
                 );
             }
         }

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -24,6 +24,49 @@ use crate::index::build_serve_client_with_key;
 // Shared with the `remote` CLI command via constants (single source of truth).
 use crate::constants::DEFAULT_REMOTE_TIMEOUT_SECS as DEFAULT_TIMEOUT_SECS;
 
+/// Whether an HTTP status from a remote peer is transient — likely a
+/// scale-to-zero cold start (503) or a short gateway hiccup (502/504) — and
+/// therefore worth a bounded in-call retry. Everything else (4xx auth/config
+/// problems, the peer's own 5xx tool errors) is a real answer, not noise:
+/// retrying it would only burn the caller's time before failing the same way.
+fn is_transient_peer_status(status: reqwest::StatusCode) -> bool {
+    matches!(status.as_u16(), 502..=504)
+}
+
+/// Backoff before federation retry attempt `retry_idx` (0-based). Honours the
+/// `CODESEARCH_REMOTE_RETRY_BACKOFF_MS` test override (a single ms value used
+/// for every retry); without it, [`REMOTE_PEER_RETRY_BACKOFF_MS`] supplies one
+/// delay per retry, reusing its last entry for any excess retries.
+async fn peer_retry_backoff(retry_idx: usize) {
+    let override_ms = std::env::var(crate::constants::REMOTE_PEER_RETRY_BACKOFF_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok());
+    let default_ms = || {
+        crate::constants::REMOTE_PEER_RETRY_BACKOFF_MS
+            .last()
+            .copied()
+            .unwrap_or(8000)
+    };
+    let ms = override_ms.unwrap_or_else(|| {
+        crate::constants::REMOTE_PEER_RETRY_BACKOFF_MS
+            .get(retry_idx)
+            .copied()
+            .unwrap_or_else(default_ms)
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+}
+
+/// Final-failure message for a peer that still answered transiently after all
+/// retries: names the likely cause (cold start) and the remedy (retry soon),
+/// so a caller can tell "temporarily unavailable" apart from "misconfigured /
+/// auth failed" — which need entirely different responses.
+fn transient_exhausted_message(what: &str, status: u16, retries: u32) -> String {
+    format!(
+        "remote {what} did not respond in time (http={status} after {retries} retries) — \
+         likely a cold start on a scale-to-zero host; retry the same call in ~30s"
+    )
+}
+
 /// A single hit returned by a remote `/search` endpoint.
 ///
 /// Fields mirror the local search-item shapes (semantic *and* literal) but are
@@ -268,40 +311,75 @@ impl FederationClient {
 
     /// Shared POST + parse for `/search` (group- and project-scoped variants
     /// prepare the body differently, then funnel through here).
+    ///
+    /// Transient statuses (502/503/504 — most often a scale-to-zero cold
+    /// start) are retried a bounded number of times inside this call before
+    /// the failure is surfaced; see [`REMOTE_PEER_RETRY_ATTEMPTS`]. Transport
+    /// errors (refused/timeout) are NOT retried: the per-request timeout
+    /// already consumed the call's latency budget, and a hard-unreachable peer
+    /// fails the same way on the next attempt.
     async fn post_search(
         &self,
         peer: &RemotePeer,
         body: serde_json::Value,
     ) -> Outcome<Vec<RemoteSearchItem>> {
         let url = Self::peer_url(peer, crate::constants::SEARCH_PATH);
-        let req = self
-            .client
-            .post(&url)
-            .timeout(Self::peer_timeout(peer))
-            .json(&body);
-        let req = attach_bearer(req, &peer.api_key);
-
-        match req.send().await {
-            Ok(resp) => {
-                let status = resp.status();
-                match resp.json::<RemoteSearchResponse>().await {
-                    Ok(parsed) if status.is_success() && !parsed._mcp_is_error.unwrap_or(false) => {
-                        Outcome::Ok(parsed.results)
-                    }
-                    Ok(parsed) => {
-                        // Tool-level error on the remote (e.g. scope_required).
-                        let n = parsed.results.len();
-                        Outcome::Unreachable(format!(
-                            "remote /search returned a tool error (http={status}, items={n})"
-                        ))
-                    }
-                    Err(e) => Outcome::Unreachable(format!(
-                        "remote /search returned non-JSON body (http={status}): {e}"
-                    )),
-                }
+        let attempts = crate::constants::REMOTE_PEER_RETRY_ATTEMPTS.max(1);
+        for attempt in 0..attempts {
+            if attempt > 0 {
+                peer_retry_backoff((attempt - 1) as usize).await;
             }
-            Err(e) => Outcome::Unreachable(format!("remote /search unreachable: {e}")),
+            let req = self
+                .client
+                .post(&url)
+                .timeout(Self::peer_timeout(peer))
+                .json(&body);
+            let req = attach_bearer(req, &peer.api_key);
+
+            match req.send().await {
+                Ok(resp) => {
+                    let status = resp.status();
+                    if is_transient_peer_status(status) {
+                        let retries_left = attempts - attempt - 1;
+                        if retries_left > 0 {
+                            tracing::debug!(
+                                "remote /search transient {} (attempt {}/{}) — retrying",
+                                status,
+                                attempt + 1,
+                                attempts
+                            );
+                            continue;
+                        }
+                        return Outcome::Unreachable(transient_exhausted_message(
+                            "/search",
+                            status.as_u16(),
+                            attempts - 1,
+                        ));
+                    }
+                    match resp.json::<RemoteSearchResponse>().await {
+                        Ok(parsed)
+                            if status.is_success() && !parsed._mcp_is_error.unwrap_or(false) =>
+                        {
+                            return Outcome::Ok(parsed.results)
+                        }
+                        Ok(parsed) => {
+                            // Tool-level error on the remote (e.g. scope_required).
+                            let n = parsed.results.len();
+                            return Outcome::Unreachable(format!(
+                                "remote /search returned a tool error (http={status}, items={n})"
+                            ));
+                        }
+                        Err(e) => {
+                            return Outcome::Unreachable(format!(
+                                "remote /search returned non-JSON body (http={status}): {e}"
+                            ))
+                        }
+                    }
+                }
+                Err(e) => return Outcome::Unreachable(format!("remote /search unreachable: {e}")),
+            }
         }
+        unreachable!("retry loop always returns on its final iteration")
     }
 
     /// Fetch a single chunk from a remote peer's `/chunk/:id` endpoint.
@@ -349,24 +427,52 @@ impl FederationClient {
             .join("&");
         url.push('?');
         url.push_str(&query);
-        let req = self.client.get(&url).timeout(Self::peer_timeout(peer));
-        let req = attach_bearer(req, &peer.api_key);
-        match req.send().await {
-            Ok(resp) => {
-                let status = resp.status();
-                match resp.json::<serde_json::Value>().await {
-                    Ok(v) if status.is_success() && !is_mcp_error(&v) => Outcome::Ok(v),
-                    Ok(v) => Outcome::Unreachable(format!(
-                        "remote /chunk returned a tool error (http={status}): {}",
-                        short_reason(&v)
-                    )),
-                    Err(e) => Outcome::Unreachable(format!(
-                        "remote /chunk returned non-JSON body (http={status}): {e}"
-                    )),
-                }
+        let attempts = crate::constants::REMOTE_PEER_RETRY_ATTEMPTS.max(1);
+        for attempt in 0..attempts {
+            if attempt > 0 {
+                peer_retry_backoff((attempt - 1) as usize).await;
             }
-            Err(e) => Outcome::Unreachable(format!("remote /chunk unreachable: {e}")),
+            let req = self.client.get(&url).timeout(Self::peer_timeout(peer));
+            let req = attach_bearer(req, &peer.api_key);
+            match req.send().await {
+                Ok(resp) => {
+                    let status = resp.status();
+                    if is_transient_peer_status(status) {
+                        let retries_left = attempts - attempt - 1;
+                        if retries_left > 0 {
+                            tracing::debug!(
+                                "remote /chunk transient {} (attempt {}/{}) — retrying",
+                                status,
+                                attempt + 1,
+                                attempts
+                            );
+                            continue;
+                        }
+                        return Outcome::Unreachable(transient_exhausted_message(
+                            "/chunk",
+                            status.as_u16(),
+                            attempts - 1,
+                        ));
+                    }
+                    match resp.json::<serde_json::Value>().await {
+                        Ok(v) if status.is_success() && !is_mcp_error(&v) => return Outcome::Ok(v),
+                        Ok(v) => {
+                            return Outcome::Unreachable(format!(
+                                "remote /chunk returned a tool error (http={status}): {}",
+                                short_reason(&v)
+                            ))
+                        }
+                        Err(e) => {
+                            return Outcome::Unreachable(format!(
+                                "remote /chunk returned non-JSON body (http={status}): {e}"
+                            ))
+                        }
+                    }
+                }
+                Err(e) => return Outcome::Unreachable(format!("remote /chunk unreachable: {e}")),
+            }
         }
+        unreachable!("retry loop always returns on its final iteration")
     }
 
     /// Shared request/response handling for the management endpoints
@@ -1107,5 +1213,202 @@ mod tests {
             ManagementOutcome::Unreachable(_) => {}
             other => panic!("expected Unreachable, got {:?}", other),
         }
+    }
+
+    // =========================================================================
+    // Transient-status retry (502/503/504 — scale-to-zero cold starts, todo #58)
+    // =========================================================================
+
+    /// Helper: an axum route answering `/chunk/:id` that returns 503 (with a
+    /// non-JSON body, like a real cold-starting gateway) for the first
+    /// `fail_first` calls, then a valid 200 JSON chunk payload. Counts every
+    /// hit so tests can assert exactly how many attempts were made.
+    fn flaky_chunk_route(
+        fail_first: u32,
+    ) -> (axum::Router, std::sync::Arc<std::sync::atomic::AtomicU32>) {
+        use axum::response::IntoResponse;
+        let hits = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let hits_clone = hits.clone();
+        let router = axum::Router::new().route(
+            "/chunk/:id",
+            axum::routing::get(move || {
+                let hits = hits_clone.clone();
+                async move {
+                    let n = hits.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                    if n <= fail_first {
+                        (
+                            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                            "backend cold start",
+                        )
+                            .into_response()
+                    } else {
+                        axum::Json(serde_json::json!({
+                            "chunk_id": n,
+                            "content": "warm",
+                            "path": "kb/warm.md",
+                            "start_line": 1,
+                            "end_line": 2
+                        }))
+                        .into_response()
+                    }
+                }
+            }),
+        );
+        (router, hits)
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn get_chunk_retries_transient_503_and_succeeds() {
+        let _env = crate::testing::EnvRestore::set(&[(
+            crate::constants::REMOTE_PEER_RETRY_BACKOFF_ENV,
+            "1",
+        )]);
+        // Fails twice with 503 (non-JSON body, exactly like the observed
+        // cold-start failure), then succeeds — must surface as Ok with the
+        // caller never seeing the transient failures.
+        let (router, hits) = flaky_chunk_route(2);
+        let addr = spawn_test_server(router).await;
+
+        let client = FederationClient::new().unwrap();
+        let outcome = client
+            .get_chunk(&peer(format!("http://{addr}")), Some("kb"), 42, None)
+            .await;
+        match outcome {
+            Outcome::Ok(v) => assert_eq!(v["content"], "warm"),
+            other => panic!("expected Ok after retry, got {other:?}"),
+        }
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "two cold-start 503s + one success = three attempts"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn get_chunk_persistent_503_reports_cold_start_hint() {
+        let _env = crate::testing::EnvRestore::set(&[(
+            crate::constants::REMOTE_PEER_RETRY_BACKOFF_ENV,
+            "1",
+        )]);
+        // Always 503: exhaust the retries, then fail with a message that
+        // names the likely cause and the remedy instead of a raw "non-JSON
+        // body (http=503)" the caller can do nothing with.
+        let (router, hits) = flaky_chunk_route(u32::MAX);
+        let addr = spawn_test_server(router).await;
+
+        let client = FederationClient::new().unwrap();
+        let outcome = client
+            .get_chunk(&peer(format!("http://{addr}")), Some("kb"), 7, None)
+            .await;
+        match outcome {
+            Outcome::Unreachable(msg) => {
+                assert!(msg.contains("503"), "message should name the status: {msg}");
+                assert!(
+                    msg.contains("cold start"),
+                    "message should name the likely cause: {msg}"
+                );
+                assert!(
+                    msg.contains("~30s"),
+                    "message should tell the caller when to retry: {msg}"
+                );
+                assert!(
+                    msg.contains("after 2 retries"),
+                    "message should state the retry count: {msg}"
+                );
+            }
+            other => panic!("expected Unreachable, got {other:?}"),
+        }
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            crate::constants::REMOTE_PEER_RETRY_ATTEMPTS,
+            "initial attempt + configured retries, no more"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn get_chunk_does_not_retry_non_transient_status() {
+        let _env = crate::testing::EnvRestore::set(&[(
+            crate::constants::REMOTE_PEER_RETRY_BACKOFF_ENV,
+            "1",
+        )]);
+        // A 500 with a JSON error body is the peer's OWN answer (the cloud
+        // peer rejects force-reindex this way) — retrying it would only burn
+        // time before failing identically. Exactly one request must be made.
+        let hits = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let hits_clone = hits.clone();
+        let router = axum::Router::new().route(
+            "/chunk/:id",
+            axum::routing::get(move || {
+                let hits = hits_clone.clone();
+                async move {
+                    hits.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR
+                }
+            }),
+        );
+        let addr = spawn_test_server(router).await;
+
+        let client = FederationClient::new().unwrap();
+        let outcome = client
+            .get_chunk(&peer(format!("http://{addr}")), Some("kb"), 1, None)
+            .await;
+        assert!(
+            matches!(outcome, Outcome::Unreachable(_)),
+            "500 must fail, not retry"
+        );
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "non-transient status must not be retried"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn search_retries_transient_503_and_succeeds() {
+        let _env = crate::testing::EnvRestore::set(&[(
+            crate::constants::REMOTE_PEER_RETRY_BACKOFF_ENV,
+            "1",
+        )]);
+        // Same exposure as get_chunk (identical pre-fix code shape) — one 503
+        // then a valid 200 search response must surface as Ok.
+        let hits = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let hits_clone = hits.clone();
+        let router = axum::Router::new().route(
+            crate::constants::SEARCH_PATH,
+            axum::routing::post(move || {
+                use axum::response::IntoResponse;
+                let hits = hits_clone.clone();
+                async move {
+                    let n = hits.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                    if n == 1 {
+                        return (axum::http::StatusCode::SERVICE_UNAVAILABLE, "cold start")
+                            .into_response();
+                    }
+                    axum::Json(serde_json::json!({
+                        "results": [{ "path": "kb/doc.md", "score": 0.9 }]
+                    }))
+                    .into_response()
+                }
+            }),
+        );
+        let addr = spawn_test_server(router).await;
+
+        let client = FederationClient::new().unwrap();
+        let outcome = client
+            .search_project(
+                &peer(format!("http://{addr}")),
+                serde_json::json!({"query": "x"}),
+                "kb",
+            )
+            .await;
+        match outcome {
+            Outcome::Ok(items) => assert_eq!(items.len(), 1),
+            other => panic!("expected Ok after retry, got {other:?}"),
+        }
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 2);
     }
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -2890,7 +2890,8 @@ mod remove_order_tests {
         let now = global_config_canary();
         assert_eq!(
             before, now,
-            "the developer's global repos.json changed during the test —              a save bypassed the CODESEARCH_REPOS_CONFIG override"
+            "the developer's global repos.json changed during the test — \
+             a save bypassed the CODESEARCH_REPOS_CONFIG override"
         );
     }
 


### PR DESCRIPTION
## What
A scale-to-zero cold start on a federated peer (Azure Container App waking from idle) answered `get_chunk` with 503 + non-JSON body and failed immediately as an undiagnosable raw error — callers read "503" as "mirror down" and abandoned work that one retry would have completed (observed in a real session, todo #58).

- Both federation read paths (`post_search`, `get_chunk` — identical pre-fix code shape) now retry transient statuses (502/503/504) a bounded number of times inside the active tool call: `REMOTE_PEER_RETRY_ATTEMPTS`=3 (3s/8s backoff, constants in src/constants.rs, test-overridable via `CODESEARCH_REMOTE_RETRY_BACKOFF_MS`). NOT a poll — the scale-to-zero "never contact a federated peer on a cadence" rule is untouched (activity-driven retries only, verified by review).
- On exhaustion the message names cause + remedy: "remote /chunk did not respond in time (http=503 after 2 retries) — likely a cold start on a scale-to-zero host; retry the same call in ~30s" — keeping "temporarily unavailable" distinguishable from auth/misconfig failures.
- No behavior change for tool-level errors, 4xx, the peer's own 5xx errors (one request, original messages) or transport errors (per-request timeout already spent).
- 4 tests (EnvRestore + #[serial] for the env override): 503→200 in exactly 3 attempts; persistent 503 hint+count+stop; 500 exactly 1 request; search identical. Red/green proven (reviewer re-ran the mutation proof independently).
- Bonus (reviewer-found, develop was red): restores two collapsed `\` continuations in caller-facing literals so `tests/caller_facing_literals` passes again.

## Validation
cargo check --all-targets, clippy -D warnings, test --lib --bins (1196 passed), caller_facing_literals (4), store_err_swallow_detector (1).

Refs: develterf_dlwr/todo#58
