### PR TITLE
chore: release-coauthors script — keep contributors credited through release squashes

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,6 +49,22 @@ git push -u origin release/v1.0.X
 
 Create PR → `master`. **Squash merge.**
 
+> **Keep contributors credited** — a squash commit is authored by whoever clicks
+> merge, so individual authorship never reaches master, and the GitHub
+> contributors list counts only the default branch. Carry the author trailers
+> in the squash commit body (review the list first — it may contain device/test
+> identities you don't want credited):
+>
+> ```bash
+> scripts/release-coauthors.sh   # prints Co-authored-by: lines
+> gh pr merge --squash --admin \
+>   --subject "release: v1.0.X" \
+>   --body "$(scripts/release-coauthors.sh)"
+> ```
+>
+> Squash-merging via the GitHub web UI instead? Its default squash message
+> already appends co-author trailers automatically — no script needed.
+
 ### 3. Tag release
 
 ```bash

--- a/scripts/release-coauthors.sh
+++ b/scripts/release-coauthors.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Print `Co-authored-by:` trailers for everyone who authored work that a
+# develop → master release squash is about to flatten away.
+#
+# Why: the contributors list is computed from the DEFAULT branch (master).
+# Release PRs are squash-merged (one commit per release, authored by whoever
+# clicks merge), so individual authorship would never reach master. GitHub
+# counts `Co-authored-by:` trailers on the default branch, so carrying these
+# trailers in the squash commit message credits every real contributor.
+#
+# Usage:
+#   scripts/release-coauthors.sh [BASE] [HEAD]     # defaults: origin/master origin/develop
+#
+# Wire into the release (step 2 of RELEASING.md):
+#   gh pr merge --squash --admin \
+#     --subject "release: v1.3.11" \
+#     --body "$(scripts/release-coauthors.sh)"
+#
+# Bots and merge commits are excluded (merge commits carry no unique
+# authorship). One line per distinct author email; the same human committing
+# under two emails produces two lines — harmless.
+
+set -euo pipefail
+
+BASE="${1:-origin/master}"
+HEAD="${2:-origin/develop}"
+
+emails=$(git log --no-merges --format='%an <%ae>' "$BASE..$HEAD" \
+  | sort -u \
+  | grep -viE 'github-actions\[bot\]|dependabot\[bot\]|41898282\+github-actions|test@example\.com' \
+  || true)
+
+if [ -z "$emails" ]; then
+  echo "(no human commits between $BASE and $HEAD — nothing to credit)" >&2
+  exit 0
+fi
+
+echo "$emails" | sed 's/^/Co-authored-by: /'
+echo "(review the list before pasting — drop device/test identities you don't want credited)" >&2


### PR DESCRIPTION
The GitHub contributors list counts only the default branch (master), but releases squash-merge develop -> master under the merger's name, flattening individual authorship. `scripts/release-coauthors.sh` prints Co-authored-by trailers for all human authors between origin/master and origin/develop (bots, merge commits, test fixture excluded); RELEASING.md step 2 documents pasting them into the squash commit body.

Verified against the live repo: output includes zcl0621 (PR #220) alongside flupkede. Tooling/docs-only — no changelog entry (no-changelog).