### PR TITLE
fix: route scip-csharp stderr through tracing instead of the TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ more PRs land; when the release is actually tagged, the same section is
 finalized in place with a date — no renaming/migration step needed.
 -->
 
+## [1.3.12]
+
+### Fixed
+
+- **scip-csharp stderr no longer scrambles the serve TUI.** The resident `scip-csharp serve` helper inherited the host's stderr, so MSBuild workspace diagnostics (e.g. project-load failures from stale NuGet restore state) were sprayed raw over the TUI, bypassing the file-only serve logger. Helper stderr is now piped and drained through tracing, with helper `[WARN]`/`[Failure]` lines classified as warn level across all invokers (index, find-refs, batch-find-refs, serve) — workspace-load errors land in the codesearch log and surface as warnings instead of corrupting the terminal.
+
 ## [1.3.10] - 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ more PRs land; when the release is actually tagged, the same section is
 finalized in place with a date — no renaming/migration step needed.
 -->
 
-## [1.3.12]
+## [1.3.13]
 
 ### Fixed
 

--- a/src/symbols/csharp.rs
+++ b/src/symbols/csharp.rs
@@ -90,6 +90,9 @@ pub(crate) fn drain_pipe_to_tracing<R: std::io::Read>(pipe: R, mut emit: impl Fn
                 }
                 emit(&String::from_utf8_lossy(&buf));
             }
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                continue; // transient (EINTR) — retry the read, do NOT end the drain
+            }
             Err(_) => break, // dead pipe — nothing more to drain
         }
     }

--- a/src/symbols/csharp.rs
+++ b/src/symbols/csharp.rs
@@ -497,11 +497,11 @@ impl CSharpSymbolIndexer {
         let stdout_handle = child.stdout.take().map(|stdout| {
             let label = solution_short.clone();
             thread::spawn(move || {
-                for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                drain_pipe_to_tracing(stdout, |line| {
                     if !line.is_empty() {
                         tracing::debug!("[scip-csharp:{}] {}", label, line);
                     }
-                }
+                });
             })
         });
 
@@ -589,11 +589,11 @@ impl CSharpSymbolIndexer {
         let stdout_handle = child.stdout.take().map(|stdout| {
             let label = solution_short.clone();
             thread::spawn(move || {
-                for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                drain_pipe_to_tracing(stdout, |line| {
                     if !line.is_empty() {
                         tracing::debug!("[scip-csharp find-refs:{}] {}", label, line);
                     }
-                }
+                });
             })
         });
 
@@ -1048,11 +1048,11 @@ impl CSharpSymbolIndexer {
         let stdout_handle = child.stdout.take().map(|stdout| {
             let label = solution_short.clone();
             thread::spawn(move || {
-                for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                drain_pipe_to_tracing(stdout, |line| {
                     if !line.is_empty() {
                         tracing::debug!("[scip-csharp batch-find-refs:{}] {}", label, line);
                     }
-                }
+                });
             })
         });
 

--- a/src/symbols/csharp.rs
+++ b/src/symbols/csharp.rs
@@ -49,6 +49,52 @@ use serde::{Deserialize, Serialize};
 use super::scip_parse;
 use super::{PrewarmSummary, RebuildScope, RebuildSummary, SymbolIndexer, SymbolReference};
 
