### PR TITLE
fix(tests): canonicalize indexing-route fixture for 8.3 short-name CI runners

### DIFF
--- a/src/serve/tests.rs
+++ b/src/serve/tests.rs
@@ -1888,8 +1888,14 @@ async fn indexing_route_answers_json() {
     // Route + handler wiring: a GET with a covered path returns our JSON
     // (never axum's empty 404), with the covered/indexing fields present.
     let tmp = tempfile::tempdir().unwrap();
-    let repo_path = tmp.path().join("hooked");
-    std::fs::create_dir(&repo_path).unwrap();
+    let raw_repo = tmp.path().join("hooked");
+    std::fs::create_dir(&raw_repo).unwrap();
+    // CANONICALIZE (same trap as remove_order_tests' make_proj): on the
+    // Windows CI runner the temp root sits under an 8.3 short name
+    // (RUNNER~1) that only canonicalize resolves, and register canonicalizes
+    // before storing — querying with the raw path made covered=false there
+    // (green locally, red on CI).
+    let repo_path = crate::cache::safe_canonicalize(&raw_repo).unwrap();
 
     let mut config = ReposConfig::default();
     config


### PR DESCRIPTION
The only real test-windows CI failure since PR #203 landed: indexing_route_answers_json queried /indexing with the raw tempdir path while register canonicalizes before storing — on GitHub's Windows runners the temp root is an 8.3 short name (RUNNER~1), so covered=false and the assert failed (green locally, red on CI). Fix mirrors remove_order_tests' make_proj (PR #197 precedent): safe_canonicalize the fixture before registering/querying. The embed::cache 'panic' in the same logs is the intentional caught panic inside catch_unwind — noise, test passes.