### PR TITLE
feat: edit-guard — fourth Claude Code guard hook (todo #134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ more PRs land; when the release is actually tagged, the same section is
 finalized in place with a date — no renaming/migration step needed.
 -->
 
+## [1.3.15]
+
+### Added
+
+- **`edit-guard` — a fourth Claude Code guard hook: edits now require a codesearch consultation first.** On `Edit`/`Write`/`MultiEdit` against a file in a codesearch-registered repo, the hook denies the edit unless codesearch was consulted for that exact path within the last 5 minutes: `find_impact` for SCIP-backed languages (`.cs .ts .tsx .mts .cts`), `find(kind="usages")` for everything else. Markers are recorded by `edit-guard-post`, the first Claude Code `PostToolUse` hook in this repo: it fires on every `find_impact` call and every `find(kind="usages")` (kind check done script-side — matchers only see tool names), counts any outcome ("no results" and "no SCIP backend" included, so the guard can never wedge permanently), and prunes expired entries on write. The guard accepts ANY marker for the path within the window and fails open on unregistered repos, non-git paths and a crashed hook; missing/corrupt state counts as not consulted (deny on covered repos, allow everywhere else). Shared target-resolution/coverage helpers moved into `codesearch-common.sh/.ps1` (grep-guard sources them too; its PowerShell twin is thereby ported off the last `.codesearch.db`/Windows-only-path coverage signals, closing the #199 gap). The native installer writes the new scripts plus a `PostToolUse` registration, idempotent by exact command as before; the subagent preamble gained an EDIT RULE line. Hook self-tests: `bash integrations/claude-code/hooks/run-tests.sh` (todo #134).
+
 ## [1.3.14]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -222,10 +222,11 @@ OpenCode: put this in the user-level `~/.config/opencode/AGENTS.md` (applies acr
 
 **Claude Code specifically** tends to ignore this advice more than other clients — its MCP tool schemas are deferred (an extra `ToolSearch` call is needed before codesearch tools are even callable), while Grep/Glob are always fully loaded and zero-friction, and spawned subagents don't inherit `AGENTS.md` or the MCP `initialize` instructions at all.
 
-To make the preference **structural** instead of advisory, this repo ships three Claude Code `PreToolUse` hooks:
+To make the preference **structural** instead of advisory, this repo ships five Claude Code hooks (four `PreToolUse` guards plus one `PostToolUse` companion):
 
 - **`grep-guard`** — on `Grep`. Blocks a grep against an in-repo path when codesearch covers that repo (the target repo — resolved from the grep target's own git root — is registered with the serve hub in `~/.codesearch/repos.json`, or a `CODESEARCH_SERVER` env var is set for remote-serve setups), with a message telling the model how to load and call codesearch instead. Grep is auto-allowed **only when the serve hub is genuinely down**, established by a live probe of the unauthenticated `/healthz` endpoint (`CODESEARCH_SERVER` > `127.0.0.1:$CODESEARCH_SERVE_PORT` > `127.0.0.1:39725`); only a connection-level failure counts as down. A low-confidence or empty codesearch result is a *successful* call meaning "reformulate the query", so it does **not** open the escape hatch — the deny message steers to `find`/`explore`/a single clean term instead. Greps outside any registered repo are never blocked, and the hook fails open (never traps the model).
-- **`subagent-preamble`** — on `Agent` (the subagent-spawn tool). Prepends a short codesearch preamble to every subagent prompt, since subagents otherwise don't inherit `AGENTS.md` or MCP instructions at all.
+- **`edit-guard`** — on `Edit`/`Write`/`MultiEdit`. Blocks an edit to a file in a codesearch-registered repo until codesearch was consulted for that exact path within the last 5 minutes — `find_impact` for SCIP-backed languages (`.cs .ts .tsx .mts .cts`), `find(kind="usages")` for everything else — making the caller-aware-editing protocol structural. Its companion **`edit-guard-post`** (`PostToolUse`) records the markers on every `find_impact` call and every `find(kind="usages")`; any outcome counts ("no results" included), so the guard can never wedge. Unregistered repos, non-git paths and hook failures fail open.
+- **`subagent-preamble`** — on `Agent` (the subagent-spawn tool). Prepends a short codesearch preamble to every subagent prompt, since subagents otherwise don't inherit `AGENTS.md` or MCP instructions at all — including the edit-guard protocol above.
 - **`web-guard`** — on `WebSearch`/`WebFetch`. When you have remote documentation projects mounted (`codesearch remote mount`, e.g. `cloud/inriver`, `cloud/example-dam`), it blocks the first web call with guidance to search those indexed mounts first — often more precise and current than the open web. Same 5-minute retry-escape; when no mounts are configured it does nothing.
 
 Install (idempotent — user scope applies to every project; `--project` is this repo only):
@@ -437,7 +438,7 @@ The install target is resolved with `git rev-parse --git-path hooks`, so it hono
 
 ### Claude Code Guard Hooks
 
-`codesearch hooks claude install` (`--project` for repo scope) installs the `PreToolUse` guard hooks that steer agents to codesearch before `Grep`/`WebSearch`/`WebFetch`. See [Agent Guidance](#agent-guidance-making-agents-use-codesearch-not-grep) above for what each guard does.
+`codesearch hooks claude install` (`--project` for repo scope) installs the four `PreToolUse` guard hooks that steer agents to codesearch before `Grep`/`WebSearch`/`WebFetch`/`Edit`/`Write`/`MultiEdit`, plus the `PostToolUse` marker hook (`edit-guard-post`) that records the consultations `edit-guard` requires. See [Agent Guidance](#agent-guidance-making-agents-use-codesearch-not-grep) above for what each guard does.
 
 ### MCP Connection Modes
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -26,7 +26,7 @@ parent's `AGENTS.md` or the MCP `initialize` instructions at all.
 
 ## The fix
 
-Two [Claude Code hooks](https://docs.claude.com/en/docs/claude-code/hooks)
+Four [Claude Code hooks](https://docs.claude.com/en/docs/claude-code/hooks)
 that make the preference *structural* instead of advisory:
 
 - **`grep-guard`** — a `PreToolUse` hook on `Grep`. Blocks every `Grep`
@@ -65,9 +65,32 @@ that make the preference *structural* instead of advisory:
   and when to prefer it over Grep/Glob. This is the only way to reach
   subagents at all, since they don't inherit `AGENTS.md` or MCP instructions.
 
-Both hooks fail open: if they can't parse their input, or codesearch isn't
-running/indexed, they get out of the way and let Grep proceed untouched. They
-never block targets outside any git repo, or repos codesearch does not cover.
+- **`edit-guard`** — a `PreToolUse` hook on `Edit`/`Write`/`MultiEdit`.
+  Blocks an edit to a file in a codesearch-registered repo until codesearch
+  was consulted for that exact path within the last 5 minutes:
+  `mcp__codesearch__find_impact` for SCIP-backed languages
+  (`.cs .ts .tsx .mts .cts`), `mcp__codesearch__find(kind="usages")` for
+  everything else — making the caller-aware-editing protocol structural.
+  Coverage uses the same registration model as grep-guard (shared
+  `codesearch-common` helpers): the file's git root must be listed in
+  `~/.codesearch/repos.json` (or `CODESEARCH_SERVER` is set); unregistered
+  repos and non-git paths are never blocked.
+
+- **`edit-guard-post`** — a `PostToolUse` hook on
+  `mcp__codesearch__find_impact` and `mcp__codesearch__find`, recording the
+  "consulted" markers `edit-guard` reads into a state file
+  (`$TMPDIR/.codesearch-edit-guard-state.json` on bash,
+  `%TEMP%\.codesearch-edit-guard-state.json` on PowerShell). It fires on
+  every `find_impact` call and every `find(kind="usages")` (the kind check
+  is done script-side — matchers only see tool names). Any outcome counts:
+  "no results" and "no SCIP backend" still mark the path as consulted, so
+  the guard can never wedge permanently. PostToolUse hooks cannot block
+  anything; this one never emits a decision and always exits 0.
+
+All hooks fail open: if they can't parse their input, or codesearch isn't
+running/indexed, they get out of the way and let the tool call proceed
+untouched. They never block targets outside any git repo, or repos
+codesearch does not cover.
 
 ## Install
 
@@ -86,9 +109,11 @@ bash integrations/claude-code/install.sh --project
 ```
 
 The installer:
-1. copies the hook scripts into `<claude-dir>/hooks/codesearch/`
-2. merges two `PreToolUse` registrations into `<claude-dir>/settings.json`
-   (backing up the existing file first)
+1. copies the guard scripts, the PostToolUse companion and the shared
+   `codesearch-common` helpers into `<claude-dir>/hooks/codesearch/`
+2. merges the `PreToolUse` registrations (one per guard) and the
+   `PostToolUse` registration (the companion) into
+   `<claude-dir>/settings.json` (backing up the existing file first)
 3. is idempotent — re-running it skips hooks already registered and never
    duplicates or clobbers unrelated settings
 
@@ -96,9 +121,9 @@ Restart Claude Code (or start a new session) after installing.
 
 ## Manual install
 
-If you'd rather wire it up by hand, or already have a `PreToolUse.Grep` /
-`PreToolUse.Agent` hook and want to merge manually, add to
-`~/.claude/settings.json` (or `.claude/settings.json` for project scope):
+If you'd rather wire it up by hand, or already have hooks on these events and
+want to merge manually, add to `~/.claude/settings.json` (or
+`.claude/settings.json` for project scope):
 
 ```json
 {
@@ -115,6 +140,20 @@ If you'd rather wire it up by hand, or already have a `PreToolUse.Grep` /
         "hooks": [
           { "type": "command", "command": "pwsh -NoProfile -NonInteractive -File \"<path>/subagent-preamble.ps1\"" }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "pwsh -NoProfile -NonInteractive -File \"<path>/edit-guard.ps1\"" }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "mcp__codesearch__find_impact|mcp__codesearch__find",
+        "hooks": [
+          { "type": "command", "command": "pwsh -NoProfile -NonInteractive -File \"<path>/edit-guard-post.ps1\"" }
+        ]
       }
     ]
   }
@@ -123,11 +162,15 @@ If you'd rather wire it up by hand, or already have a `PreToolUse.Grep` /
 
 Use the `.sh` scripts with a `bash "<path>/..."` command instead on
 macOS/Linux. Point `<path>` at wherever you copy `hooks/*.ps1` / `hooks/*.sh`.
+The guard scripts source `codesearch-common.ps1` / `codesearch-common.sh`
+from their own directory, so that file must be copied alongside them.
 
 ## Uninstall
 
-Remove the two `PreToolUse` entries (matcher `Grep` and `Agent` whose command
-points at `hooks/codesearch/`) from `settings.json`, and delete
+Remove the guard entries (matchers `Grep`, `Agent`, `WebSearch|WebFetch` and
+`Edit|Write|MultiEdit` under `PreToolUse`, and
+`mcp__codesearch__find_impact|mcp__codesearch__find` under `PostToolUse`,
+whose commands point at `hooks/codesearch/`) from `settings.json`, and delete
 `<claude-dir>/hooks/codesearch/`.
 
 ## Caveats
@@ -168,10 +211,19 @@ points at `hooks/codesearch/`) from `settings.json`, and delete
   silently allowed everything.)
   If your setup connects to a remote `codesearch serve` instance with no
   local `repos.json` registration, set `CODESEARCH_SERVER` to opt back
-  into enforcement for that repo. Note: the PowerShell twin
-  (`grep-guard.ps1`) still uses the older `.codesearch.db` coverage
-  signal and Windows-only absolute-path detection; porting it to the
-  registration-based resolution is tracked in #199.
+  into enforcement for that repo. Both the bash and the PowerShell twin
+  now resolve coverage through the shared `codesearch-common` helpers,
+  so the two shells behave identically (the PowerShell twin used to lag
+  behind on the `.codesearch.db`/Windows-only-path signals — closed with
+  the edit-guard work, #199).
+- `edit-guard` is per-file, not per-repo: a marker for one file never
+  unblocks an edit to another file. The marker state lives in a temp-dir
+  JSON file (`$TMPDIR/.codesearch-edit-guard-state.json` /
+  `%TEMP%\.codesearch-edit-guard-state.json`), entries expire after
+  5 minutes and are pruned on write; missing or corrupt state counts as
+  "not consulted" (deny on covered repos, allow everywhere else). Like
+  the other guards it is per-machine, not per-repo: it only ever fires
+  on files whose git root is registered with the serve hub.
 - Both hooks are per-machine, not per-repo: install once at user scope and
   every project benefits, including ones not registered with the serve
   hub (the guard simply won't block Grep there, since coverage fails

--- a/integrations/claude-code/hooks/codesearch-common.ps1
+++ b/integrations/claude-code/hooks/codesearch-common.ps1
@@ -1,0 +1,90 @@
+# Shared helpers for the codesearch Claude Code guard hooks. Dot-sourced by
+# grep-guard.ps1, edit-guard.ps1 and edit-guard-post.ps1:
+#   . (Join-Path $PSScriptRoot 'codesearch-common.ps1')
+#
+# PowerShell twin of codesearch-common.sh — keep the two behaviorally
+# equivalent. Coverage model: a repo is covered when its git root is
+# REGISTERED in ~/.codesearch/repos.json (CODESEARCH_REPOS_CONFIG overrides
+# the location), or when CODESEARCH_SERVER opts a pure remote-serve setup
+# in. Everything here fails open: an unresolvable coverage question must
+# allow, never deny.
+
+function Get-CodesearchReposConfigFile {
+    if ($env:CODESEARCH_REPOS_CONFIG) { return $env:CODESEARCH_REPOS_CONFIG }
+    return (Join-Path $HOME '.codesearch/repos.json')
+}
+
+function ConvertTo-NormRepoPath {
+    param([string]$P)
+    $p = $P
+    if ($p.StartsWith('\\?\')) { $p = $p.Substring(4) }
+    $p = $p -replace '\\', '/'
+    while ($p -ne '/' -and $p.EndsWith('/')) { $p = $p.TrimEnd('/') }
+    return $p
+}
+
+function Test-CodesearchRepoPathEqual {
+    param([string]$A, [string]$B)
+    $a = ConvertTo-NormRepoPath $A
+    $b = ConvertTo-NormRepoPath $B
+    # Exact on POSIX-style paths; case-insensitive for Windows drive-letter
+    # paths (NTFS folds case throughout), mirroring codesearch-common.sh.
+    if ($a -match '^[A-Za-z]:/') { $a = $a.ToLowerInvariant() }
+    if ($b -match '^[A-Za-z]:/') { $b = $b.ToLowerInvariant() }
+    return [string]::Equals($a, $b, [System.StringComparison]::Ordinal)
+}
+
+function Test-CodesearchTargetRegistered {
+    param([string]$Root)
+    if ($env:CODESEARCH_SERVER) { return $true }
+    $cfg = Get-CodesearchReposConfigFile
+    if ([string]::IsNullOrWhiteSpace($cfg)) { return $false }
+    if (-not (Test-Path -LiteralPath $cfg -PathType Leaf)) { return $false }
+    try { $json = Get-Content -LiteralPath $cfg -Raw | ConvertFrom-Json } catch { return $false }
+    if ($null -eq $json -or $null -eq $json.repos) { return $false }
+    foreach ($prop in $json.repos.PSObject.Properties) {
+        $val = $prop.Value
+        $reg = if ($val -is [string]) { $val } else { $val | ConvertTo-Json -Compress -Depth 10 }
+        if ([string]::IsNullOrEmpty($reg)) { continue }
+        if (Test-CodesearchRepoPathEqual $reg $Root) { return $true }
+    }
+    return $false
+}
+
+function Resolve-TargetGitRoot {
+    param([string]$Path)
+    $root = $null
+    $norm = $Path.TrimEnd('/', '\')
+    if ($norm -match '^([A-Za-z]:[\\/]|/)') {
+        # Absolute path (Windows drive, UNC, or any POSIX root): the git root
+        # OF THE TARGET, not of the hook's cwd.
+        $probe = $norm
+        try {
+            if (Test-Path -LiteralPath $probe -PathType Leaf) { $probe = Split-Path -Parent $probe }
+        } catch {}
+        try {
+            $gr = (& git -C $probe rev-parse --show-toplevel 2>$null)
+            if ($LASTEXITCODE -eq 0 -and $gr) { $root = "$gr".Trim() }
+        } catch {}
+    } else {
+        # Empty or relative path: resolves against the cwd repo.
+        try {
+            $gr = (& git rev-parse --show-toplevel 2>$null)
+            if ($LASTEXITCODE -eq 0 -and $gr) { $root = "$gr".Trim() }
+        } catch {}
+    }
+    return $root
+}
+
+function ConvertTo-StateKey {
+    param([string]$P)
+    if ([string]::IsNullOrEmpty($P)) { return '' }
+    $p = $P
+    $norm = $p.TrimEnd('/', '\')
+    if (-not ($norm -match '^([A-Za-z]:[\\/]|/)')) {
+        $p = (Join-Path (Get-Location).Path $p)
+    }
+    $k = ConvertTo-NormRepoPath $p
+    if ($k -match '^[A-Za-z]:/') { $k = $k.ToLowerInvariant() }
+    return $k
+}

--- a/integrations/claude-code/hooks/codesearch-common.sh
+++ b/integrations/claude-code/hooks/codesearch-common.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Shared helpers for the codesearch Claude Code guard hooks. Sourced (never
+# executed) by grep-guard.sh, edit-guard.sh and edit-guard-post.sh:
+#   . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/codesearch-common.sh"
+#
+# Coverage model (shared with the Rust serve hub, src/db_discovery/repos.rs):
+# a repo is covered when its git root is REGISTERED in
+# ~/.codesearch/repos.json (CODESEARCH_REPOS_CONFIG overrides the location),
+# or when CODESEARCH_SERVER opts a pure remote-serve setup in. Everything
+# here fails open: an unresolvable coverage question must allow, never deny.
+# Requires: jq
+
+# jq.exe builds on Windows emit CRLF; command substitution strips only the
+# \n, leaving a stray \r that breaks every following string comparison.
+# Every jq -r read pipes through this.
+jq_str() {
+    tr -d '\r'
+}
+
+# repos.json location — mirrors src/db_discovery/repos.rs `config_path()`:
+# CODESEARCH_REPOS_CONFIG override > ~/.codesearch/repos.json.
+repos_config_file() {
+    if [ -n "${CODESEARCH_REPOS_CONFIG:-}" ]; then
+        printf '%s' "$CODESEARCH_REPOS_CONFIG"
+    else
+        printf '%s' "${HOME:-}/.codesearch/repos.json"
+    fi
+}
+
+# Normalize one path for comparison: drop a Windows extended-length prefix
+# (\\?\ — exactly 4 chars), unify backslashes to forward slashes (Git-Bash
+# reports C:/x/y while repos.json records "C:\\x\\y"), and trim trailing
+# separators. Registration canonicalizes paths before writing them
+# (safe_canonicalize), so after this both sides agree byte-for-byte on
+# POSIX and component-wise on Windows.
+norm_repo_path() {
+    local p="$1"
+    p="${p%$'\r'}"
+    case "$p" in
+        '\\?\'*) p="${p:4}" ;;
+    esac
+    p="${p//\\//}"
+    while [ "$p" != "/" ] && [ "${p%/}" != "$p" ]; do
+        p="${p%/}"
+    done
+    printf '%s' "$p"
+}
+
+# Path equality: exact on POSIX, case-insensitive for Windows drive-letter
+# paths (NTFS is case-insensitive throughout) — mirrors the serve hub's own
+# /indexing resolver, which folds case on Windows only.
+repo_path_eq() {
+    local a b
+    a="$(norm_repo_path "$1")"
+    b="$(norm_repo_path "$2")"
+    case "$a" in [A-Za-z]:/*) a="$(printf '%s' "$a" | tr '[:upper:]' '[:lower:]')" ;; esac
+    case "$b" in [A-Za-z]:/*) b="$(printf '%s' "$b" | tr '[:upper:]' '[:lower:]')" ;; esac
+    [ "$a" = "$b" ]
+}
+
+# Is this git root covered by codesearch — registered with the local serve
+# hub (repos.json), or a CODESEARCH_SERVER opt-in for pure remote-serve
+# setups? Fails OPEN on any resolver problem (missing/unreadable/malformed
+# repos.json, missing jq): a guard that cannot resolve coverage must allow,
+# never deny.
+target_registered() {
+    local root="$1" cfg reg
+    [ -n "${CODESEARCH_SERVER:-}" ] && return 0
+    cfg="$(repos_config_file)"
+    [ -n "$cfg" ] || return 1
+    [ -r "$cfg" ] || return 1
+    while IFS= read -r reg; do
+        [ -n "$reg" ] || continue
+        if repo_path_eq "$reg" "$root"; then
+            return 0
+        fi
+    # jq gets the config via stdin redirection, never as a positional path
+    # argument — native jq.exe builds mangle POSIX-style paths (see the
+    # same note in web-guard.sh).
+    done < <(jq -r '(.repos // {}) | to_entries[] | .value | tostring' < "$cfg" 2>/dev/null)
+    return 1
+}
+
+# Git root of the repo a target path lives in — the TARGET's repo, never the
+# hook's cwd one, for absolute paths; empty/relative paths are relative to
+# the cwd by definition and resolve against it. Prints the root; empty when
+# the path is outside any git repo (or git is unusable).
+resolve_target_git_root() {
+    local p="$1" norm probe root=""
+    norm="${p%/}"
+    norm="${norm%\\}"
+    case "$norm" in
+        # `/*` matches every absolute path — Windows drive, UNC and POSIX
+        # alike (a Windows-style-only pattern used to strand POSIX absolute
+        # paths on the cwd branch, #199).
+        [A-Za-z]:[\\/]*|/*)
+            probe="$norm"
+            [ -f "$probe" ] && probe="$(dirname "$probe")"
+            root=$(git -C "$probe" rev-parse --show-toplevel 2>/dev/null || true)
+            ;;
+        *)
+            root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+            ;;
+    esac
+    printf '%s' "$root"
+}
+
+# Canonical state-file key for a file path: edit-guard reads the state by
+# this key and edit-guard-post writes it, so both sides must derive the SAME
+# key from whatever path form the agent happened to pass. Absolute-izes
+# relative paths against the cwd, then reuses the repos.json normalization
+# plus repo_path_eq's Windows drive-letter casefold.
+norm_state_key() {
+    local p="$1" n
+    [ -n "$p" ] || return 0
+    case "$p" in
+        [A-Za-z]:[\\/]*|/*) ;;
+        *) p="$PWD/${p#./}" ;;
+    esac
+    n="$(norm_repo_path "$p")"
+    case "$n" in [A-Za-z]:/*) n="$(printf '%s' "$n" | tr '[:upper:]' '[:lower:]')" ;; esac
+    printf '%s' "$n"
+}

--- a/integrations/claude-code/hooks/edit-guard-post.ps1
+++ b/integrations/claude-code/hooks/edit-guard-post.ps1
@@ -1,0 +1,74 @@
+# PostToolUse companion for edit-guard: records a "codesearch consulted"
+# marker per file path after qualifying MCP calls, into the same state file
+# edit-guard reads. Windows twin of edit-guard-post.sh — keep the two
+# behaviorally equivalent. Fires on:
+#   - mcp__codesearch__find_impact   (ANY outcome counts — including "no
+#     results" / "no SCIP backend": counting failures too is what keeps the
+#     guard from blocking permanently)
+#   - mcp__codesearch__find with kind="usages" (string compare HERE — the
+#     matcher regex can only filter on tool name)
+#
+# PostToolUse hooks cannot block anything: no decision is emitted and this
+# script ALWAYS exits 0. Symbol-only find_impact calls carry no file-ish
+# input field and are skipped (nothing to attribute a path to).
+
+$ErrorActionPreference = 'Stop'
+
+try {
+    . (Join-Path $PSScriptRoot 'codesearch-common.ps1')
+    $raw = [Console]::In.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($raw)) { exit 0 }
+    $data = $raw | ConvertFrom-Json
+} catch {
+    exit 0
+}
+
+$tool = $data.tool_name
+$inp  = $data.tool_input
+
+switch ($tool) {
+    'mcp__codesearch__find_impact' { $markTool = 'find_impact' }
+    'mcp__codesearch__find' {
+        $kind = if ($inp -and @($inp.PSObject.Properties.Name) -contains 'kind') { [string]$inp.kind } else { '' }
+        if ($kind -ne 'usages') { exit 0 }
+        $markTool = 'find_usages'
+    }
+    default { exit 0 }
+}
+
+$p = $null
+foreach ($field in @('file', 'path', 'file_path')) {
+    if ($inp -and @($inp.PSObject.Properties.Name) -contains $field) {
+        $candidate = [string]$inp.$field
+        if (-not [string]::IsNullOrEmpty($candidate)) { $p = $candidate; break }
+    }
+}
+if ([string]::IsNullOrEmpty($p)) { exit 0 }
+
+$key = ConvertTo-StateKey $p
+if ([string]::IsNullOrEmpty($key)) { exit 0 }
+
+$stateFile = Join-Path $env:TEMP '.codesearch-edit-guard-state.json'
+$window    = 300
+$now       = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+
+# Upsert, pruning expired entries; corrupt/unreadable state starts over.
+$state = @{}
+if (Test-Path -LiteralPath $stateFile -PathType Leaf) {
+    try {
+        $stored = Get-Content -LiteralPath $stateFile -Raw | ConvertFrom-Json
+        foreach ($pr in $stored.PSObject.Properties) {
+            $ts = 0L
+            try { $ts = [long]$pr.Value.ts } catch {}
+            if (($now - $ts) -lt $window) {
+                $state[$pr.Name] = @{ tool = [string]$pr.Value.tool; ts = $ts }
+            }
+        }
+    } catch {}
+}
+$state[$key] = @{ tool = $markTool; ts = $now }
+try {
+    $state | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $stateFile -NoNewline
+} catch {}
+
+exit 0

--- a/integrations/claude-code/hooks/edit-guard-post.sh
+++ b/integrations/claude-code/hooks/edit-guard-post.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# PostToolUse companion for edit-guard: records a "codesearch consulted"
+# marker per file path after qualifying MCP calls, into the same state file
+# edit-guard reads. Fires on:
+#   - mcp__codesearch__find_impact           (ANY outcome counts — including
+#     "no results" / "no SCIP backend": the guard cannot know the result, and
+#     counting failures too is what keeps it from blocking permanently)
+#   - mcp__codesearch__find with kind="usages"
+#     (the kind check is a string compare HERE, not in the matcher regex —
+#     matchers filter on tool name only)
+#
+# PostToolUse hooks cannot block anything: this script never emits a
+# decision and ALWAYS exits 0. Symbol-only find_impact calls carry no
+# file-ish input field and are skipped (nothing to attribute a path to).
+# Requires: jq
+
+set -euo pipefail
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/codesearch-common.sh"
+
+raw="$(cat)"
+[ -z "$raw" ] && exit 0
+
+tool=$(echo "$raw" | jq -r '.tool_name // empty' 2>/dev/null | jq_str)
+case "$tool" in
+    mcp__codesearch__find_impact)
+        mark_tool="find_impact"
+        ;;
+    mcp__codesearch__find)
+        kind=$(echo "$raw" | jq -r '.tool_input.kind // empty' 2>/dev/null | jq_str)
+        [ "$kind" = "usages" ] || exit 0
+        mark_tool="find_usages"
+        ;;
+    *) exit 0 ;;
+esac
+
+# find_impact names its target via `file`/`path`; find uses `path`. Accept
+# any of them — FIRST NON-EMPTY (jq's `//` treats "" as truthy, so the
+# empties are filtered explicitly; the ps1 twin does the same) — so both
+# tools attribute to the same key.
+p=$(echo "$raw" | jq -r '
+    [ .tool_input.file, .tool_input.path, .tool_input.file_path ]
+    | map(select(. != null and . != ""))
+    | .[0] // empty
+' 2>/dev/null | jq_str)
+[ -z "$p" ] && exit 0
+
+key="$(norm_state_key "$p")"
+[ -z "$key" ] && exit 0
+
+state_file="${TMPDIR:-/tmp}/.codesearch-edit-guard-state.json"
+window=300
+now=$(date +%s)
+
+# Upsert, pruning expired entries so the file cannot grow without bound; a
+# window-expired entry is simply dropped and the fresh write re-creates it.
+tmp="$(mktemp)"
+merged=false
+if [ -f "$state_file" ]; then
+    if jq --arg k "$key" --arg t "$mark_tool" --argjson now "$now" --argjson window "$window" '
+        with_entries(
+            (.value.ts // -1 | (tonumber? // -1)) as $ts
+            | select(($now - $ts) < $window)
+        ) + { ($k): { tool: $t, ts: $now } }
+    ' < "$state_file" > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+        merged=true
+    fi
+fi
+if [ "$merged" != true ]; then
+    # Missing or corrupt state: start over from this single marker.
+    jq -n --arg k "$key" --arg t "$mark_tool" --argjson now "$now" \
+        '{ ($k): { tool: $t, ts: $now } }' > "$tmp" 2>/dev/null || true
+fi
+mv -f "$tmp" "$state_file" 2>/dev/null || true
+rm -f "$tmp" 2>/dev/null || true
+
+exit 0

--- a/integrations/claude-code/hooks/edit-guard.ps1
+++ b/integrations/claude-code/hooks/edit-guard.ps1
@@ -1,0 +1,118 @@
+# PreToolUse hook: require a recent codesearch consultation before edits.
+# Fires on Edit/Write/MultiEdit. Windows twin of edit-guard.sh — keep the
+# two behaviorally equivalent.
+#
+# When the edited file's repo is codesearch-registered (git root listed in
+# ~/.codesearch/repos.json, honoring CODESEARCH_REPOS_CONFIG, or a
+# CODESEARCH_SERVER opt-in), every touched file needs a marker proving the
+# agent consulted codesearch for exactly that path within the last 5
+# minutes: mcp__codesearch__find_impact for SCIP-backed languages
+# (.cs .ts .tsx .mts .cts), mcp__codesearch__find kind="usages" for
+# everything else. Markers are written by the edit-guard-post PostToolUse
+# companion into $env:TEMP\.codesearch-edit-guard-state.json.
+#
+# Lenient acceptance: ANY marker for the path within the window lets the
+# edit through — the marker proves the agent consulted codesearch for this
+# file, which is the point.
+#
+# Fail-open on: no target paths, paths outside any git repo, unregistered
+# repos, or a crashed hook — all allow. Missing/corrupt state counts as NOT
+# consulted (deny on covered repos, allow everywhere else); so does an
+# expired marker, and the next consultation refreshes it.
+#
+# Install: see ../README.md (or run `codesearch hooks claude install`).
+
+$ErrorActionPreference = 'Stop'
+
+try {
+    . (Join-Path $PSScriptRoot 'codesearch-common.ps1')
+    $raw = [Console]::In.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($raw)) { exit 0 }
+    $data = $raw | ConvertFrom-Json
+} catch {
+    exit 0  # never block a tool call because the hook failed to parse its own input
+}
+
+$tool = $data.tool_name
+$inp  = $data.tool_input
+
+if ($tool -ne 'Edit' -and $tool -ne 'Write' -and $tool -ne 'MultiEdit') { exit 0 }
+if ($null -eq $inp) { exit 0 }
+
+# Target paths: the primary file_path, plus (defensively) per-edit entries.
+$candidates = @()
+$names = @($inp.PSObject.Properties.Name)
+if ($names -contains 'file_path') { $candidates += [string]$inp.file_path }
+if (($names -contains 'edits') -and $null -ne $inp.edits) {
+    foreach ($e in @($inp.edits)) {
+        if ($null -ne $e -and @($e.PSObject.Properties.Name) -contains 'file_path') {
+            $candidates += [string]$e.file_path
+        }
+    }
+}
+$paths = @($candidates | Where-Object { -not [string]::IsNullOrEmpty($_) } | Select-Object -Unique)
+if ($paths.Count -eq 0) { exit 0 }  # nothing attributable -> allow (fail-open)
+
+$stateFile = Join-Path $env:TEMP '.codesearch-edit-guard-state.json'
+$window    = 300
+$now       = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+
+function Test-CheckedRecently {
+    param([string]$Key)
+    if (-not (Test-Path -LiteralPath $stateFile -PathType Leaf)) { return $false }
+    try {
+        $state = Get-Content -LiteralPath $stateFile -Raw | ConvertFrom-Json
+        $entry = $state.PSObject.Properties[$Key]
+        if ($null -eq $entry) { return $false }
+        $ts = [long]$entry.Value.ts
+        return (($now - $ts) -lt $window)
+    } catch {
+        return $false  # corrupt/unreadable state counts as absent
+    }
+}
+
+$failPath = $null
+$failTool = $null
+foreach ($p in $paths) {
+    $root = Resolve-TargetGitRoot $p
+    if (-not $root) { continue }                    # outside any git repo -> allow
+    if (-not (Test-CodesearchTargetRegistered $root)) { continue }  # unregistered -> fail-open
+    $key = ConvertTo-StateKey $p
+    if (Test-CheckedRecently $key) { continue }
+    $failPath = $p
+    $ext = [System.IO.Path]::GetExtension($p).TrimStart('.').ToLowerInvariant()
+    if (@('cs', 'ts', 'tsx', 'mts', 'cts') -contains $ext) {
+        $failTool = 'mcp__codesearch__find_impact (SCIP-backed language)'
+    } else {
+        $failTool = 'mcp__codesearch__find(symbol, kind="usages")'
+    }
+    break
+}
+
+if ($null -eq $failPath) { exit 0 }  # every path checked recently -> allow
+
+$msg = @"
+edit-guard: this edit needs a codesearch consultation first.
+
+Blocked path: $failPath
+Required call: $failTool — on that exact file.
+
+Any outcome counts: "no results" and "no SCIP backend" still prove you
+consulted codesearch for this file. Run the call, then retry the SAME
+edit — it stays allowed for 5 minutes.
+
+Why: find_impact (C#/TS) / find kind="usages" (other languages) before
+edits keeps refactors caller-aware; this guard makes that protocol
+structural for codesearch-registered repos. Unregistered repos, non-git
+paths and unparseable events fail open and are never blocked.
+"@
+
+$out = @{
+    hookSpecificOutput = @{
+        hookEventName            = 'PreToolUse'
+        permissionDecision       = 'deny'
+        permissionDecisionReason = $msg
+    }
+}
+$out | ConvertTo-Json -Depth 10 -Compress
+exit 0

--- a/integrations/claude-code/hooks/edit-guard.sh
+++ b/integrations/claude-code/hooks/edit-guard.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# PreToolUse hook: require a recent codesearch consultation before edits.
+# Fires on Edit/Write/MultiEdit. Bash twin of edit-guard.ps1.
+# Requires: jq
+#
+# When the edited file's repo is codesearch-registered (shared coverage model
+# with grep-guard: git root listed in ~/.codesearch/repos.json, honoring
+# CODESEARCH_REPOS_CONFIG, or a CODESEARCH_SERVER opt-in), every touched file
+# needs a marker proving the agent consulted codesearch for exactly that path
+# within the last 5 minutes: mcp__codesearch__find_impact for SCIP-backed
+# languages (.cs .ts .tsx .mts .cts), mcp__codesearch__find kind="usages" for
+# everything else. The markers are written by the edit-guard-post PostToolUse
+# companion into ${TMPDIR:-/tmp}/.codesearch-edit-guard-state.json.
+#
+# Lenient acceptance: ANY marker for the path within the window lets the edit
+# through, regardless of which tool wrote it — the marker proves the agent
+# consulted codesearch for this file, which is the point; policing
+# find_impact-vs-find_usages per extension would deny edits after a
+# legitimate-but-"wrong-kind" lookup.
+#
+# Fail-open on: no target paths, paths outside any git repo, unregistered
+# repos, or a crashed hook — all allow. Missing/corrupt state counts as NOT
+# consulted (deny on covered repos, allow everywhere else); so does an
+# expired marker, and the next consultation refreshes it (no state
+# pollution).
+#
+# Install: see ../README.md (or run `codesearch hooks claude install`).
+
+set -euo pipefail
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/codesearch-common.sh"
+
+raw="$(cat)"
+[ -z "$raw" ] && exit 0
+
+tool=$(echo "$raw" | jq -r '.tool_name // empty' 2>/dev/null | jq_str)
+case "$tool" in
+    Edit | Write | MultiEdit) ;;
+    *) exit 0 ;;
+esac
+
+# Target paths: the primary file_path, plus (defensively) any per-edit
+# file_path entries a MultiEdit-style payload may carry.
+paths=$(echo "$raw" | jq -r '
+    [ .tool_input.file_path,
+      (.tool_input.edits[]?.file_path // empty)
+    ]
+    | map(select(. != null and . != ""))
+    | unique | .[]
+' 2>/dev/null | jq_str)
+[ -z "$paths" ] && exit 0  # nothing attributable -> allow (fail-open)
+
+state_file="${TMPDIR:-/tmp}/.codesearch-edit-guard-state.json"
+window=300
+now=$(date +%s)
+
+# The marker only proves "codesearch was consulted recently for this path";
+# a non-numeric ts is corruption, not a stale check.
+checked_recently() {
+    local key="$1" entry ts
+    [ -f "$state_file" ] || return 1
+    entry=$(jq -rc --arg k "$key" '.[$k] // empty' < "$state_file" 2>/dev/null | jq_str)
+    [ -n "$entry" ] || return 1
+    ts=$(printf '%s' "$entry" | jq -r '.ts // empty' 2>/dev/null | jq_str)
+    case "$ts" in '' | *[!0-9]*) return 1 ;; esac
+    [ $((now - ts)) -lt "$window" ]
+}
+
+fail_path=""
+fail_tool=""
+while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    root="$(resolve_target_git_root "$p")"
+    [ -z "$root" ] && continue             # outside any git repo -> allow
+    target_registered "$root" || continue  # unregistered repo -> allow (fail-open)
+    key="$(norm_state_key "$p")"
+    if ! checked_recently "$key"; then
+        fail_path="$p"
+        ext=$(printf '%s' "${p##*.}" | tr '[:upper:]' '[:lower:]')
+        case "$ext" in
+            cs | ts | tsx | mts | cts) fail_tool='mcp__codesearch__find_impact (SCIP-backed language)' ;;
+            *) fail_tool='mcp__codesearch__find(symbol, kind="usages")' ;;
+        esac
+        break
+    fi
+done <<< "$paths"
+
+[ -z "$fail_path" ] && exit 0  # every path checked recently -> allow
+
+msg=$(cat <<EOF
+edit-guard: this edit needs a codesearch consultation first.
+
+Blocked path: $fail_path
+Required call: $fail_tool — on that exact file.
+
+Any outcome counts: "no results" and "no SCIP backend" still prove you
+consulted codesearch for this file. Run the call, then retry the SAME
+edit — it stays allowed for 5 minutes.
+
+Why: find_impact (C#/TS) / find kind="usages" (other languages) before
+edits keeps refactors caller-aware; this guard makes that protocol
+structural for codesearch-registered repos. Unregistered repos, non-git
+paths and unparseable events fail open and are never blocked.
+EOF
+)
+
+jq -n --arg msg "$msg" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $msg
+  }
+}'
+exit 0

--- a/integrations/claude-code/hooks/grep-guard.ps1
+++ b/integrations/claude-code/hooks/grep-guard.ps1
@@ -20,15 +20,16 @@
 #   - the search target resolves to a git repo (its OWN root, not the cwd's —
 #     absolute paths into a different repo resolve against THAT repo, todo
 #     #54), AND
-#   - codesearch covers THAT repo (indexed .codesearch.db at its git root, or
-#     the CODESEARCH_SERVER opt-in for remote/hub-only setups), AND
+#   - codesearch covers THAT repo (its git root registered in the serve
+#     hub's repos.json, or the CODESEARCH_SERVER opt-in for remote/hub-only
+#     setups), AND
 #   - the codesearch serve hub answers its /healthz liveness probe (it's UP)
 #
 # Passes through (exit 0, no block) when:
 #   - the target is not inside any git repo (external path — grep is the
 #     right tool there)
-#   - codesearch does not cover the target's repo (no local index, no
-#     CODESEARCH_SERVER)
+#   - codesearch does not cover the target's repo (git root not registered
+#     in repos.json, no CODESEARCH_SERVER)
 #   - the codesearch serve hub does not answer /healthz — it's down, so grep
 #     is genuinely all you have
 #
@@ -41,6 +42,14 @@
 # Install: see ../README.md (or run ../install.ps1 to wire this up automatically).
 
 $ErrorActionPreference = 'Stop'
+
+# Shared target-resolution helpers live in codesearch-common.ps1 (shared
+# with edit-guard). Missing/broken helper file -> fail open, never block.
+try {
+    . (Join-Path $PSScriptRoot 'codesearch-common.ps1')
+} catch {
+    exit 0
+}
 
 try {
     $raw = [Console]::In.ReadToEnd()
@@ -63,50 +72,22 @@ $path  = if ($names -contains 'path') { [string]$inp.path } else { '' }
 # 1+2. Resolve the TARGET repo (the repo this Grep is aimed at) and check
 #      codesearch coverage THERE — never in the hook's cwd.
 #
-# History (#54): coverage used to be resolved from the hook's cwd. An
-# absolute-path Grep into a DIFFERENT indexed repo then failed the
-# startswith(cwd-repo-root) test, looked "external", and was allowed even
-# though its target repo was fully covered. The guard now follows the
-# target: empty/relative paths resolve against the cwd repo (they are
-# relative to it by definition), absolute paths resolve against the git
-# root of the path itself.
+# The resolution (absolute path -> the target's own git root, empty/
+# relative -> the cwd repo) lives in codesearch-common.ps1 and is shared
+# with edit-guard. History (#54, #199): see codesearch-common.sh.
 # ------------------------------------------------------------------
-$targetRoot = $null
-$normPath   = $path.TrimEnd('/\')
-$isAbsolute = $normPath -match '^([A-Za-z]:[\\/]|/[a-zA-Z]/|//)'
-
-if (-not $path -or $path -eq '.' -or $path -eq './' -or -not $isAbsolute) {
-    # Empty or relative path: resolves against the cwd repo.
-    try {
-        $gr = (& git rev-parse --show-toplevel 2>$null)
-        if ($LASTEXITCODE -eq 0 -and $gr) { $targetRoot = $gr.Trim() }
-    } catch {}
-} else {
-    # Absolute path: find the git root OF THE TARGET (may be a different
-    # repo than the cwd one — that is the whole point of #54).
-    $probe = $normPath
-    if (Test-Path -LiteralPath $probe -PathType Leaf) {
-        $probe = Split-Path -Parent $probe
-    }
-    try {
-        $gr = (& git -C $probe rev-parse --show-toplevel 2>$null)
-        if ($LASTEXITCODE -eq 0 -and $gr) { $targetRoot = $gr.Trim() }
-    } catch {}
-}
+$targetRoot = Resolve-TargetGitRoot $path
 
 # Not inside any git repo (or git unusable) -> external target: grep is right.
 if (-not $targetRoot) { exit 0 }
 
-# Coverage: a local .codesearch.db at the TARGET repo's root is the precise,
-# fast signal that THIS repo is indexed (a running serve hub alone is NOT —
-# it covers many repos and being alive says nothing about this one).
+# Coverage: the TARGET repo's git root is REGISTERED with the serve hub
+# (~/.codesearch/repos.json — the same list the hub itself resolves by),
+# matching the bash twin and edit-guard; a running serve hub alone is NOT a
+# signal (it covers many repos and being alive says nothing about this one).
 # CODESEARCH_SERVER stays the explicit opt-in for pure remote-serve setups.
-$covered = $false
-try {
-    if (Test-Path (Join-Path $targetRoot '.codesearch.db')) { $covered = $true }
-} catch {}
-if (-not $covered -and $env:CODESEARCH_SERVER) { $covered = $true }
-if (-not $covered) { exit 0 }
+# Fails open: missing/malformed repos.json counts as unregistered -> allow.
+if (-not (Test-CodesearchTargetRegistered $targetRoot)) { exit 0 }
 
 # ------------------------------------------------------------------
 # 3. Is the codesearch serve hub actually UP right now? (Liveness probe.)

--- a/integrations/claude-code/hooks/grep-guard.sh
+++ b/integrations/claude-code/hooks/grep-guard.sh
@@ -25,75 +25,17 @@
 
 set -euo pipefail
 
+# Shared coverage/target-resolution helpers (repos.json registration, path
+# normalization) live in codesearch-common.sh, shared with edit-guard.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/codesearch-common.sh"
+
 raw="$(cat)"
 [ -z "$raw" ] && exit 0
 
-tool=$(echo "$raw" | jq -r '.tool_name // empty')
+tool=$(echo "$raw" | jq -r '.tool_name // empty' | jq_str)
 [ "$tool" != "Grep" ] && exit 0
 
-path=$(echo "$raw" | jq -r '.tool_input.path // empty')
-
-# --- begin coverage helpers (repos.json registration, #199) ---------------
-
-# repos.json location — mirrors src/db_discovery/repos.rs `config_path()`:
-# CODESEARCH_REPOS_CONFIG override > ~/.codesearch/repos.json.
-repos_config_file() {
-    if [ -n "${CODESEARCH_REPOS_CONFIG:-}" ]; then
-        printf '%s' "$CODESEARCH_REPOS_CONFIG"
-    else
-        printf '%s' "${HOME:-}/.codesearch/repos.json"
-    fi
-}
-
-# Normalize one path for comparison: drop a Windows extended-length prefix
-# (\\?\ — exactly 4 chars), unify backslashes to forward slashes (Git-Bash
-# reports C:/x/y while repos.json records "C:\\x\\y"), and trim trailing
-# separators. Registration canonicalizes paths before writing them
-# (safe_canonicalize), so after this both sides agree byte-for-byte on
-# POSIX and component-wise on Windows.
-norm_repo_path() {
-    local p="$1"
-    case "$p" in
-        '\\?\'*) p="${p:4}" ;;
-    esac
-    p="${p//\\//}"
-    while [ "$p" != "/" ] && [ "${p%/}" != "$p" ]; do
-        p="${p%/}"
-    done
-    printf '%s' "$p"
-}
-
-# Path equality: exact on POSIX, case-insensitive for Windows drive-letter
-# paths (NTFS is case-insensitive throughout) — mirrors the serve hub's own
-# /indexing resolver, which folds case on Windows only.
-repo_path_eq() {
-    local a b
-    a="$(norm_repo_path "$1")"
-    b="$(norm_repo_path "$2")"
-    case "$a" in [A-Za-z]:/*) a="$(printf '%s' "$a" | tr '[:upper:]' '[:lower:]')" ;; esac
-    case "$b" in [A-Za-z]:/*) b="$(printf '%s' "$b" | tr '[:upper:]' '[:lower:]')" ;; esac
-    [ "$a" = "$b" ]
-}
-
-# Is the target's git root one of the repos registered with the local serve
-# hub? Fails OPEN on any resolver problem (missing/unreadable/malformed
-# repos.json, missing jq): a guard that cannot resolve coverage must allow,
-# never deny.
-target_registered() {
-    local root="$1" cfg reg
-    cfg="$(repos_config_file)"
-    [ -n "$cfg" ] || return 1
-    [ -r "$cfg" ] || return 1
-    while IFS= read -r reg; do
-        [ -n "$reg" ] || continue
-        if repo_path_eq "$reg" "$root"; then
-            return 0
-        fi
-    done < <(jq -r '(.repos // {}) | to_entries[] | .value | tostring' "$cfg" 2>/dev/null)
-    return 1
-}
-
-# --- end coverage helpers ----------------------------------------------------
+path=$(echo "$raw" | jq -r '.tool_input.path // empty' | jq_str)
 
 # ------------------------------------------------------------------
 # 1+2. Resolve the TARGET repo (the repo this Grep is aimed at) and check
@@ -131,38 +73,14 @@ target_registered() {
 # is a URL override rather than a coverage signal — to be reworked
 # separately).
 # ------------------------------------------------------------------
-target_root=""
-norm="${path%/}"
-norm="${norm%\\}"
-case "$norm" in
-    [A-Za-z]:[\\/]*|/*)
-        # Absolute path (Windows drive root, or any POSIX/UNC root): find
-        # the git root OF THE TARGET (may be a different repo than the cwd
-        # one — that is the whole point of #54). `/*` matches every POSIX
-        # absolute path; the old `/[a-zA-Z]/*` alternative only matched
-        # MSYS single-letter drive roots and left /home/... /tmp/...
-        # targets cwd-anchored (#199).
-        probe="$norm"
-        [ -f "$probe" ] && probe="$(dirname "$probe")"
-        target_root=$(git -C "$probe" rev-parse --show-toplevel 2>/dev/null || true)
-        ;;
-    *)
-        # Empty or relative path: resolves against the cwd repo.
-        target_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-        ;;
-esac
+target_root="$(resolve_target_git_root "$path")"
 
 # Not inside any git repo (or git unusable) -> external target: grep is right.
 [ -z "$target_root" ] && exit 0
 
-codesearch_covers=false
-if target_registered "$target_root"; then
-    codesearch_covers=true
-elif [ -n "${CODESEARCH_SERVER:-}" ]; then
-    codesearch_covers=true
-fi
-
-[ "$codesearch_covers" = false ] && exit 0
+# Covered = the target's git root is registered with the serve hub
+# (repos.json), or CODESEARCH_SERVER opts a pure remote-serve setup in.
+target_registered "$target_root" || exit 0
 
 # ------------------------------------------------------------------
 # 3. Is the codesearch serve hub actually UP right now? (Liveness probe.)

--- a/integrations/claude-code/hooks/run-tests.sh
+++ b/integrations/claude-code/hooks/run-tests.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Self-test suite for the codesearch Claude Code guard hooks: edit-guard +
+# its edit-guard-post PostToolUse companion, plus a grep-guard smoke case
+# pinning the codesearch-common.sh extraction. NOT wired into cargo or CI —
+# run manually:
+#   bash integrations/claude-code/hooks/run-tests.sh
+# Requires: bash, jq, git (and curl for the grep-guard smoke case).
+#
+# Coverage is simulated without a real index: repoA is "registered" via a
+# temp repos.json passed through CODESEARCH_REPOS_CONFIG (the same override
+# the guards honour at runtime), repoB is not listed. The serve hub is only
+# contacted by the grep-guard smoke case, which forces a dead port so the
+# answer is deterministic. State lives in a temp TMPDIR; the env overrides
+# are process-scoped and die with this script.
+
+set -u
+
+HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HOOKS_DIR/codesearch-common.sh"
+
+PASS=0
+FAIL=0
+TMP_ROOT="$(mktemp -d)"
+STATE_DIR="$TMP_ROOT/state"
+mkdir -p "$STATE_DIR"
+
+cleanup() {
+    unset CODESEARCH_REPOS_CONFIG CODESEARCH_SERVER TMPDIR
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+REPO_A="$TMP_ROOT/repoA"
+REPO_B="$TMP_ROOT/repoB"
+mkdir -p "$REPO_A" "$REPO_B"
+git init -q "$REPO_A"
+git init -q "$REPO_B"
+touch "$REPO_A/x.cs" "$REPO_A/m.ts" "$REPO_A/p.py" "$REPO_B/b.cs"
+ROOT_A="$(git -C "$REPO_A" rev-parse --show-toplevel)"
+ROOT_B="$(git -C "$REPO_B" rev-parse --show-toplevel)"
+
+REPOS_JSON="$TMP_ROOT/repos.json"
+jq -n --arg a "$ROOT_A" '{repos: {repoA: $a}}' > "$REPOS_JSON"
+
+export TMPDIR="$STATE_DIR"
+export CODESEARCH_REPOS_CONFIG="$REPOS_JSON"
+unset CODESEARCH_SERVER
+
+ok() { PASS=$((PASS + 1)); echo "PASS: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "FAIL: $1"; }
+
+run_edit() { OUT="$(printf '%s' "$1" | bash "$HOOKS_DIR/edit-guard.sh" 2>/dev/null)"; }
+run_post() { printf '%s' "$1" | bash "$HOOKS_DIR/edit-guard-post.sh" >/dev/null 2>&1; }
+
+edit_event() { jq -n --arg p "$1" '{tool_name: "Edit", tool_input: {file_path: $p}}'; }
+multiedit_event() {
+    jq -n --arg a "$1" --arg b "$2" \
+        '{tool_name: "MultiEdit", tool_input: {file_path: $a, edits: [{file_path: $a}, {file_path: $b}]}}'
+}
+post_find_impact() { jq -n --arg f "$1" '{tool_name: "mcp__codesearch__find_impact", tool_input: {file: $f}}'; }
+post_find() { jq -n --arg f "$1" --arg k "$2" '{tool_name: "mcp__codesearch__find", tool_input: {path: $f, kind: $k}}'; }
+
+expect_allow() {
+    if [ -z "$OUT" ]; then
+        ok "$1"
+    else
+        bad "$1 — expected silent allow, got: $OUT"
+    fi
+}
+expect_deny() { # $1 = label, $2 = optional substring the reason must contain
+    local d="" reason=""
+    if [ -n "$OUT" ]; then
+        d="$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null | jq_str 2>/dev/null)"
+        reason="$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null | jq_str 2>/dev/null)"
+    fi
+    if [ "$d" != "deny" ]; then
+        bad "$1 — expected deny, got: ${OUT:-<empty>}"
+        return
+    fi
+    if [ $# -ge 2 ] && ! printf '%s' "$reason" | grep -q "$2"; then
+        bad "$1 — deny message missing '$2'"
+        return
+    fi
+    ok "$1"
+}
+
+case_no_coverage_allows() {
+    run_edit "$(edit_event "$REPO_B/b.cs")"
+    expect_allow "unregistered repo: Edit .cs fails open (silent allow)"
+}
+case_covered_cs_denied() {
+    run_edit "$(edit_event "$REPO_A/x.cs")"
+    expect_deny "covered repo: Edit .cs denied (find_impact required)" "find_impact"
+}
+case_covered_ts_denied() {
+    run_edit "$(edit_event "$REPO_A/m.ts")"
+    expect_deny "covered repo: Edit .ts denied (find_impact required)" "find_impact"
+}
+case_covered_py_needs_usages() {
+    run_edit "$(edit_event "$REPO_A/p.py")"
+    expect_deny "covered repo: Edit .py denied (find kind=usages required)" 'kind="usages"'
+}
+case_definition_does_not_mark() {
+    run_post "$(post_find "$REPO_A/m.ts" "definition")"
+    run_edit "$(edit_event "$REPO_A/m.ts")"
+    expect_deny "find kind=definition does not mark: Edit .ts still denied" "find_impact"
+}
+case_find_impact_marker_allows() {
+    run_post "$(post_find_impact "$REPO_A/x.cs")"
+    run_edit "$(edit_event "$REPO_A/x.cs")"
+    expect_allow "after find_impact marker: Edit .cs allowed"
+}
+case_empty_first_field_falls_through() {
+    # jq's `//` treats "" as truthy: the post hook must filter empties
+    # explicitly or {"file":"","path":...} writes NO marker while the ps1
+    # twin writes one (shell drift, review round 1).
+    run_post "$(jq -n --arg p "$REPO_A/m.ts" \
+        '{tool_name: "mcp__codesearch__find_impact", tool_input: {file: "", path: $p}}')"
+    run_edit "$(edit_event "$REPO_A/m.ts")"
+    expect_allow "empty-string file field falls through to path: marker written"
+}
+case_multiedit_partial_marks_denied() {
+    run_edit "$(multiedit_event "$REPO_A/x.cs" "$REPO_A/p.py")"
+    expect_deny "MultiEdit: marked .cs + unmarked .py denied, failing path named" "$REPO_A/p.py"
+}
+case_find_usages_marker_allows() {
+    run_post "$(post_find "$REPO_A/p.py" "usages")"
+    run_edit "$(edit_event "$REPO_A/p.py")"
+    expect_allow "after find(kind=usages) marker: Edit .py allowed"
+    run_edit "$(multiedit_event "$REPO_A/x.cs" "$REPO_A/p.py")"
+    expect_allow "MultiEdit with every path marked allowed"
+}
+case_window_expiry_denies_again() {
+    local sf="$STATE_DIR/.codesearch-edit-guard-state.json"
+    local old=$(( $(date +%s) - 400 ))
+    jq --argjson old "$old" 'with_entries(.value.ts = $old)' < "$sf" > "$sf.new" &&
+        mv "$sf.new" "$sf"
+    run_edit "$(edit_event "$REPO_A/x.cs")"
+    expect_deny "expired marker (>5 min): Edit .cs denied again" "find_impact"
+}
+case_grep_guard_smoke() {
+    # Regression pin for the codesearch-common.sh extraction: grep-guard
+    # still resolves + guards the covered repo, and still auto-allows when
+    # the hub is unreachable (dead port -> /healthz probe fails).
+    local out
+    out="$(printf '{"tool_name":"Grep","tool_input":{"path":"%s"}}' "$REPO_A" |
+        CODESEARCH_SERVE_PORT=1 bash "$HOOKS_DIR/grep-guard.sh" 2>/dev/null)"
+    if [ -z "$out" ]; then
+        ok "grep-guard smoke: covered repo + hub down -> allow"
+    else
+        bad "grep-guard smoke — expected silent allow, got: $out"
+    fi
+}
+
+case_no_coverage_allows
+case_covered_cs_denied
+case_covered_ts_denied
+case_covered_py_needs_usages
+case_definition_does_not_mark
+case_find_impact_marker_allows
+case_empty_first_field_falls_through
+case_multiedit_partial_marks_denied
+case_find_usages_marker_allows
+case_window_expiry_denies_again
+case_grep_guard_smoke
+
+echo
+echo "edit-guard self-tests: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/integrations/claude-code/hooks/subagent-preamble.ps1
+++ b/integrations/claude-code/hooks/subagent-preamble.ps1
@@ -64,6 +64,11 @@ add project="<repo-alias>" (single repo) or group="<group>" (cross-repo). The
 error response lists the valid available_projects / available_groups — pick
 from that list; the alias may differ from the folder name.
 
+EDIT RULE: before editing code in a codesearch-registered repo, consult it
+for the file first — mcp__codesearch__find_impact (C#/TS) or
+mcp__codesearch__find(kind="usages") (other languages). The edit-guard hook
+blocks Edit/Write/MultiEdit on that file until you do (5-minute window).
+
 Fall back to Grep/Glob only after codesearch returns no useful results,
 or when the path is outside the current repo (codesearch covers internal
 paths only unless you're in multi-repo serve mode with an explicit group).

--- a/integrations/claude-code/hooks/subagent-preamble.sh
+++ b/integrations/claude-code/hooks/subagent-preamble.sh
@@ -46,6 +46,11 @@ add project="<repo-alias>" (single repo) or group="<group>" (cross-repo). The
 error response lists the valid available_projects / available_groups — pick
 from that list; the alias may differ from the folder name.
 
+EDIT RULE: before editing code in a codesearch-registered repo, consult it
+for the file first — mcp__codesearch__find_impact (C#/TS) or
+mcp__codesearch__find(kind="usages") (other languages). The edit-guard hook
+blocks Edit/Write/MultiEdit on that file until you do (5-minute window).
+
 Fall back to Grep/Glob only after codesearch returns no useful results,
 or when the path is outside the current repo (codesearch covers internal
 paths only unless you're in multi-repo serve mode with an explicit group).

--- a/integrations/claude-code/install.ps1
+++ b/integrations/claude-code/install.ps1
@@ -2,8 +2,10 @@
 #
 # What this does:
 #   1. Copies hooks/*.ps1 into ~/.claude/hooks/codesearch/
-#   2. Merges two PreToolUse hook registrations into ~/.claude/settings.json
-#      (Grep -> grep-guard.ps1, Agent -> subagent-preamble.ps1)
+#   2. Merges the guard registrations into ~/.claude/settings.json:
+#      PreToolUse: Grep -> grep-guard, Agent -> subagent-preamble,
+#      WebSearch|WebFetch -> web-guard, Edit|Write|MultiEdit -> edit-guard;
+#      PostToolUse: find_impact|find -> edit-guard-post
 #   3. Backs up settings.json before touching it
 #
 # Safe to re-run: registrations are matched by command string and skipped if
@@ -41,10 +43,15 @@ New-Item -ItemType Directory -Force -Path $hooksDest | Out-Null
 Copy-Item -Path (Join-Path $hooksSrc 'grep-guard.ps1')        -Destination $hooksDest -Force
 Copy-Item -Path (Join-Path $hooksSrc 'subagent-preamble.ps1') -Destination $hooksDest -Force
 Copy-Item -Path (Join-Path $hooksSrc 'web-guard.ps1')         -Destination $hooksDest -Force
+Copy-Item -Path (Join-Path $hooksSrc 'edit-guard.ps1')        -Destination $hooksDest -Force
+Copy-Item -Path (Join-Path $hooksSrc 'edit-guard-post.ps1')   -Destination $hooksDest -Force
+Copy-Item -Path (Join-Path $hooksSrc 'codesearch-common.ps1') -Destination $hooksDest -Force
 
-$grepGuardCmd = "pwsh -NoProfile -NonInteractive -File `"$($hooksDest -replace '\\','/')/grep-guard.ps1`""
-$preambleCmd  = "pwsh -NoProfile -NonInteractive -File `"$($hooksDest -replace '\\','/')/subagent-preamble.ps1`""
-$webGuardCmd  = "pwsh -NoProfile -NonInteractive -File `"$($hooksDest -replace '\\','/')/web-guard.ps1`""
+$grepGuardCmd     = "pwsh -NoProfile -NonInteractive -File `"$($hooksDest -replace '\\','/')/grep-guard.ps1`""
+$preambleCmd      = "pwsh -NoProfile -NonInteractive -File `"$($hooksDest -replace '\\','/')/subagent-preamble.ps1`""
+$webGuardCmd      = "pwsh -NoProfile -NonInteractive -File `"$($hooksDest -replace '\\','/')/web-guard.ps1`""
+$editGuardCmd     = "pwsh -NoProfile -NonInteractive -File `"$($hooksDest -replace '\\','/')/edit-guard.ps1`""
+$editGuardPostCmd = "pwsh -NoProfile -NonInteractive -File `"$($hooksDest -replace '\\','/')/edit-guard-post.ps1`""
 
 # Load or initialize settings.json
 if (Test-Path $settingsPath) {
@@ -57,30 +64,39 @@ if (Test-Path $settingsPath) {
     $settings = @{}
 }
 
-if (-not $settings.ContainsKey('hooks'))               { $settings['hooks'] = @{} }
+if (-not $settings.ContainsKey('hooks'))                { $settings['hooks'] = @{} }
 if (-not $settings['hooks'].ContainsKey('PreToolUse'))  { $settings['hooks']['PreToolUse'] = @() }
+if (-not $settings['hooks'].ContainsKey('PostToolUse')) { $settings['hooks']['PostToolUse'] = @() }
 
-$preToolUse = [System.Collections.ArrayList]$settings['hooks']['PreToolUse']
+$preToolUse  = [System.Collections.ArrayList]$settings['hooks']['PreToolUse']
+$postToolUse = [System.Collections.ArrayList]$settings['hooks']['PostToolUse']
 
-function Add-MatcherHook($matcher, $command) {
-    # Skip if a hook with this exact command already exists anywhere in PreToolUse
-    foreach ($entry in $preToolUse) {
+function Add-MatcherHook {
+    param([string]$HookEvent, $HookList, [string]$Matcher, [string]$Command)
+    # Skip if a hook with this exact command already exists anywhere in the list
+    foreach ($entry in $HookList) {
         foreach ($h in $entry.hooks) {
-            if ($h.command -eq $command) { return }
+            if ($h.command -eq $Command) {
+                Write-Host "Already registered: $HookEvent $Matcher (skipping)"
+                return
+            }
         }
     }
-    [void]$preToolUse.Add(@{
-        matcher = $matcher
-        hooks   = @(@{ type = 'command'; command = $command })
+    [void]$HookList.Add(@{
+        matcher = $Matcher
+        hooks   = @(@{ type = 'command'; command = $Command })
     })
-    Write-Host "Registered $matcher hook -> $command"
+    Write-Host "Registered $HookEvent $Matcher hook -> $Command"
 }
 
-Add-MatcherHook -matcher 'Grep'              -command $grepGuardCmd
-Add-MatcherHook -matcher 'Agent'             -command $preambleCmd
-Add-MatcherHook -matcher 'WebSearch|WebFetch' -command $webGuardCmd
+Add-MatcherHook -HookEvent 'PreToolUse'  -HookList $preToolUse  -Matcher 'Grep'                 -Command $grepGuardCmd
+Add-MatcherHook -HookEvent 'PreToolUse'  -HookList $preToolUse  -Matcher 'Agent'                -Command $preambleCmd
+Add-MatcherHook -HookEvent 'PreToolUse'  -HookList $preToolUse  -Matcher 'WebSearch|WebFetch'   -Command $webGuardCmd
+Add-MatcherHook -HookEvent 'PreToolUse'  -HookList $preToolUse  -Matcher 'Edit|Write|MultiEdit' -Command $editGuardCmd
+Add-MatcherHook -HookEvent 'PostToolUse' -HookList $postToolUse -Matcher 'mcp__codesearch__find_impact|mcp__codesearch__find' -Command $editGuardPostCmd
 
-$settings['hooks']['PreToolUse'] = @($preToolUse)
+$settings['hooks']['PreToolUse']  = @($preToolUse)
+$settings['hooks']['PostToolUse'] = @($postToolUse)
 
 $settings | ConvertTo-Json -Depth 20 | Set-Content $settingsPath -Encoding utf8
 

--- a/integrations/claude-code/install.sh
+++ b/integrations/claude-code/install.sh
@@ -33,11 +33,17 @@ mkdir -p "$HOOKS_DEST"
 cp "$HOOKS_SRC/grep-guard.sh" "$HOOKS_DEST/"
 cp "$HOOKS_SRC/subagent-preamble.sh" "$HOOKS_DEST/"
 cp "$HOOKS_SRC/web-guard.sh" "$HOOKS_DEST/"
-chmod +x "$HOOKS_DEST/grep-guard.sh" "$HOOKS_DEST/subagent-preamble.sh" "$HOOKS_DEST/web-guard.sh"
+cp "$HOOKS_SRC/edit-guard.sh" "$HOOKS_DEST/"
+cp "$HOOKS_SRC/edit-guard-post.sh" "$HOOKS_DEST/"
+cp "$HOOKS_SRC/codesearch-common.sh" "$HOOKS_DEST/"
+chmod +x "$HOOKS_DEST/grep-guard.sh" "$HOOKS_DEST/subagent-preamble.sh" "$HOOKS_DEST/web-guard.sh" \
+         "$HOOKS_DEST/edit-guard.sh" "$HOOKS_DEST/edit-guard-post.sh"
 
 GREP_GUARD_CMD="bash \"$HOOKS_DEST/grep-guard.sh\""
 PREAMBLE_CMD="bash \"$HOOKS_DEST/subagent-preamble.sh\""
 WEB_GUARD_CMD="bash \"$HOOKS_DEST/web-guard.sh\""
+EDIT_GUARD_CMD="bash \"$HOOKS_DEST/edit-guard.sh\""
+EDIT_GUARD_POST_CMD="bash \"$HOOKS_DEST/edit-guard-post.sh\""
 
 mkdir -p "$CLAUDE_DIR"
 if [ -f "$SETTINGS_PATH" ]; then
@@ -49,30 +55,33 @@ else
     settings='{}'
 fi
 
-# Ensure hooks.PreToolUse exists as an array
+# Ensure hooks.PreToolUse and hooks.PostToolUse exist as arrays
 settings=$(echo "$settings" | jq 'if has("hooks") then . else . + {hooks: {}} end
-  | .hooks |= (if has("PreToolUse") then . else . + {PreToolUse: []} end)')
+  | .hooks |= (if has("PreToolUse") then . else . + {PreToolUse: []} end)
+  | .hooks |= (if has("PostToolUse") then . else . + {PostToolUse: []} end)')
 
 already_registered() {
-    local cmd="$1"
-    echo "$settings" | jq -e --arg cmd "$cmd" \
-        '.hooks.PreToolUse[]?.hooks[]? | select(.command == $cmd)' >/dev/null 2>&1
+    local event="$1" cmd="$2"
+    echo "$settings" | jq -e --arg ev "$event" --arg cmd "$cmd" \
+        '.hooks[$ev][]?.hooks[]? | select(.command == $cmd)' >/dev/null 2>&1
 }
 
 add_matcher_hook() {
-    local matcher="$1" cmd="$2"
-    if already_registered "$cmd"; then
-        echo "Already registered: $matcher -> $cmd (skipping)"
+    local event="$1" matcher="$2" cmd="$3"
+    if already_registered "$event" "$cmd"; then
+        echo "Already registered: $event $matcher -> $cmd (skipping)"
         return
     fi
-    settings=$(echo "$settings" | jq --arg matcher "$matcher" --arg cmd "$cmd" \
-        '.hooks.PreToolUse += [{matcher: $matcher, hooks: [{type: "command", command: $cmd}]}]')
-    echo "Registered $matcher hook -> $cmd"
+    settings=$(echo "$settings" | jq --arg ev "$event" --arg matcher "$matcher" --arg cmd "$cmd" \
+        '.hooks[$ev] += [{matcher: $matcher, hooks: [{type: "command", command: $cmd}]}]')
+    echo "Registered $event $matcher hook -> $cmd"
 }
 
-add_matcher_hook "Grep"             "$GREP_GUARD_CMD"
-add_matcher_hook "Agent"            "$PREAMBLE_CMD"
-add_matcher_hook "WebSearch|WebFetch" "$WEB_GUARD_CMD"
+add_matcher_hook "PreToolUse"  "Grep"                 "$GREP_GUARD_CMD"
+add_matcher_hook "PreToolUse"  "Agent"                "$PREAMBLE_CMD"
+add_matcher_hook "PreToolUse"  "WebSearch|WebFetch"   "$WEB_GUARD_CMD"
+add_matcher_hook "PreToolUse"  "Edit|Write|MultiEdit" "$EDIT_GUARD_CMD"
+add_matcher_hook "PostToolUse" "mcp__codesearch__find_impact|mcp__codesearch__find" "$EDIT_GUARD_POST_CMD"
 
 echo "$settings" | jq '.' > "$SETTINGS_PATH"
 

--- a/src/cli/claude_hooks.rs
+++ b/src/cli/claude_hooks.rs
@@ -7,9 +7,11 @@
 //! no dependency on the source tree at install time.
 //!
 //! Behaviour mirrors the shell installers:
-//!   1. Write the hook scripts into `<claude_dir>/hooks/codesearch/`.
-//!   2. Merge one PreToolUse registration per guard into `settings.json`,
-//!      keyed by the exact command string so re-running never duplicates.
+//!   1. Write the hook scripts (guards, the PostToolUse companion and the
+//!      shared helper libraries) into `<claude_dir>/hooks/codesearch/`.
+//!   2. Merge one PreToolUse registration per guard and one PostToolUse
+//!      registration per companion into `settings.json`, keyed by the exact
+//!      command string so re-running never duplicates.
 //!   3. Back up an existing `settings.json` before rewriting it.
 //!
 //! `<claude_dir>` is `~/.claude` (user scope) or `./.claude` (`--project`).
@@ -28,6 +30,16 @@ const PREAMBLE_PS1: &str =
     include_str!("../../integrations/claude-code/hooks/subagent-preamble.ps1");
 const WEB_GUARD_SH: &str = include_str!("../../integrations/claude-code/hooks/web-guard.sh");
 const WEB_GUARD_PS1: &str = include_str!("../../integrations/claude-code/hooks/web-guard.ps1");
+const EDIT_GUARD_SH: &str = include_str!("../../integrations/claude-code/hooks/edit-guard.sh");
+const EDIT_GUARD_PS1: &str = include_str!("../../integrations/claude-code/hooks/edit-guard.ps1");
+const EDIT_GUARD_POST_SH: &str =
+    include_str!("../../integrations/claude-code/hooks/edit-guard-post.sh");
+const EDIT_GUARD_POST_PS1: &str =
+    include_str!("../../integrations/claude-code/hooks/edit-guard-post.ps1");
+const CODESEARCH_COMMON_SH: &str =
+    include_str!("../../integrations/claude-code/hooks/codesearch-common.sh");
+const CODESEARCH_COMMON_PS1: &str =
+    include_str!("../../integrations/claude-code/hooks/codesearch-common.ps1");
 
 /// A PreToolUse guard hook to install: the tool matcher it fires on, the script
 /// basename, and the per-platform script files to write out.
@@ -44,6 +56,8 @@ struct GuardHook {
 /// - `Grep` → codesearch-first for internal code discovery.
 /// - `Agent` → inject a codesearch-first preamble into subagent prompts.
 /// - `WebSearch`/`WebFetch` → steer to remote doc mounts before the open web.
+/// - `Edit`/`Write`/`MultiEdit` → require a recent codesearch consultation
+///   (find_impact / find kind="usages") per file before edits.
 static GUARD_HOOKS: &[GuardHook] = &[
     GuardHook {
         matcher: "Grep",
@@ -70,6 +84,34 @@ static GUARD_HOOKS: &[GuardHook] = &[
             ("web-guard.ps1", WEB_GUARD_PS1),
         ],
     },
+    GuardHook {
+        matcher: "Edit|Write|MultiEdit",
+        stem: "edit-guard",
+        files: &[
+            ("edit-guard.sh", EDIT_GUARD_SH),
+            ("edit-guard.ps1", EDIT_GUARD_PS1),
+        ],
+    },
+];
+
+/// PostToolUse companion hooks. These can never block anything (Claude Code
+/// ignores decisions there); they only record state — `edit-guard-post`
+/// marks "codesearch consulted" per file path after qualifying MCP calls,
+/// which `edit-guard` honours on the next Edit/Write/MultiEdit.
+static POST_TOOL_USE_HOOKS: &[GuardHook] = &[GuardHook {
+    matcher: "mcp__codesearch__find_impact|mcp__codesearch__find",
+    stem: "edit-guard-post",
+    files: &[
+        ("edit-guard-post.sh", EDIT_GUARD_POST_SH),
+        ("edit-guard-post.ps1", EDIT_GUARD_POST_PS1),
+    ],
+}];
+
+/// Shared helper libraries sourced by the guard scripts at runtime; written
+/// once into the same hooks directory as the guards themselves.
+static COMMON_HOOK_FILES: &[(&str, &str)] = &[
+    ("codesearch-common.sh", CODESEARCH_COMMON_SH),
+    ("codesearch-common.ps1", CODESEARCH_COMMON_PS1),
 ];
 
 /// Resolve the `.claude` directory for the requested scope.
@@ -97,12 +139,17 @@ fn hook_command(hooks_dest: &Path, stem: &str) -> String {
     }
 }
 
-/// Ensure `settings.hooks.PreToolUse` contains a `{matcher, hooks:[…]}` entry
+/// Ensure `settings.hooks.<event>` contains a `{matcher, hooks:[…]}` entry
 /// for `command`. Idempotent: returns `Ok(false)` without modifying anything if
-/// an entry with this exact `command` already exists anywhere in `PreToolUse`.
-/// Returns an error if a pre-existing `hooks`/`PreToolUse` value has a shape
+/// an entry with this exact `command` already exists anywhere in `<event>`.
+/// Returns an error if a pre-existing `hooks`/`<event>` value has a shape
 /// incompatible with the expected object/array.
-fn add_matcher_hook(settings: &mut Value, matcher: &str, command: &str) -> Result<bool> {
+fn add_matcher_hook(
+    settings: &mut Value,
+    event: &str,
+    matcher: &str,
+    command: &str,
+) -> Result<bool> {
     let root = settings
         .as_object_mut()
         .context("settings.json root must be a JSON object")?;
@@ -111,13 +158,13 @@ fn add_matcher_hook(settings: &mut Value, matcher: &str, command: &str) -> Resul
         .or_insert_with(|| json!({}))
         .as_object_mut()
         .context("settings.hooks must be a JSON object")?;
-    let pre = hooks
-        .entry("PreToolUse")
+    let list = hooks
+        .entry(event)
         .or_insert_with(|| json!([]))
         .as_array_mut()
-        .context("settings.hooks.PreToolUse must be a JSON array")?;
+        .context("settings.hooks.{event} must be a JSON array")?;
 
-    let already = pre.iter().any(|entry| {
+    let already = list.iter().any(|entry| {
         entry
             .get("hooks")
             .and_then(Value::as_array)
@@ -131,11 +178,26 @@ fn add_matcher_hook(settings: &mut Value, matcher: &str, command: &str) -> Resul
         return Ok(false);
     }
 
-    pre.push(json!({
+    list.push(json!({
         "matcher": matcher,
         "hooks": [ { "type": "command", "command": command } ]
     }));
     Ok(true)
+}
+
+/// Write one hook script (or shared library) into the hooks directory,
+/// executable on unix. Scripts are re-written verbatim on every install.
+fn write_hook_file(hooks_dest: &Path, name: &str, contents: &str) -> Result<()> {
+    let path = hooks_dest.join(name);
+    std::fs::write(&path, contents).with_context(|| format!("writing {}", path.display()))?;
+    #[cfg(unix)]
+    if name.ends_with(".sh") {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&path)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms)?;
+    }
+    Ok(())
 }
 
 /// Load an existing `settings.json` (backing it up first) or start from `{}`.
@@ -163,36 +225,36 @@ pub fn run_claude_install(project: bool) -> Result<()> {
     std::fs::create_dir_all(&hooks_dest)
         .with_context(|| format!("creating {}", hooks_dest.display()))?;
 
-    // 1. Write the hook scripts.
-    for gh in GUARD_HOOKS {
+    // 1. Write the hook scripts (guards, PostToolUse companions, shared
+    //    helper libraries — all into the same directory).
+    for (name, contents) in COMMON_HOOK_FILES {
+        write_hook_file(&hooks_dest, name, contents)?;
+    }
+    for gh in GUARD_HOOKS.iter().chain(POST_TOOL_USE_HOOKS) {
         for (name, contents) in gh.files {
-            let path = hooks_dest.join(name);
-            std::fs::write(&path, contents)
-                .with_context(|| format!("writing {}", path.display()))?;
-            #[cfg(unix)]
-            if name.ends_with(".sh") {
-                use std::os::unix::fs::PermissionsExt;
-                let mut perms = std::fs::metadata(&path)?.permissions();
-                perms.set_mode(0o755);
-                std::fs::set_permissions(&path, perms)?;
-            }
+            write_hook_file(&hooks_dest, name, contents)?;
         }
     }
 
-    // 2. Merge the PreToolUse registrations into settings.json.
+    // 2. Merge the PreToolUse / PostToolUse registrations into settings.json.
     // (`claude_dir` already exists — creating `hooks_dest` above made it.)
     let settings_path = claude_dir.join("settings.json");
     let mut settings = load_or_init_settings(&settings_path)?;
 
-    for gh in GUARD_HOOKS {
-        let cmd = hook_command(&hooks_dest, gh.stem);
-        if add_matcher_hook(&mut settings, gh.matcher, &cmd)? {
-            eprintln!(
-                "{}",
-                format!("Registered {} hook -> {}", gh.matcher, cmd).green()
-            );
-        } else {
-            eprintln!("Already registered: {} (skipping)", gh.matcher);
+    for (event, hooks) in [
+        ("PreToolUse", GUARD_HOOKS),
+        ("PostToolUse", POST_TOOL_USE_HOOKS),
+    ] {
+        for gh in hooks {
+            let cmd = hook_command(&hooks_dest, gh.stem);
+            if add_matcher_hook(&mut settings, event, gh.matcher, &cmd)? {
+                eprintln!(
+                    "{}",
+                    format!("Registered {} {} hook -> {}", event, gh.matcher, cmd).green()
+                );
+            } else {
+                eprintln!("Already registered: {} {} (skipping)", event, gh.matcher);
+            }
         }
     }
 
@@ -217,7 +279,8 @@ mod tests {
     #[test]
     fn add_matcher_hook_registers_on_empty_settings() {
         let mut settings = json!({});
-        let added = add_matcher_hook(&mut settings, "Grep", "bash /x/grep-guard.sh").unwrap();
+        let added =
+            add_matcher_hook(&mut settings, "PreToolUse", "Grep", "bash /x/grep-guard.sh").unwrap();
         assert!(added, "first registration must add the hook");
         let pre = settings["hooks"]["PreToolUse"].as_array().unwrap();
         assert_eq!(pre.len(), 1);
@@ -230,10 +293,39 @@ mod tests {
     fn add_matcher_hook_is_idempotent_by_command() {
         let mut settings = json!({});
         let cmd = "bash /x/grep-guard.sh";
-        assert!(add_matcher_hook(&mut settings, "Grep", cmd).unwrap());
+        assert!(add_matcher_hook(&mut settings, "PreToolUse", "Grep", cmd).unwrap());
         // Same command again -> no-op, no duplicate.
-        assert!(!add_matcher_hook(&mut settings, "Grep", cmd).unwrap());
+        assert!(!add_matcher_hook(&mut settings, "PreToolUse", "Grep", cmd).unwrap());
         assert_eq!(settings["hooks"]["PreToolUse"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn post_tool_use_hook_is_idempotent_by_command() {
+        let mut settings = json!({});
+        let cmd = "bash /x/edit-guard-post.sh";
+        assert!(add_matcher_hook(
+            &mut settings,
+            "PostToolUse",
+            "mcp__codesearch__find_impact|mcp__codesearch__find",
+            cmd
+        )
+        .unwrap());
+        // Same command again -> no-op, no duplicate, and the entry stays in
+        // PostToolUse (never leaking into PreToolUse).
+        assert!(!add_matcher_hook(
+            &mut settings,
+            "PostToolUse",
+            "mcp__codesearch__find_impact|mcp__codesearch__find",
+            cmd
+        )
+        .unwrap());
+        let post = settings["hooks"]["PostToolUse"].as_array().unwrap();
+        assert_eq!(post.len(), 1);
+        assert_eq!(
+            post[0]["matcher"],
+            "mcp__codesearch__find_impact|mcp__codesearch__find"
+        );
+        assert!(settings["hooks"].get("PreToolUse").is_none());
     }
 
     #[test]
@@ -246,7 +338,9 @@ mod tests {
                 ]
             }
         });
-        assert!(add_matcher_hook(&mut settings, "Grep", "bash /x/grep-guard.sh").unwrap());
+        assert!(
+            add_matcher_hook(&mut settings, "PreToolUse", "Grep", "bash /x/grep-guard.sh").unwrap()
+        );
         let pre = settings["hooks"]["PreToolUse"].as_array().unwrap();
         assert_eq!(pre.len(), 2, "existing Bash hook must survive");
         assert_eq!(settings["model"], "opus", "unrelated settings must survive");
@@ -255,29 +349,38 @@ mod tests {
     #[test]
     fn add_matcher_hook_rejects_bad_pretooluse_shape() {
         let mut settings = json!({ "hooks": { "PreToolUse": "not-an-array" } });
-        assert!(add_matcher_hook(&mut settings, "Grep", "cmd").is_err());
+        assert!(add_matcher_hook(&mut settings, "PreToolUse", "Grep", "cmd").is_err());
     }
 
     #[test]
     fn add_matcher_hook_rejects_non_object_hooks() {
         let mut settings = json!({ "hooks": "not-an-object" });
-        assert!(add_matcher_hook(&mut settings, "Grep", "cmd").is_err());
+        assert!(add_matcher_hook(&mut settings, "PreToolUse", "Grep", "cmd").is_err());
     }
 
     #[test]
     fn add_matcher_hook_rejects_non_object_root() {
         let mut settings = json!(["not", "an", "object"]);
-        assert!(add_matcher_hook(&mut settings, "Grep", "cmd").is_err());
+        assert!(add_matcher_hook(&mut settings, "PreToolUse", "Grep", "cmd").is_err());
     }
 
     #[test]
-    fn guard_hooks_cover_grep_agent_and_web() {
+    fn guard_hooks_cover_grep_agent_edit_and_web() {
         let matchers: Vec<&str> = GUARD_HOOKS.iter().map(|g| g.matcher).collect();
         assert!(matchers.contains(&"Grep"));
         assert!(matchers.contains(&"Agent"));
         assert!(matchers.contains(&"WebSearch|WebFetch"));
-        // Every guard ships both a .sh and a .ps1 with non-empty embedded bodies.
-        for g in GUARD_HOOKS {
+        assert!(matchers.contains(&"Edit|Write|MultiEdit"));
+        // The PostToolUse companion registers under its own event list.
+        let post: Vec<&str> = POST_TOOL_USE_HOOKS.iter().map(|g| g.matcher).collect();
+        assert!(post.contains(&"mcp__codesearch__find_impact|mcp__codesearch__find"));
+        // The shared helper libraries ship alongside the guards.
+        for (name, body) in COMMON_HOOK_FILES {
+            assert!(!body.is_empty(), "{name} embedded body is empty");
+        }
+        // Every guard and companion ships both a .sh and a .ps1 with
+        // non-empty embedded bodies.
+        for g in GUARD_HOOKS.iter().chain(POST_TOOL_USE_HOOKS) {
             assert_eq!(
                 g.files.len(),
                 2,


### PR DESCRIPTION
Edit/Write/MultiEdit in codesearch-registered repos now require a codesearch consultation for that exact file within 5 minutes: `find_impact` for SCIP-backed languages (.cs .ts .tsx .mts .cts), `find(kind="usages")` for everything else. First `PostToolUse` hook in the repo (`edit-guard-post`) records the markers; any outcome counts. Shared coverage helpers extracted to codesearch-common.sh/.ps1 — grep-guard's PowerShell twin thereby ported off the legacy .codesearch.db/Windows-only-path signals (#199 closed). Installer (native + legacy) writes the new scripts and the PostToolUse registration; subagent preamble gained an EDIT RULE line. Hook self-suite: `bash integrations/claude-code/hooks/run-tests.sh` (12 assertions). Closes todo #134. Validation: cargo gate green (1328/42), clippy -D warnings clean, 2 review rounds PASS.