+// ── Helper stderr routing ─────────────────────────────────────────
+
+/// True when a scip-csharp stderr line carries warning-severity output:
+/// the helper's own `[WARN]` prefix or MSBuildWorkspace's `[Failure]`
+/// workspace diagnostics (e.g. project-load failures).
+pub(crate) fn is_helper_warning_line(line: &str) -> bool {
+    line.contains("[WARN]") || line.contains("[Failure]")
+}
+
+/// Route one scip-csharp stderr line into tracing at the right severity.
+/// This is the ONLY sanctioned path for helper stderr: spawn helpers with
+/// `Stdio::piped()` and drain through here — never `Stdio::inherit()`,
+/// which bypasses tracing entirely and sprays raw MSBuild output over the
+/// serve process (file-only logging, TUI on stderr), scrambling it.
+pub(crate) fn emit_helper_stderr_line(tag: &str, label: &str, line: &str) {
+    if is_helper_warning_line(line) {
+        tracing::warn!("[{tag}:{label}] {line}");
+    } else {
+        tracing::info!("[{tag}:{label}] {line}");
+    }
+}
+
+/// Drain a helper output pipe to EOF, invoking `emit` once per line.
+/// Undecodable bytes are lossy-decoded and the line is still emitted, and
+/// a persistent read error ends the drain. A drain must never stop on
+/// individual bad lines: a stalled drain lets the pipe fill and blocks the
+/// helper mid-workspace-load (`lines().map_while(Result::ok)` had exactly
+/// that failure mode; `filter_map(Result::ok)` traded it for a busy spin
+/// under `clippy::lines_filter_map_ok` — read_until has neither problem).
+pub(crate) fn drain_pipe_to_tracing<R: std::io::Read>(pipe: R, mut emit: impl FnMut(&str)) {
+    let mut reader = BufReader::new(pipe);
+    loop {
+        let mut buf = Vec::new();
+        match reader.read_until(b'\n', &mut buf) {
+            Ok(0) => break, // EOF — helper died; drain thread exits here
+            Ok(_) => {
+                while matches!(buf.last(), Some(b'\n') | Some(b'\r')) {
+                    buf.pop();
+                }
+                emit(&String::from_utf8_lossy(&buf));
+            }
+            Err(_) => break, // dead pipe — nothing more to drain
+        }
+    }
+}
+
 // ── Constants ─────────────────────────────────────────────────────
 
 /// LMDB database name for the SCIP symbol table (definitions only after Opt 2).
@@ -440,11 +486,11 @@ impl CSharpSymbolIndexer {
         let stderr_handle = child.stderr.take().map(|stderr| {
             let label = solution_short.clone();
             thread::spawn(move || {
-                for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+                drain_pipe_to_tracing(stderr, |line| {
                     if !line.is_empty() {
-                        tracing::info!("[scip-csharp:{}] {}", label, line);
+                        emit_helper_stderr_line("scip-csharp", &label, line);
                     }
-                }
+                });
             })
         });
 
@@ -532,11 +578,11 @@ impl CSharpSymbolIndexer {
         let stderr_handle = child.stderr.take().map(|stderr| {
             let label = solution_short.clone();
             thread::spawn(move || {
-                for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+                drain_pipe_to_tracing(stderr, |line| {
                     if !line.is_empty() {
-                        tracing::info!("[scip-csharp find-refs:{}] {}", label, line);
+                        emit_helper_stderr_line("scip-csharp find-refs", &label, line);
                     }
-                }
+                });
             })
         });
 
@@ -991,11 +1037,11 @@ impl CSharpSymbolIndexer {
         let stderr_handle = child.stderr.take().map(|stderr| {
             let label = solution_short.clone();
             thread::spawn(move || {
-                for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+                drain_pipe_to_tracing(stderr, |line| {
                     if !line.is_empty() {
-                        tracing::info!("[scip-csharp batch-find-refs:{}] {}", label, line);
+                        emit_helper_stderr_line("scip-csharp batch-find-refs", &label, line);
                     }
-                }
+                });
             })
         });
 

