### PR TITLE
ci: bump-develop uses pull_request_target so fork PRs can bump too

### DIFF
--- a/.github/workflows/bump-develop.yml
+++ b/.github/workflows/bump-develop.yml
@@ -26,8 +26,14 @@ name: Bump develop version
 #      actions/create-github-app-token instead of the secret below.
 # Until CI_PAT exists, every run fails fast at checkout (empty token).
 
+# `pull_request_target` (not `pull_request`): fork PRs run `pull_request`
+# WITHOUT repo secrets, so CI_PAT is empty and checkout fails
+# ("Input required and not supplied: token" — seen on fork PR #220).
+# pull_request_target runs in base-repo context WITH secrets. Safe here: the
+# workflow file comes from develop (never from the PR) and this job checks out
+# `ref: develop` only — the PR's code is never executed or checked out.
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [develop]
 


### PR DESCRIPTION
One-line workflow fix: fork PRs run `pull_request` WITHOUT repo secrets, so the bump job's `CI_PAT` checkout fails (seen as run #42 failing on PR #220 — harmless, develop stayed green at 1.3.10). `pull_request_target` runs in base-repo context with secrets; safe because the workflow file comes from develop and the job only checks out `ref: develop` — PR code is never executed. Workflow-only change, no changelog entry (no-changelog).