### PR TITLE
chore: sync CHANGELOG after v1.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ more PRs land; when the release is actually tagged, the same section is
 finalized in place with a date — no renaming/migration step needed.
 -->
 
-## [1.3.2]
+## [1.3.3] - 2026-08-18
 
 ### Added
 


### PR DESCRIPTION
Dates the [1.3.3] section on develop to match the released/tagged v1.3.3 (mirrors the [1.3.0] precedent of carrying dated released sections on develop). Content-only sync of the heading line already on master. Tagged release: PR #211, tag v1.3.3.