--- a/src/symbols/csharp_tests.rs
+++ b/src/symbols/csharp_tests.rs
@@ -1,0 +1,88 @@
+//! Helper stderr routing tests (`csharp.rs`). Sibling `_tests.rs` file
+//! per repo convention.
+
+use super::csharp::{drain_pipe_to_tracing, is_helper_warning_line};
+use std::io::Cursor;
+use std::sync::Mutex;
+
+fn drained(input: &[u8]) -> Vec<String> {
+    let out: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    drain_pipe_to_tracing(Cursor::new(input.to_vec()), |line| {
+        out.lock().expect("test mutex").push(line.to_string());
+    });
+    out.into_inner().expect("test mutex")
+}
+
+#[test]
+fn drain_survives_bad_bytes_and_strips_eol() {
+    let mut raw = b"first line\n".to_vec();
+    raw.extend_from_slice(b"bad \xFF\xFE bytes\n"); // invalid UTF-8 mid-stream
+    raw.extend_from_slice(b"crlf line\r\n");
+    raw.extend_from_slice(b"no trailing newline");
+
+    let lines = drained(&raw);
+
+    // The defect this pins: lines().map_while(Result::ok) ended the drain
+    // permanently at the non-UTF-8 line, silently dropping lines 3-4 and
+    // eventually stalling the pipe. All four lines must come through.
+    assert_eq!(lines.len(), 4, "drain stopped early: {lines:?}");
+    assert_eq!(lines[0], "first line");
+    assert!(
+        lines[1].starts_with("bad ") && lines[1].ends_with(" bytes"),
+        "expected lossy-decoded line, got: {:?}",
+        lines[1]
+    );
+    assert_eq!(lines[2], "crlf line");
+    assert_eq!(lines[3], "no trailing newline");
+}
+
+#[test]
+fn drain_stops_at_eof_and_handles_empty_pipe() {
+    assert!(drained(b"").is_empty());
+    assert_eq!(drained(b"only\n"), vec!["only".to_string()]);
+}
+
+#[test]
+fn helper_warning_classification_table() {
+    let cases: [(&str, bool); 10] = [
+        // Helper's own workspace-failure warnings (WorkspaceFailed handler).
+        (
+            "[WARN] Workspace error: [Failure] Msbuild failed when processing the file 'C:\\r\\p.csproj' with message: Dependency specified was X but ended up with X 1.2.3",
+            true,
+        ),
+        (
+            "[WARN] Solution load partially failed (InvalidOperationException: boom); continuing with 13 loaded project(s).",
+            true,
+        ),
+        (
+            "serve: [WARN] no projects loaded — cannot serve.",
+            true,
+        ),
+        // Bare MSBuildWorkspace diagnostic without the helper prefix.
+        (
+            "[Failure] Msbuild failed when processing the file 'C:\\r\\p.csproj'",
+            true,
+        ),
+        ("[WARN] Project file not found: C:\\r\\missing.csproj", true),
+        // Progress / info lines must NOT escalate to warn.
+        (
+            "[INFO] Skipping unsupported project type: C:\\r\\x.shproj",
+            false,
+        ),
+        ("Loading solution: C:\\r\\x.sln", false),
+        ("Loaded 13 project(s) from filtered solution", false),
+        (
+            "MSBuild: registering '.NET SDK' v10.0.303 at C:\\Program Files\\dotnet\\sdk\\10.0.303",
+            false,
+        ),
+        ("Index written to: C:\\tmp\\out.json", false),
+    ];
+
+    for (line, expected) in cases {
+        assert_eq!(
+            is_helper_warning_line(line),
+            expected,
+            "misclassified line: {line}"
+        );
+    }
+}

