### PR TITLE
build.ps1: orphaned-cargo guard + file-redirect output

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -10,6 +10,14 @@
 
     Version bumping is handled by the pre-commit hook, NOT here.
 
+    Harness-independent cargo-stall hardening: before invoking cargo the
+    script reports cargo.exe/rustc.exe processes already referencing this
+    repo's target dir (a killed previous run leaves orphans that make cargo
+    hang forever on "Blocking waiting for file lock"); -KillOrphans clears
+    them first. Cargo output is redirected to a temp log file and printed
+    afterwards instead of being captured through the pipeline, so lingering
+    child processes cannot stall output capture.
+
 .EXAMPLE
     .\build.ps1
     Builds in debug mode
@@ -17,10 +25,15 @@
 .EXAMPLE
     .\build.ps1 -Release
     Builds in release mode
+
+.EXAMPLE
+    .\build.ps1 -KillOrphans
+    Kills cargo/rustc processes holding this target dir, then builds in debug mode
 #>
 
 param(
-    [switch]$Release
+    [switch]$Release,
+    [switch]$KillOrphans
 )
 
 $ErrorActionPreference = "Stop"
@@ -47,20 +60,71 @@ try {
     # run and surface its own error.
 }
 
+# --- Orphan guard: cargo/rustc processes already running on this machine ---
+# A previous run killed mid-build (hook timeout, editor restart, agent abort)
+# leaves cargo.exe/rustc.exe alive; the next cargo then hangs forever on
+# "Blocking waiting for file lock". There is no reliable per-repo scoping:
+# a blocked cargo.exe's own command line never mentions the target dir (only
+# its rustc children do, and only mid-build), and neither WMI nor
+# Get-Process exposes the working directory. So report ALL cargo/rustc
+# processes, flagging the ones that provably reference THIS repo's target
+# dir; -KillOrphans clears them all (they may belong to another checkout —
+# the flag is explicit, so that is the operator's call).
+$TargetDir = Join-Path $ScriptDir "target"
+$running = @(Get-Process -Name cargo, rustc -ErrorAction SilentlyContinue)
+$holders = @(
+    Get-CimInstance Win32_Process -Filter "Name='cargo.exe' OR Name='rustc.exe'" -ErrorAction SilentlyContinue |
+        Where-Object { $_.CommandLine -and $_.CommandLine -like "*$TargetDir*" }
+)
+if ($running.Count -gt 0) {
+    foreach ($h in $holders) {
+        Write-Host "  [lock] PID $($h.ProcessId) $($h.Name) REFERENCES this target dir: $($h.CommandLine)" -ForegroundColor Yellow
+    }
+    foreach ($p in $running | Where-Object { $_.Id -notin $holders.ProcessId }) {
+        Write-Host "  [lock] PID $($p.Id) $($p.Name) running (no target-dir reference on its command line — possibly another checkout or an early-phase build)" -ForegroundColor DarkYellow
+    }
+    if ($KillOrphans) {
+        foreach ($p in $running) {
+            try {
+                Stop-Process -Id $p.Id -Force -ErrorAction Stop
+                Write-Host "  [lock] killed PID $($p.Id)" -ForegroundColor DarkYellow
+            } catch {
+                Write-Host "  [lock] could not kill PID $($p.Id): $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
+    } else {
+        Write-Host "  [lock] WARNING: cargo/rustc process(es) are already running; cargo may hang on 'Blocking waiting for file lock'." -ForegroundColor Yellow
+        Write-Host "  [lock] Re-run with -KillOrphans to clear them first." -ForegroundColor Yellow
+    }
+}
+
 # Determine build mode
 $BuildMode = if ($Release) { "release" } else { "debug" }
 
 Write-Host "Building in $BuildMode mode..." -ForegroundColor Yellow
 
+# --- File-redirect output: log to a temp file, print afterwards ---
+# Capturing cargo's streams through the PowerShell pipeline stalls when a
+# lingering child process inherits the pipe and never closes it (the same
+# orphan class the guard above reports). Redirecting all streams to a file
+# lets this script finish reading the result even if children linger; the
+# log path is printed up front so a live watcher can tail it.
+$LogPath = Join-Path $env:TEMP ("codesearch-build-{0}.log" -f (Get-Date -Format "yyyyMMdd-HHmmss"))
+Write-Host "  [log] $LogPath" -ForegroundColor DarkGray
+# Literal args, not array splatting: `cargo @args *> file` mangles the
+# splatted array on this pwsh/cargo combination (cargo receives a stray
+# truncated argument), while literal args with the same redirection are fine.
 if ($Release) {
-    & cargo build --release
+    & cargo build --release *> $LogPath
 } else {
-    & cargo build
+    & cargo build *> $LogPath
 }
+$BuildExitCode = $LASTEXITCODE
+Get-Content $LogPath | ForEach-Object { Write-Host $_ }
 
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "Build failed!" -ForegroundColor Red
-    exit $LASTEXITCODE
+if ($BuildExitCode -ne 0) {
+    Write-Host "Build failed! Full log: $LogPath" -ForegroundColor Red
+    exit $BuildExitCode
 }
 
 Write-Host "Build completed: target/$BuildMode/codesearch.exe" -ForegroundColor Green


### PR DESCRIPTION
Hardens build.ps1 against cargo stalls (todo #106 in the tracking repo), harness-independent — the Claude Code post-tool hook that managed this does not run in opencode/oc-runner environments.

- **Orphan guard**: before any cargo invocation, report cargo.exe/rustc.exe processes already running, flagging ones whose command line references this repo's target dir. Per-repo scoping is not reliably possible (a blocked cargo.exe's own cmdline never mentions the target dir; WMI/Get-Process expose no cwd), so the net is deliberately broad. `-KillOrphans` clears them; the help text states they may belong to another checkout.
- **File-redirect output**: cargo streams go to a timestamped temp log via `*>`, printed after completion — lingering children inheriting the pipe can no longer stall capture. Log path printed up front; failure names the log.
- **Invocation quirk proven and avoided**: `cargo @args *>` array splatting mangles arguments on this pwsh/cargo combination (cargo received a stray `u`); literal args with the same redirection work.

Verified against a real detached `cargo build --release` holder: detected (2 cargo + 9 rustc), killed by `-KillOrphans`, subsequent debug build completed normally.

`no-changelog`: developer tooling only, no product behavior change.