--- a/src/symbols/csharp_tests.rs
+++ b/src/symbols/csharp_tests.rs
@@ -64,9 +64,11 @@ impl std::io::Read for InterruptedOnce {
 
 #[test]
 fn drain_retries_after_transient_interrupted_read() {
-    // EINTR on a blocking pipe read must not end the drain: on Linux a
-    // signal during the minutes-long workspace load would otherwise kill
-    // the drain thread and stall the helper on a full pipe.
+    // Contract: a transient Interrupted read must not end the drain. std's
+    // own read_until already retries Interrupted internally (rustc 1.98,
+    // library/std/src/io/mod.rs), so the local arm in drain_pipe_to_tracing
+    // is belt-and-braces and unreachable via its internal BufReader — this
+    // test pins the observable contract, not that arm.
     let mut out: Vec<String> = Vec::new();
     drain_pipe_to_tracing(
         InterruptedOnce {

--- a/src/symbols/csharp_tests.rs
+++ b/src/symbols/csharp_tests.rs
@@ -42,6 +42,42 @@ fn drain_stops_at_eof_and_handles_empty_pipe() {
     assert_eq!(drained(b"only\n"), vec!["only".to_string()]);
 }
 
+/// Read impl whose first read fails with `Interrupted` (EINTR), then
+/// behaves like a normal pipe.
+struct InterruptedOnce {
+    armed: bool,
+    inner: Cursor<Vec<u8>>,
+}
+
+impl std::io::Read for InterruptedOnce {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.armed {
+            self.armed = false;
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "eintr",
+            ));
+        }
+        self.inner.read(buf)
+    }
+}
+
+#[test]
+fn drain_retries_after_transient_interrupted_read() {
+    // EINTR on a blocking pipe read must not end the drain: on Linux a
+    // signal during the minutes-long workspace load would otherwise kill
+    // the drain thread and stall the helper on a full pipe.
+    let mut out: Vec<String> = Vec::new();
+    drain_pipe_to_tracing(
+        InterruptedOnce {
+            armed: true,
+            inner: Cursor::new(b"before\nafter\n".to_vec()),
+        },
+        |line| out.push(line.to_string()),
+    );
+    assert_eq!(out, vec!["before".to_string(), "after".to_string()]);
+}
+
 #[test]
 fn helper_warning_classification_table() {
     let cases: [(&str, bool); 10] = [

--- a/src/symbols/mod.rs
+++ b/src/symbols/mod.rs
@@ -470,3 +470,9 @@ mod lock_visibility_tests;
 #[cfg(test)]
 #[path = "resident_tests.rs"]
 mod resident_tests;
+
+/// Helper stderr routing tests (`csharp.rs`). Sibling `_tests.rs` file
+/// per repo convention.
+#[cfg(test)]
+#[path = "csharp_tests.rs"]
+mod csharp_tests;

--- a/src/symbols/resident.rs
+++ b/src/symbols/resident.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use super::SymbolReference;
@@ -61,9 +62,11 @@ impl ServeClient {
             .arg(solution)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            // Helper stderr is diagnostics (load progress); route it into the
-            // host's log stream instead of piping and draining a third pipe.
-            .stderr(Stdio::inherit())
+            // Helper stderr is diagnostics (load progress + workspace-load
+            // warnings). Pipe it and drain via tracing: an inherited stderr
+            // bypasses the file-only serve logger entirely and sprays raw
+            // MSBuild output straight onto the TUI, scrambling it.
+            .stderr(Stdio::piped())
             .env("DOTNET_GCHeapHardLimit", heap_cap_hex)
             .spawn()
             .with_context(|| {
@@ -81,6 +84,25 @@ impl ServeClient {
             .stdout
             .take()
             .context("serve helper has no stdout pipe")?;
+
+        // Drain helper stderr through tracing (warnings classified as warn).
+        // Detached: the thread lives until the helper dies (EOF), so kill and
+        // Drop teardown need no coordination with it. Without a concurrent
+        // drain the pipe buffer would fill during the minutes-long workspace
+        // load and block the helper.
+        if let Some(stderr) = child.stderr.take() {
+            let label = solution
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_else(|| solution.display().to_string());
+            thread::spawn(move || {
+                super::csharp::drain_pipe_to_tracing(stderr, |line| {
+                    if !line.is_empty() {
+                        super::csharp::emit_helper_stderr_line("scip-csharp serve", &label, line);
+                    }
+                });
+            });
+        }
 
         let client = Self {
             stdin: Mutex::new(stdin),


### PR DESCRIPTION
## Summary

- **Problem:** resident scip-csharp serve helper inherited host stderr; MSBuild workspace diagnostics (e.g. NuGet version-mismatch project-load failures) were sprayed raw over the serve TUI, bypassing the file-only serve logger.
- **Fix:** all helper pipes are captured; stderr/stdout drain through a shared read_until + lossy-decode helper (drain_pipe_to_tracing) into tracing; helper [WARN]/[Failure] lines log at warn level. Stall-proof (no map_while early-stop, Interrupted-safe), pinned by table tests. CHANGELOG entry under [1.3.12].
- **Validation:** cargo check / clippy -D warnings / cargo test --lib --bins green (1322 passed, 42 ignored).
- **Reviews:** stage review PASS (round 2), final full review findings resolved (stdout drains same class fixed; Interrupted handling hardened + comment corrected).